### PR TITLE
feat: add support decompress *br* response content

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ colorama = "^0.4.6"
 docutils = "^0.21.0"
 eval-type-backport = "^0.2.0"
 html5lib = { version = "^1.1", optional = true }
-httpx = "^0.27.0"
+httpx = {extras = ["brotli"], version = "^0.27.0"}
 lxml = { version = "^5.2.1", optional = true }
 more_itertools = "^10.2.0"
 playwright = { version = "^1.43.0", optional = true }


### PR DESCRIPTION
### Description

Adds support for decompressing a brotli-compressed server response if an "Accept-Encoding" header was passed with the "br"  or "gzip, deflate, br" parameter and the server supports this type of compression.

Httpx provides the necessary functionality, but requires additional libraries to be installed to work correctly.