### PR TITLE
chore: use latest crawlee version in templates

### DIFF
--- a/templates/beautifulsoup/{{cookiecutter.project_name}}/pyproject.toml
+++ b/templates/beautifulsoup/{{cookiecutter.project_name}}/pyproject.toml
@@ -8,8 +8,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.9"
-crawlee = {version = "^0.0.6", extras = ["beautifulsoup"]}
-
+crawlee = {version = "*", extras = ["beautifulsoup"]}
 
 [build-system]
 requires = ["poetry-core"]

--- a/templates/playwright/{{cookiecutter.project_name}}/pyproject.toml
+++ b/templates/playwright/{{cookiecutter.project_name}}/pyproject.toml
@@ -8,8 +8,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.9"
-crawlee = {version = "^0.0.6", extras = ["playwright"]}
-
+crawlee = {version = "*", extras = ["playwright"]}
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
so we do not have to do things like https://github.com/apify/crawlee-python/pull/247