### PR TITLE
Exclude TYPE_CHECKING blocks from test coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,3 +188,6 @@ ignore_missing_imports = true
 
 [tool.mypy-sortedcollections]
 ignore_missing_imports = true
+
+[tool.coverage.report]
+exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]


### PR DESCRIPTION
- E.g. for `HttpCrawler`:

![image](https://github.com/apify/crawlee-py/assets/25082181/6e7fcb00-0915-4b01-af85-b6b1cbc9063b)

- Context: https://github.com/nedbat/coveragepy/issues/831.
