### PR TITLE
Remove type hints for self and cls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,8 @@ line-length = 120
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
+    "ANN101",  # Missing type annotation for `{name}` in method
+    "ANN102",  # Missing type annotation for `{name}` in classmethod
     "ANN401",  # Dynamically typed expressions (typing.Any) are disallowed in {filename}
     "BLE001",  # Do not catch blind exception
     "C901",    # `{name}` is too complex

--- a/src/crawlee/_utils/recurring_task.py
+++ b/src/crawlee/_utils/recurring_task.py
@@ -19,13 +19,13 @@ class RecurringTask:
         task: The underlying task object.
     """
 
-    def __init__(self: RecurringTask, func: Callable, delay: timedelta) -> None:
+    def __init__(self, func: Callable, delay: timedelta) -> None:
         logger.debug(f'Calling RecurringTask.__init__(func={func.__name__}, delay={delay})...')
         self.func = func
         self.delay = delay
         self.task: asyncio.Task | None = None
 
-    async def _wrapper(self: RecurringTask) -> None:
+    async def _wrapper(self) -> None:
         """Internal method that repeatedly executes the provided function with the specified delay."""
         logger.debug('Calling RecurringTask._wrapper()...')
         sleep_time_secs = self.delay.total_seconds()
@@ -34,12 +34,12 @@ class RecurringTask:
             await self.func() if asyncio.iscoroutinefunction(self.func) else self.func()
             await asyncio.sleep(sleep_time_secs)
 
-    def start(self: RecurringTask) -> None:
+    def start(self) -> None:
         """Start the recurring task execution."""
         logger.debug('Calling RecurringTask.start()...')
         self.task = asyncio.create_task(self._wrapper(), name=f'Task-recurring-{self.func.__name__}')
 
-    async def stop(self: RecurringTask) -> None:
+    async def stop(self) -> None:
         """Stop the recurring task execution."""
         logger.debug('Calling RecurringTask.stop()...')
         if self.task:

--- a/src/crawlee/autoscaling/snapshotter.py
+++ b/src/crawlee/autoscaling/snapshotter.py
@@ -38,7 +38,7 @@ class Snapshotter:
     """
 
     def get_memory_sample(  # type: ignore
-        self: Snapshotter,
+        self,
         sample_duration: timedelta | None = None,
     ) -> Sequence[MemorySnapshot]:
         """Returns a sample of the latest memory snapshots.
@@ -51,7 +51,7 @@ class Snapshotter:
         """
 
     def get_event_loop_sample(  # type: ignore
-        self: Snapshotter,
+        self,
         sample_duration: timedelta | None = None,
     ) -> Sequence[EventLoopSnapshot]:
         """Returns a sample of the latest event loop snapshots.
@@ -64,7 +64,7 @@ class Snapshotter:
         """
 
     def get_cpu_sample(  # type: ignore
-        self: Snapshotter,
+        self,
         sample_duration: timedelta | None = None,
     ) -> Sequence[CpuSnapshot]:
         """Returns a sample of the latest CPU snapshots.
@@ -77,7 +77,7 @@ class Snapshotter:
         """
 
     def get_client_sample(  # type: ignore
-        self: Snapshotter,
+        self,
         sample_duration: timedelta | None = None,
     ) -> Sequence[ClientSnapshot]:
         """Returns a sample of the latest client snapshots.

--- a/src/crawlee/autoscaling/system_status.py
+++ b/src/crawlee/autoscaling/system_status.py
@@ -51,7 +51,7 @@ class SystemStatus:
     """
 
     def __init__(
-        self: SystemStatus,
+        self,
         snapshotter: Snapshotter,
         current_history: timedelta = timedelta(seconds=5),
         max_memory_overloaded_ratio: float = 0.2,
@@ -66,7 +66,7 @@ class SystemStatus:
         self.max_cpu_overloaded_ratio = max_cpu_overloaded_ratio
         self.max_client_overloaded_ratio = max_client_overloaded_ratio
 
-    def get_current_status(self: SystemStatus) -> SystemInfo:
+    def get_current_status(self) -> SystemInfo:
         """Get the current system status.
 
         Returns a `SystemInfo` object where the `is_system_idle` property is `False` if the system has been overloaded
@@ -77,7 +77,7 @@ class SystemStatus:
         """
         return self._is_system_idle(self.current_history)
 
-    def get_historical_status(self: SystemStatus) -> SystemInfo:
+    def get_historical_status(self) -> SystemInfo:
         """Get the historical system status.
 
         Returns a `SystemInfo` where the `is_system_idle` property is set to `False` if the system has been overloaded
@@ -88,7 +88,7 @@ class SystemStatus:
         """
         return self._is_system_idle()
 
-    def _is_system_idle(self: SystemStatus, sample_duration: timedelta | None = None) -> SystemInfo:
+    def _is_system_idle(self, sample_duration: timedelta | None = None) -> SystemInfo:
         """Determine if the system is currently idle or overloaded.
 
         Args:
@@ -110,7 +110,7 @@ class SystemStatus:
             client_info=client_info,
         )
 
-    def _is_memory_overloaded(self: SystemStatus, sample_duration: timedelta | None = None) -> LoadRatioInfo:
+    def _is_memory_overloaded(self, sample_duration: timedelta | None = None) -> LoadRatioInfo:
         """Determine if memory has been overloaded within a specified time duration.
 
         Args:
@@ -123,7 +123,7 @@ class SystemStatus:
         sample = self.snapshotter.get_memory_sample(sample_duration)
         return self._is_sample_overloaded(sample, self.max_memory_overloaded_ratio)
 
-    def _is_event_loop_overloaded(self: SystemStatus, sample_duration: timedelta | None = None) -> LoadRatioInfo:
+    def _is_event_loop_overloaded(self, sample_duration: timedelta | None = None) -> LoadRatioInfo:
         """Determine if the event loop has been overloaded within a specified time duration.
 
         Args:
@@ -136,7 +136,7 @@ class SystemStatus:
         sample = self.snapshotter.get_event_loop_sample(sample_duration)
         return self._is_sample_overloaded(sample, self.max_event_loop_overloaded_ratio)
 
-    def _is_cpu_overloaded(self: SystemStatus, sample_duration: timedelta | None = None) -> LoadRatioInfo:
+    def _is_cpu_overloaded(self, sample_duration: timedelta | None = None) -> LoadRatioInfo:
         """Determine if the CPU has been overloaded within a specified time duration.
 
         Args:
@@ -149,7 +149,7 @@ class SystemStatus:
         sample = self.snapshotter.get_cpu_sample(sample_duration)
         return self._is_sample_overloaded(sample, self.max_cpu_overloaded_ratio)
 
-    def _is_client_overloaded(self: SystemStatus, sample_duration: timedelta | None = None) -> LoadRatioInfo:
+    def _is_client_overloaded(self, sample_duration: timedelta | None = None) -> LoadRatioInfo:
         """Determine if the client has been overloaded within a specified time duration.
 
         Args:
@@ -162,7 +162,7 @@ class SystemStatus:
         sample = self.snapshotter.get_client_sample(sample_duration)
         return self._is_sample_overloaded(sample, self.max_client_overloaded_ratio)
 
-    def _is_sample_overloaded(self: SystemStatus, sample: Sequence[Snapshot], ratio: float) -> LoadRatioInfo:
+    def _is_sample_overloaded(self, sample: Sequence[Snapshot], ratio: float) -> LoadRatioInfo:
         """Determine if a sample of snapshot data is overloaded based on a specified ratio.
 
         Args:

--- a/src/crawlee/autoscaling/types.py
+++ b/src/crawlee/autoscaling/types.py
@@ -16,7 +16,7 @@ class LoadRatioInfo:
     actual_ratio: float
 
     @property
-    def is_overloaded(self: LoadRatioInfo) -> bool:
+    def is_overloaded(self) -> bool:
         """Returns whether the resource is overloaded."""
         return self.actual_ratio > self.limit_ratio
 
@@ -33,7 +33,7 @@ class SystemInfo:
     mem_current_bytes: int | None = None
 
     @property
-    def is_system_idle(self: SystemInfo) -> bool:
+    def is_system_idle(self) -> bool:
         """Indicates whether the system is currently idle or overloaded."""
         if self.mem_info is None or self.event_loop_info is None or self.cpu_info is None or self.client_info is None:
             raise ValueError('SystemInfo is missing some load ratio info.')
@@ -45,7 +45,7 @@ class SystemInfo:
             and not self.client_info.is_overloaded
         )
 
