### PR TITLE
doc: add a first version of Quick start page

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ from crawlee.beautifulsoup_crawler import BeautifulSoupCrawler, BeautifulSoupCra
 
 
 async def main() -> None:
-    # Create a BeautifulSoupCrawler instance and provide a request provider
+    # Create a BeautifulSoupCrawler instance
     crawler = BeautifulSoupCrawler()
 
     # Define a handler for processing requests
@@ -229,7 +229,7 @@ from crawlee.playwright_crawler import PlaywrightCrawler, PlaywrightCrawlingCont
 
 
 async def main() -> None:
-    # Create a crawler instance and provide a request provider (and other optional arguments)
+    # Create a crawler instance
     crawler = PlaywrightCrawler(
         # headless=False,
         # browser_type='firefox',
@@ -273,7 +273,7 @@ async def main() -> None:
         ]
     )
 
-    # Create a crawler instance and provide a browser pool and request provider
+    # Create a crawler instance and provide a browser pool
     crawler = PlaywrightCrawler(browser_pool=browser_pool)
 
     @crawler.router.default_handler

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -28,10 +28,11 @@ library. It can manage Chromium, Firefox, Webkit, and other browsers. Playwright
 the [Puppeteer](https://pptr.dev/) library and is becoming the de facto standard in headless browser automation.
 If you need a headless browser, choose Playwright.
 
-```
-BEFORE YOU START
+:::caution before you start
+
 Crawlee requires Python 3.9 or later.
-```
+
+:::
 
 ## Installation
 
@@ -180,8 +181,12 @@ The JSON file will contain data similar to the following:
 }
 ```
 
+:::tip
+
 If you want to change the storage directory, you can set the `CRAWLEE_LOCAL_STORAGE_DIR` environment variable
 to your preferred path.
+
+:::
 
 ## Examples and further reading
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -1,0 +1,193 @@
+# Quick start
+
+This short tutorial will help you start scraping with Crawlee in just a minute or two. For an in-depth understanding
+of how Crawlee works, check out the [Introduction](https://crawlee.dev/docs/introduction) section, which provides
+a comprehensive step-by-step guide to creating your first scraper.
+
+## Choose your crawler
+
+Crawlee offers three main crawler classes: `BeautifulSoupCrawler`, `HttpCrawler`, and `PlaywrightCrawler`.
+All crawlers share the same interface, providing maximum flexibility when switching between them.
+
+### BeautifulSoupCrawler
+
+The `BeautifulSoupCrawler` is a plain HTTP crawler that parses HTML using the well-known
+[BeautifulSoup](https://pypi.org/project/beautifulsoup4/) library. It crawls the web using an HTTP client
+that mimics a browser. This crawler is very fast and efficient but cannot handle JavaScript rendering.
+
+### HttpCrawler
+
+The `HttpCrawler` serves as the core component of the `BeautifulSoupCrawler`, minus the `BeautifulSoup` library
+as a parser and some scraper-specific features like enqueue links helper. You can parse the HTML yourself or
+use any other parsing library.
+
+### PlaywrightCrawler
+
+The `PlaywrightCrawler` uses a headless browser controlled by the [Playwright](https://playwright.dev/)
+library. It can manage Chromium, Firefox, Webkit, and other browsers. Playwright is the successor to
+the [Puppeteer](https://pptr.dev/) library and is becoming the de facto standard in headless browser automation.
+If you need a headless browser, choose Playwright.
+
+```
+BEFORE YOU START
+Crawlee requires Python 3.9 or later.
+```
+
+## Installation
+
+Crawlee is available as the [`crawlee`](https://pypi.org/project/crawlee/) PyPI package.
+
+```bash
+pip install crawlee
+```
+
+Additional, optional dependencies unlocking more features are shipped as package extras.
+
+If you plan to use `BeautifulSoupCrawler`, install `crawlee` with `beautifulsoup` extra:
+
+```bash
+pip install 'crawlee[beautifulsoup]'
+```
+
+If you plan to use `PlaywrightCrawler`, install `crawlee` with the `playwright` extra:
+
+```bash
+pip install 'crawlee[playwright]'
+```
+
+Then, install the Playwright dependencies:
+
+```bash
+playwright install
+```
+
+You can install multiple extras at once by using a comma as a separator:
+
+```bash
+pip install 'crawlee[beautifulsoup,playwright]'
+```
+
+## Crawling
+
+Run the following example to perform a recursive crawl of the Crawlee website using the selected crawler.
+
+```python
+import asyncio
+
+from crawlee.beautifulsoup_crawler import BeautifulSoupCrawler, BeautifulSoupCrawlingContext
+
+
+async def main() -> None:
+    # BeautifulSoupCrawler crawls the web using HTTP requests and parses HTML using the BeautifulSoup library.
+    crawler = BeautifulSoupCrawler()
+
+    # Define a request handler to process each crawled page and attach it to the crawler using a decorator.
+    @crawler.router.default_handler
+    async def request_handler(context: BeautifulSoupCrawlingContext) -> None:
+        # Extract relevant data from the page context.
+        data = {
+            'url': context.request.url,
+            'title': context.soup.title.text,
+        }
+        # Store the extracted data.
+        await context.push_data(data)
+        # Extract links from the current page and add them to the crawling queue.
+        await context.enqueue_links()
+
+    await crawler.run(['https://crawlee.dev'])
+
+
+if __name__ == '__main__':
+    asyncio.run(main())
+```
+
+```python
+import asyncio
+
+from crawlee.playwright_crawler import PlaywrightCrawler, PlaywrightCrawlingContext
+
+
+async def main() -> None:
+    # PlaywrightCrawler crawls the web using a headless browser controlled by the Playwright library.
+    crawler = PlaywrightCrawler()
+
+    # Define a request handler to process each crawled page and attach it to the crawler using a decorator.
+    @crawler.router.default_handler
+    async def request_handler(context: PlaywrightCrawlingContext) -> None:
+        # Extract relevant data from the page context.
+        data = {
+            'url': context.request.url,
+            'title': await context.page.title(),
+        }
+        # Store the extracted data.
+        await context.push_data(data)
+        # Extract links from the current page and add them to the crawling queue.
+        await context.enqueue_links()
+
+    # Add first URL to the queue and start the crawl.
+    await crawler.run(['https://crawlee.dev'])
+
+
+if __name__ == '__main__':
+    asyncio.run(main())
+```
+
+When you run the example, you will see Crawlee automating the data extraction process in your terminal.
+
+<!-- TODO: improve the logging and add here a sample -->
+
+## Running headful browser
+
+By default, browsers controlled by Playwright run in headless mode (without a visible window). However,
+you can configure the crawler to run in a headful mode, which is useful during development phase to observe
+the browser's actions. You can alsoswitch from the default Chromium browser to Firefox or WebKit.
+
+```python
+# ...
+
+async def main() -> None:
+    crawler = PlaywrightCrawler(
+        # Run with a visible browser window.
+        headless=False,
+        # Switch to the Firefox browser.
+        browser_type='firefox'
+    )
+
+    # ...
+```
+
+When you run the example code, you'll see an automated browser navigating through the Crawlee website.
+
+<!-- TODO: add video example -->
+
+## Results
+
+By default, Crawlee stores data in the `./storage` directory within your current working directory.
+The results of your crawl will be saved as JSON files under `./storage/datasets/default/`.
+
+To view the results, you can use the `cat` command:
+
+```sh
+cat ./storage/datasets/default/000000001.json
+```
+
+The JSON file will contain data similar to the following:
+
+```json
+{
+    "url": "https://crawlee.dev/",
+    "title": "Crawlee · Build reliable crawlers. Fast. | Crawlee"
+}
+```
+
+If you want to change the storage directory, you can set the `CRAWLEE_LOCAL_STORAGE_DIR` environment variable
+to your preferred path.
+
+## Examples and further reading
+
+For more examples showcasing various features of Crawlee, visit
+the [Examples](https://crawlee.dev/python/docs/examples) section of the documentation.
+To get a deeper understanding of Crawlee and its components, read the step-by-step
+[Introduction](https://crawlee.dev/python/docs/examples) guide.
+
+<!-- TODO: add related links once they are ready -->

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -1,32 +1,22 @@
 # Quick start
 
-This short tutorial will help you start scraping with Crawlee in just a minute or two. For an in-depth understanding
-of how Crawlee works, check out the [Introduction](https://crawlee.dev/docs/introduction) section, which provides
-a comprehensive step-by-step guide to creating your first scraper.
+This short tutorial will help you start scraping with Crawlee in just a minute or two. For an in-depth understanding of how Crawlee works, check out the [Introduction](https://crawlee.dev/docs/introduction) section, which provides a comprehensive step-by-step guide to creating your first scraper.
 
 ## Choose your crawler
 
-Crawlee offers three main crawler classes: `BeautifulSoupCrawler`, `HttpCrawler`, and `PlaywrightCrawler`.
-All crawlers share the same interface, providing maximum flexibility when switching between them.
+Crawlee offers three main crawler classes: `BeautifulSoupCrawler`, `HttpCrawler`, and `PlaywrightCrawler`. All crawlers share the same interface, providing maximum flexibility when switching between them.
 
 ### BeautifulSoupCrawler
 
-The `BeautifulSoupCrawler` is a plain HTTP crawler that parses HTML using the well-known
-[BeautifulSoup](https://pypi.org/project/beautifulsoup4/) library. It crawls the web using an HTTP client
-that mimics a browser. This crawler is very fast and efficient but cannot handle JavaScript rendering.
+The `BeautifulSoupCrawler` is a plain HTTP crawler that parses HTML using the well-known [BeautifulSoup](https://pypi.org/project/beautifulsoup4/) library. It crawls the web using an HTTP client that mimics a browser. This crawler is very fast and efficient but cannot handle JavaScript rendering.
 
 ### HttpCrawler
 
-The `HttpCrawler` serves as the core component of the `BeautifulSoupCrawler`, minus the `BeautifulSoup` library
-as a parser and some scraper-specific features like enqueue links helper. You can parse the HTML yourself or
-use any other parsing library.
+The `HttpCrawler` serves as the core component of the `BeautifulSoupCrawler`, minus the `BeautifulSoup` library as a parser and some scraper-specific features like enqueue links helper. You can parse the HTML yourself or use any other parsing library.
 
 ### PlaywrightCrawler
 
-The `PlaywrightCrawler` uses a headless browser controlled by the [Playwright](https://playwright.dev/)
-library. It can manage Chromium, Firefox, Webkit, and other browsers. Playwright is the successor to
-the [Puppeteer](https://pptr.dev/) library and is becoming the de facto standard in headless browser automation.
-If you need a headless browser, choose Playwright.
+The `PlaywrightCrawler` uses a headless browser controlled by the [Playwright](https://playwright.dev/) library. It can manage Chromium, Firefox, Webkit, and other browsers. Playwright is the successor to the [Puppeteer](https://pptr.dev/) library and is becoming the de facto standard in headless browser automation. If you need a headless browser, choose Playwright.
 
 :::caution before you start
 
@@ -139,9 +129,7 @@ When you run the example, you will see Crawlee automating the data extraction pr
 
 ## Running headful browser
 
-By default, browsers controlled by Playwright run in headless mode (without a visible window). However,
-you can configure the crawler to run in a headful mode, which is useful during development phase to observe
-the browser's actions. You can alsoswitch from the default Chromium browser to Firefox or WebKit.
+By default, browsers controlled by Playwright run in headless mode (without a visible window). However, you can configure the crawler to run in a headful mode, which is useful during development phase to observe the browser's actions. You can alsoswitch from the default Chromium browser to Firefox or WebKit.
 
 ```python
 # ...
