### PR TITLE
fix: do not import curl impersonate in http clients init

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Verify that Crawlee is successfully installed:
 python -c 'import crawlee; print(crawlee.__version__)'
 ```
 
-For detail installation information see the [Setting up](../introduction/01-setting-up.mdx) documentation page.
+For detailed installation instructions see the [Setting up](../introduction/01-setting-up.mdx) documentation page.
 
 ### With Crawlee CLI
 

--- a/README.md
+++ b/README.md
@@ -49,24 +49,10 @@ We also have a TypeScript implementation of the Crawlee, which you can explore a
 
 We recommend visiting the [Introduction tutorial](https://crawlee.dev/python/docs/introduction) in Crawlee documentation for more information.
 
-Crawlee is available as the [`crawlee`](https://pypi.org/project/crawlee/) PyPI package.
+Crawlee is available as the [`crawlee`](https://pypi.org/project/crawlee/) PyPI package. The core functionality is included in the base package, with additional features available as optional extras to minimize package size and dependencies. To install Crawlee with all features, run the following command:
 
 ```sh
-pip install crawlee
-```
-
-Additional, optional dependencies unlocking more features are shipped as package extras.
-
-If you plan to parse HTML and use CSS selectors, install `crawlee` with `beautifulsoup` extra:
-
-```sh
-pip install 'crawlee[beautifulsoup]'
-```
-
-If you plan to use a (headless) browser, install `crawlee` with the `playwright` extra:
-
-```sh
-pip install 'crawlee[playwright]'
+pip install 'crawlee[all]'
 ```
 
 Then, install the Playwright dependencies:
@@ -75,17 +61,13 @@ Then, install the Playwright dependencies:
 playwright install
 ```
 
-You can install multiple extras at once by using a comma as a separator:
-
-```sh
-pip install 'crawlee[beautifulsoup,playwright]'
-```
-
 Verify that Crawlee is successfully installed:
 
 ```sh
 python -c 'import crawlee; print(crawlee.__version__)'
 ```
+
+For detail installation information see the [Setting up](../introduction/01-setting-up.mdx) documentation page.
 
 ### With Crawlee CLI
 

--- a/docs/introduction/01-setting-up.mdx
+++ b/docs/introduction/01-setting-up.mdx
@@ -52,6 +52,12 @@ You can install multiple extras at once by using a comma as a separator:
 pip install 'crawlee[beautifulsoup,playwright]'
 ```
 
+Or if you do not care about the package size, you can install everything:
+
+```sh
+pip install 'crawlee[all]'
+```
+
 Verify that Crawlee is successfully installed:
 
 ```sh

--- a/docs/quick-start/index.mdx
+++ b/docs/quick-start/index.mdx
@@ -46,7 +46,7 @@ Verify that Crawlee is successfully installed:
 python -c 'import crawlee; print(crawlee.__version__)'
 ```
 
-For detail installation information see the [Setting up](../introduction/01-setting-up.mdx) documentation page.
+For detailed installation instructions see the [Setting up](../introduction/01-setting-up.mdx) documentation page.
 
 ## Crawling
 

--- a/docs/quick-start/index.mdx
+++ b/docs/quick-start/index.mdx
@@ -28,24 +28,10 @@ Crawlee requires Python 3.9 or later.
 
 ## Installation
 
-Crawlee is available as the [`crawlee`](https://pypi.org/project/crawlee/) PyPI package.
+Crawlee is available as the [`crawlee`](https://pypi.org/project/crawlee/) PyPI package. The core functionality is included in the base package, with additional features available as optional extras to minimize package size and dependencies. To install Crawlee with all features, run the following command:
 
 ```sh
-pip install crawlee
-```
-
-Additional, optional dependencies unlocking more features are shipped as package extras.
-
-If you plan to use `BeautifulSoupCrawler`, install `crawlee` with `beautifulsoup` extra:
-
-```sh
-pip install 'crawlee[beautifulsoup]'
-```
-
-If you plan to use `PlaywrightCrawler`, install `crawlee` with the `playwright` extra:
-
-```sh
-pip install 'crawlee[playwright]'
+pip install 'crawlee[all]'
 ```
 
 Then, install the Playwright dependencies:
@@ -54,11 +40,13 @@ Then, install the Playwright dependencies:
 playwright install
 ```
 
-You can install multiple extras at once by using a comma as a separator:
+Verify that Crawlee is successfully installed:
 
 ```sh
-pip install 'crawlee[beautifulsoup,playwright]'
+python -c 'import crawlee; print(crawlee.__version__)'
 ```
+
+For detail installation information see the [Setting up](../introduction/01-setting-up.mdx) documentation page.
 
 ## Crawling
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ types-psutil = "~5.9.5.20240205"
 types-python-dateutil = "~2.9.0.20240316"
 
 [tool.poetry.extras]
+all = ["beautifulsoup4", "lxml", "html5lib", "curl-cffi", "playwright"]
 beautifulsoup = ["beautifulsoup4", "lxml", "html5lib"]
 curl-impersonate = ["curl-cffi"]
 playwright = ["playwright"]

--- a/src/crawlee/http_clients/__init__.py
+++ b/src/crawlee/http_clients/__init__.py
@@ -1,12 +1,4 @@
 from .base import BaseHttpClient, HttpCrawlingResult, HttpResponse
 from .httpx import HttpxHttpClient
 
-try:
-    from .curl_impersonate import CurlImpersonateHttpClient
-except ImportError as exc:
-    raise ImportError(
-        "To import anything from this subpackage, you need to install the 'curl-impersonate' extra."
-        "For example, if you use pip, run `pip install 'crawlee[curl-impersonate]'`.",
-    ) from exc
-
-__all__ = ['BaseHttpClient', 'CurlImpersonateHttpClient', 'HttpCrawlingResult', 'HttpResponse', 'HttpxHttpClient']
+__all__ = ['BaseHttpClient', 'HttpCrawlingResult', 'HttpResponse', 'HttpxHttpClient']

--- a/src/crawlee/http_clients/curl_impersonate.py
+++ b/src/crawlee/http_clients/curl_impersonate.py
@@ -2,8 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional
 
-from curl_cffi.requests import AsyncSession
-from curl_cffi.requests.errors import RequestsError
+try:
+    from curl_cffi.requests import AsyncSession
+    from curl_cffi.requests.errors import RequestsError
+except ImportError as exc:
+    raise ImportError(
+        "To import anything from this subpackage, you need to install the 'curl-impersonate' extra."
+        "For example, if you use pip, run `pip install 'crawlee[curl-impersonate]'`.",
+    ) from exc
+
 from typing_extensions import override
 
 from crawlee._utils.blocked import ROTATE_PROXY_ERRORS

--- a/tests/unit/http_clients/test_curl_impersonate.py
+++ b/tests/unit/http_clients/test_curl_impersonate.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from crawlee.errors import ProxyError
-from crawlee.http_clients import CurlImpersonateHttpClient
+from crawlee.http_clients.curl_impersonate import CurlImpersonateHttpClient
 from crawlee.models import Request
 from crawlee.statistics import Statistics
 


### PR DESCRIPTION
### Description

- do not import curl impersonate in http clients init
- add extra all for installing everything
- minor improvement of readme & intro docs

### Issues

N/A

### Testing

N/A

### Checklist

- [x] CI passed
