### PR TITLE
chore: add basic badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@
     <small>A web scraping and browser automation library</small>
 </h1>
 
+<p align=center>
+    <a href="https://badge.fury.io/py/crawlee" rel="nofollow">
+        <img src="https://badge.fury.io/py/crawlee.svg" alt="PyPI version" style="max-width: 100%;">
+    </a>
+    <a href="https://pypi.org/project/crawlee/" rel="nofollow">
+        <img src="https://img.shields.io/pypi/dm/crawlee" alt="PyPI - Downloads" style="max-width: 100%;">
+    </a>
+    <a href="https://pypi.org/project/crawlee/" rel="nofollow">
+        <img src="https://img.shields.io/pypi/pyversions/crawlee" alt="PyPI - Python Version" style="max-width: 100%;">
+    </a>
+    <a href="https://discord.gg/jyEM2PRvMU" rel="nofollow">
+        <img src="https://img.shields.io/discord/801163717915574323?label=discord" alt="Chat on discord" style="max-width: 100%;">
+    </a>
+</p>
+
 Crawlee covers your crawling and scraping end-to-end and **helps you build reliable scrapers. Fast.**
 
 > 🚀 Crawlee for Python is open to early adopters!


### PR DESCRIPTION
If we would like to add a test coverage badge, we would need to utilize some 3rd part service like [Codecov](https://codecov.io/) or [Coveralls](https://coveralls.io/).