### PR TITLE
feat: add max requests per crawl to `BasicCrawler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@
 - Add batched request addition in `RequestQueue`
 - Add start requests option to `BasicCrawler`
 - Add storage-related helpers `get_data`, `push_data` and `export_to` to `BasicCrawler` and `BasicContext`
-- Add `PlaywrightCrawler`'s enqueue links helper
+- Add enqueue links helper to `PlaywrightCrawler`
+- Add max requests per crawl option to `BasicCrawler`
 
 ### Fixes
 

--- a/src/crawlee/autoscaling/autoscaled_pool.py
+++ b/src/crawlee/autoscaling/autoscaled_pool.py
@@ -95,16 +95,12 @@ class AutoscaledPool:
             is_task_ready_function: A function that indicates whether `run_task_function` should be called. This
                 function is called every time there is free capacity for a new task and it should indicate whether
                 it should start a new task or not by resolving to either `True` or `False`. Besides its obvious use,
-                it is also useful for task throttling to save resources. is_finished_function: A function that is
-                called only when there are no tasks to be processed. If it resolves to `True` then the pool's run
-                finishes. Being called only when there are no tasks being processed means that as long as
-                `is_task_ready_function()` keeps resolving to `True`, `is_finished_function()` will never be called.
-                To abort a run, use the `abort` method.
+                it is also useful for task throttling to save resources.
 
-            is_finished_function: A function that is called only when there are no tasks to be processed. If it resolves
-                to `true` then the pool's run finishes. Being called only when there are no tasks being processed means
-                that as long as `isTaskReadyFunction()` keeps resolving to `true`, `isFinishedFunction()` will never
-                be called. To abort a run, use the `abort` method.
+            is_finished_function: A function that is called only when there are no tasks to be processed. If it
+                resolves to `True` then the pool's run finishes. Being called only when there are no tasks being
+                processed means that as long as `is_task_ready_function` keeps resolving to `True`,
+                `is_finished_function` will never be called. To abort a run, use the `abort` method.
 
             task_timeout: Timeout in which the `run_task_function` needs to finish.
 

--- a/src/crawlee/basic_crawler/basic_crawler.py
+++ b/src/crawlee/basic_crawler/basic_crawler.py
@@ -63,6 +63,7 @@ class BasicCrawlerOptions(TypedDict, Generic[TCrawlingContext]):
     http_client: NotRequired[BaseHttpClient]
     concurrency_settings: NotRequired[ConcurrencySettings]
     max_request_retries: NotRequired[int]
+    max_requests_per_crawl: NotRequired[int | None]
     max_session_rotations: NotRequired[int]
     configuration: NotRequired[Configuration]
     request_handler_timeout: NotRequired[timedelta]
@@ -94,6 +95,7 @@ class BasicCrawler(Generic[TCrawlingContext]):
         http_client: BaseHttpClient | None = None,
         concurrency_settings: ConcurrencySettings | None = None,
         max_request_retries: int = 3,
+        max_requests_per_crawl: int | None = None,
         max_session_rotations: int = 10,
         configuration: Configuration | None = None,
         request_handler_timeout: timedelta = timedelta(minutes=1),
@@ -113,6 +115,10 @@ class BasicCrawler(Generic[TCrawlingContext]):
             http_client: HTTP client to be used for `BasicCrawlingContext.send_request` and HTTP-only crawling.
             concurrency_settings: Allows fine-tuning concurrency levels
             max_request_retries: Maximum amount of attempts at processing a request
+            max_requests_per_crawl: Maximum number of pages that the crawler will open. The crawl will stop when
+                the limit is reached. It is recommended to set this value in order to prevent infinite loops in
+                misconfigured crawlers. None means no limit. Due to concurrency_settings, the actual number of pages
+                visited may slightly exceed this value.
             max_session_rotations: Maximum number of session rotations per request.
                 The crawler will automatically rotate the session in case of a proxy error or if it gets blocked by
                 the website.
@@ -144,6 +150,7 @@ class BasicCrawler(Generic[TCrawlingContext]):
         self._failed_request_handler: FailedRequestHandler[TCrawlingContext] | None = None
 
         self._max_request_retries = max_request_retries
+        self._max_requests_per_crawl = max_requests_per_crawl
         self._max_session_rotations = max_session_rotations
 
         self._request_provider = request_provider
@@ -203,6 +210,14 @@ class BasicCrawler(Generic[TCrawlingContext]):
     def statistics(self) -> Statistics[StatisticsState]:
         """Statistics about the current (or last) crawler run."""
         return self._statistics
+
+    @property
+    def _max_requests_count_exceeded(self) -> bool:
+        """Whether the maximum number of requests to crawl has been reached."""
+        if self._max_requests_per_crawl is None:
+            return False
+
+        return self._statistics.state.requests_finished >= self._max_requests_per_crawl
 
     async def _get_session(self) -> Session | None:
         """If session pool is being used, try to take a session from it."""
@@ -575,9 +590,27 @@ class BasicCrawler(Generic[TCrawlingContext]):
 
     async def __is_finished_function(self) -> bool:
         request_provider = await self.get_request_provider()
-        return await request_provider.is_finished()
+        is_finished = await request_provider.is_finished()
+
+        if self._max_requests_count_exceeded:
+            logger.info(
+                f'The crawler has reached its limit of {self._max_requests_per_crawl} requests per crawl. '
+                f'All ongoing requests have now completed. Total requests processed: '
+                f'{self._statistics.state.requests_finished}. The crawler will now shut down.'
+            )
+            logger.info(f'is_finished: {is_finished}')
+            return True
+
+        return is_finished
 
     async def __is_task_ready_function(self) -> bool:
+        if self._max_requests_count_exceeded:
+            logger.info(
+                f'The crawler has reached its limit of {self._max_requests_per_crawl} requests per crawl. '
+                f'The crawler will soon shut down. Ongoing requests will be allowed to complete.'
+            )
+            return False
+
         request_provider = await self.get_request_provider()
         return not await request_provider.is_empty()
 

--- a/tests/unit/basic_crawler/test_basic_crawler.py
+++ b/tests/unit/basic_crawler/test_basic_crawler.py
@@ -13,6 +13,7 @@ import pytest
 from httpx import Headers, Response
 
 from crawlee import Glob
+from crawlee.autoscaling import ConcurrencySettings
 from crawlee.basic_crawler import BasicCrawler
 from crawlee.basic_crawler.errors import SessionError, UserDefinedErrorHandlerError
 from crawlee.basic_crawler.types import AddRequestsKwargs, BasicCrawlingContext
@@ -554,3 +555,25 @@ async def test_context_push_and_export_data(httpbin: str) -> None:
         {'id': 2, 'test': 'test'},
     ]
     assert await kvs.get_value('dataset-csv') == 'id,test\r\n0,test\r\n1,test\r\n2,test\r\n'
+
+
+async def test_max_requests_per_crawl(httpbin: str) -> None:
+    start_urls = [f'{httpbin}/1', f'{httpbin}/2', f'{httpbin}/3', f'{httpbin}/4', f'{httpbin}/5']
+    processed_urls = []
+
+    # Set max_concurrency to 1 to ensure testing max_requests_per_crawl accurately
+    crawler = BasicCrawler(
+        concurrency_settings=ConcurrencySettings(max_concurrency=1),
+        max_requests_per_crawl=3,
+    )
+
+    @crawler.router.default_handler
+    async def handler(context: BasicCrawlingContext) -> None:
+        processed_urls.append(context.request.url)
+
+    stats = await crawler.run(start_urls)
+
+    # Verify that only 3 out of the 5 provided URLs were made
+    assert len(processed_urls) == 3
+    assert stats.requests_total == 3
+    assert stats.requests_finished == 3


### PR DESCRIPTION
### Description

- Add max requests per crawl to `BasicCrawler`.

### Related issues

- #173 

### Testing

- A new unit test was implemented

Code sample for manual replication:

```python
import asyncio
import logging

from crawlee.autoscaling import ConcurrencySettings
from crawlee.beautifulsoup_crawler import BeautifulSoupCrawler, BeautifulSoupCrawlingContext

logging.basicConfig(level=logging.INFO)


async def main() -> None:
    crawler = BeautifulSoupCrawler(
        concurrency_settings=ConcurrencySettings(max_concurrency=1),
        max_requests_per_crawl=4,
    )

    @crawler.router.default_handler
    async def request_handler(context: BeautifulSoupCrawlingContext) -> None:
        await context.enqueue_links()
        data = {
            'url': context.request.url,
            'title': context.soup.title.string if context.soup.title else None,
        }
        await context.push_data(data)

    await crawler.run(['https://crawlee.dev'])


if __name__ == '__main__':
    asyncio.run(main())

```

### Checklist

- [x] Changes are described in the `CHANGELOG.md`
- [x] CI passed
