### PR TITLE
fix: Selector handling in BeautifulSoupCrawler enqueue_links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.7](../../releases/tag/v0.0.7) - Unreleased
+
+### Fixes
+
+- selector handling in `enqueue_links` in `BeautifulSoupCrawler`
+
 ## [0.0.6](../../releases/tag/v0.0.6) - Unreleased
 
 ### Adds

--- a/src/crawlee/beautifulsoup_crawler/beautifulsoup_crawler.py
+++ b/src/crawlee/beautifulsoup_crawler/beautifulsoup_crawler.py
@@ -123,7 +123,7 @@ class BeautifulSoupCrawler(BasicCrawler[BeautifulSoupCrawlingContext]):
             user_data = user_data or {}
 
             link: Tag
-            for link in soup.find_all(selector):
+            for link in soup.select(selector):
                 link_user_data = user_data
 
                 if label is not None:

--- a/tests/unit/beautifulsoup_crawler/test_beautifulsoup_crawler.py
+++ b/tests/unit/beautifulsoup_crawler/test_beautifulsoup_crawler.py
@@ -25,7 +25,7 @@ async def server() -> AsyncGenerator[respx.MockRouter, None]:
                     <title>Hello</title>
                 </head>
                 <body>
-                    <a href="/asdf">Link 1</a>
+                    <a href="/asdf" class="foo">Link 1</a>
                     <a href="/hjkl">Link 2</a>
                 </body>
             </html>""",
@@ -102,6 +102,27 @@ async def test_enqueue_links(server: respx.MockRouter) -> None:
         'https://test.io/hjkl',
         'https://test.io/qwer',
         'https://test.io/uiop',
+    }
+
+
+async def test_enqueue_links_selector(server: respx.MockRouter) -> None:
+    crawler = BeautifulSoupCrawler(request_provider=RequestList(['https://test.io/']))
+    visit = mock.Mock()
+
+    @crawler.router.default_handler
+    async def request_handler(context: BeautifulSoupCrawlingContext) -> None:
+        visit(context.request.url)
+        await context.enqueue_links(selector='a.foo')
+
+    await crawler.run()
+
+    assert server['index_endpoint'].called
+    assert server['secondary_index_endpoint'].called
+
+    visited = {call[0][0] for call in visit.call_args_list}
+    assert visited == {
+        'https://test.io/',
+        'https://test.io/asdf',
     }
 
 


### PR DESCRIPTION
- closes #230