-    def __str__(self: SystemInfo) -> str:
+    def __str__(self) -> str:
         """Get a string representation of the system info."""
         stats = {
             'cpu': self.cpu_info.actual_ratio if self.cpu_info else '-',

--- a/src/crawlee/events/event_manager.py
+++ b/src/crawlee/events/event_manager.py
@@ -34,7 +34,7 @@ class EventManager:
             registered with the event emitter.
     """
 
-    def __init__(self: EventManager) -> None:
+    def __init__(self) -> None:
         logger.debug('Calling EventManager.__init__()...')
         self._event_emitter = AsyncIOEventEmitter()
 
@@ -47,7 +47,7 @@ class EventManager:
             lambda: defaultdict(list),
         )
 
-    def on(self: EventManager, *, event: Event, listener: Listener) -> None:
+    def on(self, *, event: Event, listener: Listener) -> None:
         """Add an event listener to the event manager.
 
         Args:
@@ -90,7 +90,7 @@ class EventManager:
         self._listeners_to_wrappers[event][listener].append(listener_wrapper)
         self._event_emitter.add_listener(event.value, listener_wrapper)
 
-    def off(self: EventManager, *, event: Event, listener: Listener | None = None) -> None:
+    def off(self, *, event: Event, listener: Listener | None = None) -> None:
         """Remove a listener, or all listeners, from an Actor event.
 
         Args:
@@ -108,7 +108,7 @@ class EventManager:
             self._listeners_to_wrappers[event] = defaultdict(list)
             self._event_emitter.remove_all_listeners(event.value)
 
-    def emit(self: EventManager, *, event: Event, event_data: EventData) -> None:
+    def emit(self, *, event: Event, event_data: EventData) -> None:
         """Emit an event.
 
         Args:
@@ -118,7 +118,7 @@ class EventManager:
         logger.debug('Calling EventManager.emit()...')
         self._event_emitter.emit(event.value, event_data)
 
-    async def close(self: EventManager, *, timeout: timedelta | None = None) -> None:
+    async def close(self, *, timeout: timedelta | None = None) -> None:
         """Close the event manager.
 
         This will stop listening for the events, and it will wait for all the event listeners to finish.
@@ -132,7 +132,7 @@ class EventManager:
         self._listener_tasks.clear()
         self._listeners_to_wrappers.clear()
 
-    async def _wait_for_all_listeners_to_complete(self: EventManager, *, timeout: timedelta | None = None) -> None:
+    async def _wait_for_all_listeners_to_complete(self, *, timeout: timedelta | None = None) -> None:
         """Wait for all currently executing event listeners to complete.
 
         Args:

--- a/src/crawlee/events/local_event_manager.py
+++ b/src/crawlee/events/local_event_manager.py
@@ -35,13 +35,13 @@ class LocalEventManager(EventManager):
         _emit_system_info_event_rec_task: The recurring task for emitting system info events.
     """
 
-    def __init__(self: LocalEventManager, config: Config, timeout: timedelta | None = None) -> None:
+    def __init__(self, config: Config, timeout: timedelta | None = None) -> None:
         self.config = config
         self.timeout = timeout
         self._emit_system_info_event_rec_task: RecurringTask | None = None
         super().__init__()
 
-    async def __aenter__(self: LocalEventManager) -> LocalEventManager:
+    async def __aenter__(self) -> LocalEventManager:
         """Initializes the local event manager upon entering the async context.
 
         It starts emitting system info events at regular intervals.
@@ -55,7 +55,7 @@ class LocalEventManager(EventManager):
         return self
 
     async def __aexit__(
-        self: LocalEventManager,
+        self,
         exc_type: type[BaseException] | None,
         exc_value: BaseException | None,
         exc_traceback: TracebackType | None,
@@ -74,14 +74,14 @@ class LocalEventManager(EventManager):
 
         await super().close(timeout=self.timeout)
 
-    async def _emit_system_info_event(self: LocalEventManager) -> None:
+    async def _emit_system_info_event(self) -> None:
         """Emits a system info event with the current CPU and memory usage."""
         logger.debug('Calling LocalEventManager._emit_system_info_event()...')
         system_info = await self._get_system_info()
         event_data = EventSystemInfoData(system_info=system_info)
         self.emit(event=Event.SYSTEM_INFO, event_data=event_data)
 
-    async def _get_system_info(self: LocalEventManager) -> SystemInfo:
+    async def _get_system_info(self) -> SystemInfo:
         """Gathers system info about the CPU and memory usage.
 
         Returns:
@@ -96,7 +96,7 @@ class LocalEventManager(EventManager):
             mem_current_bytes=mem_usage,
         )
 
-    async def _get_cpu_info(self: LocalEventManager) -> LoadRatioInfo:
+    async def _get_cpu_info(self) -> LoadRatioInfo:
         """Retrieves the current CPU usage and calculates the load ratio.
 
         It utilizes the `psutil` library. Function `psutil.cpu_percent()` returns a float representing the current
@@ -110,7 +110,7 @@ class LocalEventManager(EventManager):
         cpu_ratio = cpu_percent / 100
         return LoadRatioInfo(limit_ratio=self.config.max_used_cpu_ratio, actual_ratio=cpu_ratio)
 
-    def _get_current_mem_usage(self: LocalEventManager) -> int:
+    def _get_current_mem_usage(self) -> int:
         """Retrieves the current memory usage of the process and its children.
 
         Returns:

--- a/src/crawlee/log_config.py
+++ b/src/crawlee/log_config.py
@@ -48,7 +48,7 @@ class CrawleeLogFormatter(logging.Formatter):
     empty_record = logging.LogRecord('dummy', 0, 'dummy', 0, 'dummy', None, None)
 
     def __init__(
-        self: CrawleeLogFormatter,
+        self,
         include_logger_name: bool = True,  # noqa: FBT001, FBT002
         *args: Any,
         **kwargs: Any,
@@ -63,7 +63,7 @@ class CrawleeLogFormatter(logging.Formatter):
         super().__init__(*args, **kwargs)
         self.include_logger_name = include_logger_name
 
-    def _get_extra_fields(self: CrawleeLogFormatter, record: logging.LogRecord) -> dict[str, Any]:
+    def _get_extra_fields(self, record: logging.LogRecord) -> dict[str, Any]:
         extra_fields: dict[str, Any] = {}
         for key, value in record.__dict__.items():
             if key not in self.empty_record.__dict__:
@@ -71,7 +71,7 @@ class CrawleeLogFormatter(logging.Formatter):
 
         return extra_fields
 
-    def format(self: CrawleeLogFormatter, record: logging.LogRecord) -> str:
+    def format(self, record: logging.LogRecord) -> str:
         """Format the log record nicely.
 
         This formats the log record so that it:


### PR DESCRIPTION
- Remove type hints for `self` and `cls`.
- We already discussed this before with @janbuchar.
- The Ruff's rules for this are deprecated ([missing-type-self](https://docs.astral.sh/ruff/rules/missing-type-self/),  [missing-type-cls](https://docs.astral.sh/ruff/rules/missing-type-cls/)), the reasoning:
> This rule is commonly disabled because type checkers can infer this type without annotation. It will be removed in a future release.

