### PR TITLE
fix: Pylance reportPrivateImportUsage errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 0.1.1 (Unreleased)
 
-- ...
+### Bug fixes
+
+- Fix Pylance `reportPrivateImportUsage` errors by defining `__all__` in modules `__init__.py`.
 
 ## [0.1.0](https://github.com/apify/crawlee-python/releases/tag/v0.1.0) (2024-07-09)
 
@@ -10,13 +12,13 @@
 
 - new project bootstrapping via `pipx run crawlee create`
 
-### Bug Fixes
+### Bug fixes
 
 - improve error handling in project bootstrapping
 
 ## [0.0.7](https://github.com/apify/crawlee-python/releases/tag/v0.0.7) (2024-06-27)
 
-### Bug Fixes
+### Bug fixes
 
 - selector handling for `RETRY_CSS_SELECTORS` in `_handle_blocked_request` in `BeautifulSoupCrawler`
 - selector handling in `enqueue_links` in `BeautifulSoupCrawler`
@@ -31,7 +33,7 @@
 - Automatic logging setup
 - Context helper for logging (`context.log`)
 
-### Bug Fixes
+### Bug fixes
 
 - Handling of relative URLs in `add_requests`
 - Graceful exit in `BasicCrawler.run`
@@ -52,7 +54,7 @@
 - Add enqueue links helper to `PlaywrightCrawler`
 - Add max requests per crawl option to `BasicCrawler`
 
-### Bug Fixes
+### Bug fixes
 
 - Fix type error in persist state of statistics
 

--- a/src/crawlee/autoscaling/__init__.py
+++ b/src/crawlee/autoscaling/__init__.py
@@ -1,3 +1,5 @@
 from .autoscaled_pool import AutoscaledPool, ConcurrencySettings
 from .snapshotter import Snapshotter
 from .system_status import SystemStatus
+
+__all__ = ['AutoscaledPool', 'ConcurrencySettings', 'Snapshotter', 'SystemStatus']

--- a/src/crawlee/base_storage_client/__init__.py
+++ b/src/crawlee/base_storage_client/__init__.py
@@ -5,3 +5,13 @@ from .base_key_value_store_collection_client import BaseKeyValueStoreCollectionC
 from .base_request_queue_client import BaseRequestQueueClient
 from .base_request_queue_collection_client import BaseRequestQueueCollectionClient
 from .base_storage_client import BaseStorageClient
+
+__all__ = [
+    'BaseDatasetClient',
+    'BaseDatasetCollectionClient',
+    'BaseKeyValueStoreClient',
+    'BaseKeyValueStoreCollectionClient',
+    'BaseRequestQueueClient',
+    'BaseRequestQueueCollectionClient',
+    'BaseStorageClient',
+]

--- a/src/crawlee/basic_crawler/__init__.py
+++ b/src/crawlee/basic_crawler/__init__.py
@@ -2,3 +2,5 @@ from .basic_crawler import BasicCrawler, BasicCrawlerOptions
 from .context_pipeline import ContextPipeline
 from .router import Router
 from .types import BasicCrawlingContext
+
+__all__ = ['BasicCrawler', 'BasicCrawlerOptions', 'ContextPipeline', 'Router', 'BasicCrawlingContext']

--- a/src/crawlee/beautifulsoup_crawler/__init__.py
+++ b/src/crawlee/beautifulsoup_crawler/__init__.py
@@ -6,3 +6,5 @@ except ImportError as exc:
         'To import anything from this subpacakge, you need to install the "beautifulsoup" extra. '
         'For example, if you use pip, run "pip install crawlee[beautifulsoup]".',
     ) from exc
+
+__all__ = ['BeautifulSoupCrawler', 'BeautifulSoupCrawlingContext']

--- a/src/crawlee/browsers/__init__.py
+++ b/src/crawlee/browsers/__init__.py
@@ -7,3 +7,5 @@ except ImportError as exc:
         'To import anything from this subpacakge, you need to install the "playwright" extra. '
         'For example, if you use pip, run "pip install crawlee[playwright]".',
     ) from exc
+
+__all__ = ['BrowserPool', 'PlaywrightBrowserController', 'PlaywrightBrowserPlugin']

--- a/src/crawlee/events/__init__.py
+++ b/src/crawlee/events/__init__.py
@@ -1,2 +1,4 @@
 from .event_manager import EventManager
 from .local_event_manager import LocalEventManager
+
+__all__ = ['EventManager', 'LocalEventManager']

--- a/src/crawlee/http_clients/__init__.py
+++ b/src/crawlee/http_clients/__init__.py
@@ -1,2 +1,4 @@
 from .base_http_client import BaseHttpClient, HttpCrawlingResult, HttpResponse
 from .httpx_client import HttpxClient
+
+__all__ = ['BaseHttpClient', 'HttpCrawlingResult', 'HttpResponse', 'HttpxClient']

--- a/src/crawlee/http_crawler/__init__.py
+++ b/src/crawlee/http_crawler/__init__.py
@@ -1,2 +1,4 @@
 from .http_crawler import HttpCrawler
 from .types import HttpCrawlingContext, HttpCrawlingResult
+
+__all__ = ['HttpCrawler', 'HttpCrawlingContext', 'HttpCrawlingResult']

--- a/src/crawlee/memory_storage_client/__init__.py
+++ b/src/crawlee/memory_storage_client/__init__.py
@@ -1,1 +1,3 @@
 from .memory_storage_client import MemoryStorageClient
+
+__all__ = ['MemoryStorageClient']

--- a/src/crawlee/playwright_crawler/__init__.py
+++ b/src/crawlee/playwright_crawler/__init__.py
@@ -6,3 +6,5 @@ except ImportError as exc:
         'To import anything from this subpacakge, you need to install the "playwright" extra. '
         'For example, if you use pip, run "pip install crawlee[playwright]".',
     ) from exc
+
+__all__ = ['PlaywrightCrawler', 'PlaywrightCrawlingContext']

--- a/src/crawlee/sessions/__init__.py
+++ b/src/crawlee/sessions/__init__.py
@@ -1,2 +1,4 @@
 from .session import Session
 from .session_pool import SessionPool
+
+__all__ = ['Session', 'SessionPool']

--- a/src/crawlee/statistics/__init__.py
+++ b/src/crawlee/statistics/__init__.py
@@ -1,2 +1,4 @@
 from .models import FinalStatistics, StatisticsPersistedState, StatisticsState
 from .statistics import Statistics
+
+__all__ = ['FinalStatistics', 'Statistics', 'StatisticsPersistedState', 'StatisticsState']

--- a/src/crawlee/storages/__init__.py
+++ b/src/crawlee/storages/__init__.py
@@ -2,3 +2,5 @@ from .dataset import Dataset
 from .key_value_store import KeyValueStore
 from .request_list import RequestList
 from .request_queue import RequestQueue
+
+__all__ = ['Dataset', 'KeyValueStore', 'RequestList', 'RequestQueue']


### PR DESCRIPTION
### Description

- Fix Pylance `reportPrivateImportUsage` errors by defining `__all__` in modules `__init__.py`.

### Issues

- Closes: #283

### Testing

- N/A

### Checklist

- [x] Changes are described in the `CHANGELOG.md`
- [x] CI passed
