### PR TITLE
refactor: `context.request.url` is string

### DIFF
--- a/src/crawlee/_utils/urls.py
+++ b/src/crawlee/_utils/urls.py
@@ -1,19 +1,34 @@
 from __future__ import annotations
 
-from urllib.parse import urljoin, urlparse
+from urllib.parse import parse_qs, urljoin, urlparse
 
-from pydantic import HttpUrl
+from pydantic import AnyHttpUrl, TypeAdapter
 
 
-def is_url_absolute(url: str | HttpUrl) -> bool:
+def is_url_absolute(url: str) -> bool:
     """Check if a URL is absolute."""
-    url = url if isinstance(url, str) else str(url)
     return bool(urlparse(url).netloc)
 
 
-def make_url_absolute(base_url: str | HttpUrl, relative_url: str | HttpUrl) -> HttpUrl:
-    """Make a relative URL absolute by combining it with a base URL."""
-    base_url = base_url if isinstance(base_url, str) else str(base_url)
-    relative_url = relative_url if isinstance(relative_url, str) else str(relative_url)
-    absolute_url = urljoin(base_url, relative_url)
-    return HttpUrl(absolute_url)
+def convert_to_absolute_url(base_url: str, relative_url: str) -> str:
+    """Convert a relative URL to an absolute URL using a base URL."""
+    return urljoin(base_url, relative_url)
+
+
+def extract_query_params(url: str) -> dict[str, list[str]]:
+    """Extract query parameters from a given URL."""
+    url_parsed = urlparse(url)
+    return parse_qs(url_parsed.query)
+
+
+def validate_http_url(value: str | None) -> str | None:
+    """Validate the given HTTP URL.
+
+    Raises:
+        pydantic.error_wrappers.ValidationError: If the URL is not valid.
+    """
+    if value is None:
+        return None
+    adapter = TypeAdapter(AnyHttpUrl)
+    adapter.validate_python(value)
+    return value

--- a/src/crawlee/_utils/urls.py
+++ b/src/crawlee/_utils/urls.py
@@ -23,6 +23,7 @@ def extract_query_params(url: str) -> dict[str, list[str]]:
 
 _http_url_adapter = TypeAdapter(AnyHttpUrl)
 
