### PR TITLE
feat: support custom profile in playwright

### DIFF
--- a/tests/unit/browsers/test_playwright_browser_plugin_with_profile.py
+++ b/tests/unit/browsers/test_playwright_browser_plugin_with_profile.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import AsyncGenerator
+
+import pytest
+
+from crawlee.browsers import PlaywrightBrowserPlugin
+
+
+@pytest.fixture()
+async def plugin(tmp_path: Path) -> AsyncGenerator[PlaywrightBrowserPlugin, None]:
+    async with PlaywrightBrowserPlugin(browser_options={'user_data_dir': tmp_path / 'profile'}) as plugin:
+        yield plugin
+
+
+async def test_new_browser(plugin: PlaywrightBrowserPlugin, httpbin: str) -> None:
+    browser_controller = await plugin.new_browser()
+
+    # assert browser_controller.is_browser_connected
+
+    page = await browser_controller.new_page()
+    await page.goto(f'{httpbin}')
+
+    await page.close()
+    await browser_controller.close()
+
+    # assert not browser_controller.is_browser_connected
+
+    # check if profile directory does contain some files
+    user_data_dir = plugin.browser_options.get('user_data_dir')
+    assert user_data_dir is not None
+    assert any(Path(user_data_dir).iterdir())


### PR DESCRIPTION
if user_data_dir option is found in browser_option, then the launch function used is launch_persistent_context instead of launch and the user_data_dir option is passed to playwright

### Description

it makes possible to use custom user provided profile directory with playwright
without changing the api

### Issues

- Closes: #399

### Testing

```python
def create_crawler(profile: Path):
    browser_options = {
        'user_data_dir': profile
    }

    plugin = PlaywrightBrowserPlugin(browser_type='chromium', browser_options=browser_options)
    browser_pool = BrowserPool(plugins=[plugin])
    crawler = PlaywrightCrawler(browser_pool=browser_pool)

    return crawler
```

### Checklist

- [ ] CI passed