@@ -163,8 +151,7 @@ When you run the example code, you'll see an automated browser navigating throug
 
 ## Results
 
-By default, Crawlee stores data in the `./storage` directory within your current working directory.
-The results of your crawl will be saved as JSON files under `./storage/datasets/default/`.
+By default, Crawlee stores data in the `./storage` directory within your current working directory. The results of your crawl will be saved as JSON files under `./storage/datasets/default/`.
 
 To view the results, you can use the `cat` command:
 
@@ -183,16 +170,12 @@ The JSON file will contain data similar to the following:
 
 :::tip
 
-If you want to change the storage directory, you can set the `CRAWLEE_LOCAL_STORAGE_DIR` environment variable
-to your preferred path.
+If you want to change the storage directory, you can set the `CRAWLEE_LOCAL_STORAGE_DIR` environment variable to your preferred path.
 
 :::
 
 ## Examples and further reading
 
-For more examples showcasing various features of Crawlee, visit
-the [Examples](https://crawlee.dev/python/docs/examples) section of the documentation.
-To get a deeper understanding of Crawlee and its components, read the step-by-step
-[Introduction](https://crawlee.dev/python/docs/examples) guide.
+For more examples showcasing various features of Crawlee, visit the [Examples](https://crawlee.dev/python/docs/examples) section of the documentation. To get a deeper understanding of Crawlee and its components, read the step-by-step [Introduction](https://crawlee.dev/python/docs/examples) guide.
 
 <!-- TODO: add related links once they are ready -->


### PR DESCRIPTION
### Description

- Add a first version of Quick start page.
- Let's leave readme as it is for now and update it once the first version of doc is published.

### Related issues

- #169 

### Testing

- N/A

### Checklist

- [x] Changes are described in the `CHANGELOG.md`
- [x] CI passed