+
 def validate_http_url(value: str | None) -> str | None:
     """Validate the given HTTP URL.
 

--- a/src/crawlee/_utils/urls.py
+++ b/src/crawlee/_utils/urls.py
@@ -21,14 +21,15 @@ def extract_query_params(url: str) -> dict[str, list[str]]:
     return parse_qs(url_parsed.query)
 
 
+_http_url_adapter = TypeAdapter(AnyHttpUrl)
+
 def validate_http_url(value: str | None) -> str | None:
     """Validate the given HTTP URL.
 
     Raises:
         pydantic.error_wrappers.ValidationError: If the URL is not valid.
     """
-    if value is None:
-        return None
-    adapter = TypeAdapter(AnyHttpUrl)
-    adapter.validate_python(value)
+    if value is not None:
+        _http_url_adapter.validate_python(value)
+
     return value

--- a/src/crawlee/beautifulsoup_crawler/beautifulsoup_crawler.py
+++ b/src/crawlee/beautifulsoup_crawler/beautifulsoup_crawler.py
@@ -8,7 +8,7 @@ from bs4 import BeautifulSoup, Tag
 from typing_extensions import Unpack
 
 from crawlee._utils.blocked import RETRY_CSS_SELECTORS
-from crawlee._utils.urls import is_url_absolute, make_url_absolute
+from crawlee._utils.urls import convert_to_absolute_url, is_url_absolute
 from crawlee.basic_crawler import BasicCrawler, BasicCrawlerOptions, ContextPipeline
 from crawlee.basic_crawler.errors import SessionError
 from crawlee.beautifulsoup_crawler.types import BeautifulSoupCrawlingContext
@@ -134,7 +134,7 @@ class BeautifulSoupCrawler(BasicCrawler[BeautifulSoupCrawlingContext]):
                     url = url.strip()
 
                     if not is_url_absolute(url):
-                        url = str(make_url_absolute(context.request.url, url))
+                        url = convert_to_absolute_url(context.request.url, url)
 
                     requests.append(BaseRequestData.from_url(url, user_data=link_user_data))
 

--- a/src/crawlee/http_clients/httpx_client.py
+++ b/src/crawlee/http_clients/httpx_client.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, cast
 
 import httpx
-from pydantic import HttpUrl
 from typing_extensions import override
 
 from crawlee._utils.blocked import ROTATE_PROXY_ERRORS
@@ -89,7 +88,7 @@ class HttpxClient(BaseHttpClient):
         client = self._get_client(proxy_info.url if proxy_info else None)
         http_request = client.build_request(
             method=request.method,
-            url=str(request.url),
+            url=request.url,
             headers=request.headers,
             cookies=session.cookies if session else None,
             extensions={'crawlee_session': session if self._persist_cookies_per_session else None},
@@ -120,7 +119,7 @@ class HttpxClient(BaseHttpClient):
                 f'Status code {response.status_code} returned', request=response.request, response=response
             )
 
-        request.loaded_url = HttpUrl(str(response.url))
+        request.loaded_url = str(response.url)
         return HttpCrawlingResult(http_response=response)
 
     @override

--- a/src/crawlee/playwright_crawler/playwright_crawler.py
+++ b/src/crawlee/playwright_crawler/playwright_crawler.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Literal
 
-from pydantic import HttpUrl
 from typing_extensions import Unpack
 
 from crawlee._utils.blocked import RETRY_CSS_SELECTORS
-from crawlee._utils.urls import is_url_absolute, make_url_absolute
+from crawlee._utils.urls import convert_to_absolute_url, is_url_absolute
 from crawlee.basic_crawler import BasicCrawler, BasicCrawlerOptions, ContextPipeline
 from crawlee.basic_crawler.errors import SessionError
 from crawlee.browsers import BrowserPool
@@ -104,13 +103,13 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext]):
 
         async with crawlee_page.page:
             # Navigate to the URL and get response.
-            response = await crawlee_page.page.goto(str(context.request.url))
+            response = await crawlee_page.page.goto(context.request.url)
 
             if response is None:
                 raise SessionError(f'Failed to load the URL: {context.request.url}')
 
             # Set the loaded URL to the actual URL after redirection.
-            context.request.loaded_url = HttpUrl(crawlee_page.page.url)
+            context.request.loaded_url = crawlee_page.page.url
 
             async def enqueue_links(
                 *,
@@ -134,7 +133,7 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext]):
                         url = url.strip()
 
                         if not is_url_absolute(url):
-                            url = str(make_url_absolute(context.request.url, url))
+                            url = convert_to_absolute_url(context.request.url, url)
 
                         link_user_data = user_data.copy()
 

--- a/src/crawlee/proxy_configuration.py
+++ b/src/crawlee/proxy_configuration.py
@@ -4,6 +4,7 @@ import inspect
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
+from urllib.parse import urlparse
 
 from httpx import URL
 from more_itertools import flatten
@@ -210,7 +211,7 @@ class ProxyConfiguration:
 
         if self._proxy_tier_tracker:
             if request is not None and proxy_tier is None:
-                hostname = request.url.host
+                hostname = urlparse(request.url).hostname
                 if hostname is None:
                     raise ValueError('The request URL does not have a hostname')
 

--- a/tests/unit/_utils/test_urls.py
+++ b/tests/unit/_utils/test_urls.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from pydantic import HttpUrl
+import pytest
+from pydantic.error_wrappers import ValidationError
 
-from crawlee._utils.urls import is_url_absolute, make_url_absolute
+from crawlee._utils.urls import convert_to_absolute_url, extract_query_params, is_url_absolute, validate_http_url
 
 
 def test_is_url_absolute() -> None:
@@ -12,21 +13,35 @@ def test_is_url_absolute() -> None:
     assert is_url_absolute('/path/to/resource') is False
     assert is_url_absolute('relative/path/to/resource') is False
     assert is_url_absolute('example.com/path') is False
-    assert is_url_absolute(HttpUrl('http://example.com/path')) is True
 
 
-def test_make_url_absolute() -> None:
-    base_url: str | HttpUrl = 'http://example.com'
+def test_convert_to_absolute_url() -> None:
+    base_url = 'http://example.com'
     relative_url = '/path/to/resource'
-    absolute_url = make_url_absolute(base_url, relative_url)
-    assert str(absolute_url) == 'http://example.com/path/to/resource'
-
-    base_url = HttpUrl('http://example.com')
-    relative_url = 'path/to/resource'
-    absolute_url = make_url_absolute(base_url, relative_url)
-    assert str(absolute_url) == 'http://example.com/path/to/resource'
+    absolute_url = convert_to_absolute_url(base_url, relative_url)
+    assert absolute_url == 'http://example.com/path/to/resource'
 
     base_url = 'http://example.com/base/'
     relative_url = '../path/to/resource'
-    absolute_url = make_url_absolute(base_url, relative_url)
-    assert str(absolute_url) == 'http://example.com/path/to/resource'
+    absolute_url = convert_to_absolute_url(base_url, relative_url)
+    assert absolute_url == 'http://example.com/path/to/resource'
+
+
+def test_extract_query_parameters() -> None:
+    url = 'https://example.com/path?name=John&age=30&city=New%20York'
+    expected_params = {'name': ['John'], 'age': ['30'], 'city': ['New York']}
+    assert extract_query_params(url) == expected_params
+
+    url_no_params = 'https://example.com/path'
+    assert extract_query_params(url_no_params) == {}
+
+
+def test_validate_http_url() -> None:
+    assert validate_http_url(None) is None
+
+    valid_url = 'https://example.com'
+    assert validate_http_url(valid_url) == valid_url
+
+    invalid_url = 'htp://invalid-url'
+    with pytest.raises(ValidationError):
+        validate_http_url(invalid_url)

--- a/tests/unit/basic_crawler/test_basic_crawler.py
+++ b/tests/unit/basic_crawler/test_basic_crawler.py
@@ -34,7 +34,7 @@ async def test_processes_requests() -> None:
 
     @crawler.router.default_handler
     async def handler(context: BasicCrawlingContext) -> None:
-        calls.append(str(context.request.url))
+        calls.append(context.request.url)
 
     await crawler.run()
 
@@ -47,7 +47,7 @@ async def test_processes_requests_from_run_args() -> None:
 
     @crawler.router.default_handler
     async def handler(context: BasicCrawlingContext) -> None:
-        calls.append(str(context.request.url))
+        calls.append(context.request.url)
 
     await crawler.run(['http://a.com/', 'http://b.com/', 'http://c.com/'])
 
@@ -60,7 +60,7 @@ async def test_allows_multiple_run_calls() -> None:
 
     @crawler.router.default_handler
     async def handler(context: BasicCrawlingContext) -> None:
-        calls.append(str(context.request.url))
+        calls.append(context.request.url)
 
     await crawler.run(['http://a.com/', 'http://b.com/', 'http://c.com/'])
     await crawler.run(['http://a.com/', 'http://b.com/', 'http://c.com/'])
@@ -81,10 +81,9 @@ async def test_retries_failed_requests() -> None:
 
     @crawler.router.default_handler
     async def handler(context: BasicCrawlingContext) -> None:
-        url = str(context.request.url)
-        calls.append(url)
+        calls.append(context.request.url)
 
-        if url == 'http://b.com/':
+        if context.request.url == 'http://b.com/':
             raise RuntimeError('Arbitrary crash for testing purposes')
 
     await crawler.run()
@@ -109,7 +108,7 @@ async def test_respects_no_retry() -> None:
 
     @crawler.router.default_handler
     async def handler(context: BasicCrawlingContext) -> None:
-        calls.append(str(context.request.url))
+        calls.append(context.request.url)
         raise RuntimeError('Arbitrary crash for testing purposes')
 
     await crawler.run()
@@ -140,7 +139,7 @@ async def test_respects_request_specific_max_retries() -> None:
 
     @crawler.router.default_handler
     async def handler(context: BasicCrawlingContext) -> None:
-        calls.append(str(context.request.url))
+        calls.append(context.request.url)
         raise RuntimeError('Arbitrary crash for testing purposes')
 
     await crawler.run()
@@ -164,7 +163,7 @@ async def test_calls_error_handler() -> None:
 
     @crawler.router.default_handler
     async def handler(context: BasicCrawlingContext) -> None:
-        if str(context.request.url) == 'http://b.com/':
+        if context.request.url == 'http://b.com/':
             raise RuntimeError('Arbitrary crash for testing purposes')
 
     @crawler.error_handler
@@ -181,7 +180,7 @@ async def test_calls_error_handler() -> None:
     await crawler.run()
 
     assert len(calls) == 2  # error handler should be called for each retryable request
-    assert str(calls[0][0].request.url) == 'http://b.com/'
+    assert calls[0][0].request.url == 'http://b.com/'
     assert isinstance(calls[0][1], RuntimeError)
 
     # Check the contents of the `custom_retry_count` header added by the error handler
@@ -197,7 +196,7 @@ async def test_handles_error_in_error_handler() -> None:
 
     @crawler.router.default_handler
     async def handler(context: BasicCrawlingContext) -> None:
-        if str(context.request.url) == 'http://b.com/':
+        if context.request.url == 'http://b.com/':
             raise RuntimeError('Arbitrary crash for testing purposes')
 
     @crawler.error_handler
@@ -217,7 +216,7 @@ async def test_calls_failed_request_handler() -> None:
 
     @crawler.router.default_handler
     async def handler(context: BasicCrawlingContext) -> None:
-        if str(context.request.url) == 'http://b.com/':
+        if context.request.url == 'http://b.com/':
             raise RuntimeError('Arbitrary crash for testing purposes')
 
     @crawler.failed_request_handler
@@ -227,7 +226,7 @@ async def test_calls_failed_request_handler() -> None:
     await crawler.run()
 
     assert len(calls) == 1
-    assert str(calls[0][0].request.url) == 'http://b.com/'
+    assert calls[0][0].request.url == 'http://b.com/'
     assert isinstance(calls[0][1], RuntimeError)
 
 
@@ -239,7 +238,7 @@ async def test_handles_error_in_failed_request_handler() -> None:
 
     @crawler.router.default_handler
     async def handler(context: BasicCrawlingContext) -> None:
-        if str(context.request.url) == 'http://b.com/':
+        if context.request.url == 'http://b.com/':
             raise RuntimeError('Arbitrary crash for testing purposes')
 
     @crawler.failed_request_handler
@@ -396,8 +395,7 @@ async def test_enqueue_strategy(test_input: AddRequestsTestInput) -> None:
 
     @crawler.router.default_handler
     async def handler(context: BasicCrawlingContext) -> None:
-        url = str(context.request.url)
-        visit(url)
+        visit(context.request.url)
 
     await crawler.run()
 
@@ -492,7 +490,7 @@ async def test_crawler_run_requests(httpbin: str) -> None:
 
     @crawler.router.default_handler
     async def handler(context: BasicCrawlingContext) -> None:
-        seen_urls.append(str(context.request.url))
+        seen_urls.append(context.request.url)
 
     stats = await crawler.run([f'{httpbin}/1', f'{httpbin}/2', f'{httpbin}/3'])
 

--- a/tests/unit/beautifulsoup_crawler/test_beautifulsoup_crawler.py
+++ b/tests/unit/beautifulsoup_crawler/test_beautifulsoup_crawler.py
@@ -100,8 +100,7 @@ async def test_enqueue_links(server: respx.MockRouter) -> None:
 
     @crawler.router.default_handler
     async def request_handler(context: BeautifulSoupCrawlingContext) -> None:
-        url = str(context.request.url)
-        visit(url)
+        visit(context.request.url)
         await context.enqueue_links()
 
     await crawler.run()
@@ -125,8 +124,7 @@ async def test_enqueue_links_selector(server: respx.MockRouter) -> None:
 
     @crawler.router.default_handler
     async def request_handler(context: BeautifulSoupCrawlingContext) -> None:
-        url = str(context.request.url)
-        visit(url)
+        visit(context.request.url)
         await context.enqueue_links(selector='a.foo')
 
     await crawler.run()

--- a/tests/unit/http_crawler/test_http_crawler.py
+++ b/tests/unit/http_crawler/test_http_crawler.py
@@ -74,7 +74,7 @@ async def test_fetches_html(
     assert server['html_endpoint'].called
 
     mock_request_handler.assert_called_once()
-    assert str(mock_request_handler.call_args[0][0].request.url) == 'https://test.io/html'
+    assert mock_request_handler.call_args[0][0].request.url == 'https://test.io/html'
 
 
 async def test_handles_redirects(
@@ -84,7 +84,7 @@ async def test_handles_redirects(
     await crawler.run()
 
     mock_request_handler.assert_called_once()
-    assert str(mock_request_handler.call_args[0][0].request.loaded_url) == 'https://test.io/html'
+    assert mock_request_handler.call_args[0][0].request.loaded_url == 'https://test.io/html'
 
     assert server['redirect_endpoint'].called
     assert server['html_endpoint'].called
@@ -97,7 +97,7 @@ async def test_handles_client_errors(
     await crawler.run()
 
     mock_request_handler.assert_called_once()
-    assert str(mock_request_handler.call_args[0][0].request.loaded_url) == 'https://test.io/404'
+    assert mock_request_handler.call_args[0][0].request.loaded_url == 'https://test.io/404'
     assert server['404_endpoint'].called
 
 
@@ -129,8 +129,7 @@ async def test_stores_cookies(httpbin: str) -> None:
 
     @crawler.router.default_handler
     async def handler(context: HttpCrawlingContext) -> None:
-        url = str(context.request.url)
-        visit(url)
+        visit(context.request.url)
         track_session_usage(context.session.id if context.session else None)
 
     await crawler.run()

--- a/tests/unit/memory_storage_client/test_request_queue_client.py
+++ b/tests/unit/memory_storage_client/test_request_queue_client.py
@@ -6,7 +6,6 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 import pytest
-from pydantic import HttpUrl
 
 from crawlee.models import Request
 
@@ -119,7 +118,7 @@ async def test_get_record(request_queue_client: RequestQueueClient) -> None:
 
     request = await request_queue_client.get_request(processed_request.id)
     assert request is not None
-    assert request.url == request.url == HttpUrl(request_url)
+    assert request.url == request.url == request_url
 
     # Non-existent id
     assert (await request_queue_client.get_request('non-existent id')) is None

--- a/tests/unit/memory_storage_client/test_request_queue_client.py
+++ b/tests/unit/memory_storage_client/test_request_queue_client.py
@@ -118,7 +118,7 @@ async def test_get_record(request_queue_client: RequestQueueClient) -> None:
 
     request = await request_queue_client.get_request(processed_request.id)
     assert request is not None
-    assert request.url == request.url == request_url
+    assert request.url == request_url
 
     # Non-existent id
     assert (await request_queue_client.get_request('non-existent id')) is None

--- a/tests/unit/playwright_crawler/test_playwright_crawler.py
+++ b/tests/unit/playwright_crawler/test_playwright_crawler.py
@@ -23,7 +23,7 @@ async def test_basic_request(httpbin: str) -> None:
     @crawler.router.default_handler
     async def request_handler(context: PlaywrightCrawlingContext) -> None:
         assert context.page is not None
-        result['request_url'] = str(context.request.url)
+        result['request_url'] = context.request.url
         result['page_url'] = context.page.url
         result['page_title'] = await context.page.title()
         result['page_content'] = await context.page.content()
@@ -42,8 +42,7 @@ async def test_enqueue_links() -> None:
 
     @crawler.router.default_handler
     async def request_handler(context: PlaywrightCrawlingContext) -> None:
-        url = str(context.request.url)
-        visit(url)
+        visit(context.request.url)
         await context.enqueue_links(include=[Glob('https://crawlee.dev/docs/examples/**')])
 
     await crawler.run(requests)

--- a/tests/unit/storages/test_request_queue.py
+++ b/tests/unit/storages/test_request_queue.py
@@ -5,7 +5,6 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 import pytest
-from pydantic import HttpUrl
 
 from crawlee.models import BaseRequestData, Request
 from crawlee.storages import RequestQueue
@@ -118,7 +117,7 @@ async def test_reclaim_request(request_queue: RequestQueue) -> None:
     # Fetch the request
     next_request = await request_queue.fetch_next_request()
     assert next_request is not None
-    assert HttpUrl(next_request.unique_key) == request.url
+    assert next_request.unique_key == request.url
 
     # Reclaim
     await request_queue.reclaim_request(next_request)
@@ -159,7 +158,7 @@ async def test_add_batched_requests(
         next_request = await request_queue.fetch_next_request()
         assert next_request is not None
 
-        expected_url = HttpUrl(original_request) if isinstance(original_request, str) else original_request.url
+        expected_url = original_request if isinstance(original_request, str) else original_request.url
         assert next_request.url == expected_url
 
     # Confirm the queue is empty after processing all requests


### PR DESCRIPTION
### Description

- `context.request.url` is a string, but URL validation is kept

### Issues

- N/A

### Testing

- Tests pass

### Checklist

- [x] Changes are described in the `CHANGELOG.md`
- [x] CI passed
