### PR TITLE
PyPI releases in CI uses pypa/gh-action-pypi-publish step

### DIFF
--- a/.github/workflows/_publish_to_pypi.yaml
+++ b/.github/workflows/_publish_to_pypi.yaml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write  # Required for OIDC authentication.
     environment:
       name: pypi
       url: https://pypi.org/project/crawlee
@@ -43,9 +44,13 @@ jobs:
         if: steps.determine-release-type.outputs.release_type != 'final'
         run: python ./scripts/update_version_for_prerelease.py ${{ steps.determine-release-type.outputs.release_type }}
 
-      # Builds and publishes the package to PyPI, using OIDC for PyPI authentication.
-      - name: Build & publish package to PyPI
-        run: poetry publish --build --no-interaction -vv
+      # Builds the package.
+      - name: Build package
+        run: make build
+
+      # Publishes the package to PyPI using PyPA official GitHub action with OIDC authentication.
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       # If this workflow is not triggered by a GitHub release event, manually create and push a Git tag.
       - name: Create Git tag with the published version

--- a/.github/workflows/run_code_checks.yaml
+++ b/.github/workflows/run_code_checks.yaml
@@ -4,10 +4,8 @@ on:
   # Trigger code checks on opening a new pull request.
   pull_request_target:
 
-  # Trigger code checks on push to the master branch.
-  push:
-    branches:
-      - master
+  # Do not trigger code checks on push to the master branch, as they will be triggered
+  # by the release workflow.
 
   # Trigger code checks on workflow call (e.g. from run release workflow).
   workflow_call:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean install-dev build-and-publish-to-pypi lint type-check unit-tests unit-tests-cov integration-tests check-code format check-version-conflict check-changelog-entry
+.PHONY: clean install-dev build publish-to-pypi lint type-check unit-tests unit-tests-cov integration-tests check-code format check-version-conflict check-changelog-entry
 
 DIRS_WITH_CODE = src tests scripts
 
@@ -13,11 +13,13 @@ install-dev:
 	poetry install --all-extras
 	poetry run pre-commit install
 
+build:
+	poetry build --no-interaction -vv
+
 # APIFY_PYPI_TOKEN_CRAWLEE is expected to be set in the environment
-build-and-publish-to-pypi:
-	rm -rf dist
+publish-to-pypi:
 	poetry config pypi-token.pypi "${APIFY_PYPI_TOKEN_CRAWLEE}"
-	poetry publish --build --no-interaction -vv
+	poetry publish --no-interaction -vv
 
 lint:
 	poetry run ruff check $(DIRS_WITH_CODE)


### PR DESCRIPTION
### Description

- The PyPI release pipeline uses [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) step for publishing.

### Related issues

- https://github.com/apify/crawlee-py/issues/109

### Testing

- N/A