### PR TITLE
fix: handle blocked request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [0.0.7](../../releases/tag/v0.0.7) - Unreleased
 
-- ...
+### Fixes
+
+- selector handling for `RETRY_CSS_SELECTORS` in `_handle_blocked_request` in `BeautifulSoupCrawler`
 
 ## [0.0.6](../../releases/tag/v0.0.6) - 2024-06-25
 

--- a/src/crawlee/beautifulsoup_crawler/beautifulsoup_crawler.py
+++ b/src/crawlee/beautifulsoup_crawler/beautifulsoup_crawler.py
@@ -93,7 +93,7 @@ class BeautifulSoupCrawler(BasicCrawler[BeautifulSoupCrawlingContext]):
                 raise SessionError(f'Assuming the session is blocked based on HTTP status code {status_code}')
 
             matched_selectors = [
-                selector for selector in RETRY_CSS_SELECTORS if crawling_context.soup.find(selector) is not None
+                selector for selector in RETRY_CSS_SELECTORS if crawling_context.soup.select_one(selector) is not None
             ]
 
             if matched_selectors:

--- a/tests/unit/beautifulsoup_crawler/test_beautifulsoup_crawler.py
+++ b/tests/unit/beautifulsoup_crawler/test_beautifulsoup_crawler.py
@@ -143,10 +143,7 @@ async def test_enqueue_links_with_max_crawl(server: respx.MockRouter) -> None:
 
 
 async def test_handle_blocked_request(server: respx.MockRouter) -> None:
-    crawler = BeautifulSoupCrawler(
-        request_provider=RequestList(['https://test.io/fdyr']),
-        max_session_rotations=1
-        )
+    crawler = BeautifulSoupCrawler(request_provider=RequestList(['https://test.io/fdyr']), max_session_rotations=1)
     stats = await crawler.run()
     assert server['incapsula_endpoint'].called
     assert stats.requests_failed == 1


### PR DESCRIPTION
### Description

Replaced `find` to `select_one` because `find` does not support CSS selectors, which caused incorrect behavior.

### Related issues

#230


