### PR TITLE
refactor: Remove dependency on aiofiles and aioshutil

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,6 @@ keywords = [
 # https://github.com/apify/apify-sdk-python/pull/154.
 [tool.poetry.dependencies]
 python = "^3.9"
-aiofiles = "^23.2.1"
-aioshutil = "^1.3"
 beautifulsoup4 = { version = "^4.12.3", optional = true }
 colorama = "^0.4.6"
 cookiecutter = "^2.6.0"
@@ -87,7 +85,6 @@ pytest-xdist = "~3.6.0"
 respx = "~0.21.0"
 ruff = "~0.5.0"
 setuptools = "~72.1.0"  # setuptools are used by pytest, but not explicitly required
-types-aiofiles = "~23.2.0.20240106"
 types-beautifulsoup4 = "~4.12.0.20240229"
 types-colorama = "~0.4.15.20240106"
 types-psutil = "~5.9.5.20240205"

--- a/src/crawlee/_utils/file.py
+++ b/src/crawlee/_utils/file.py
@@ -5,13 +5,11 @@ import contextlib
 import io
 import json
 import mimetypes
+import os
 import re
+import shutil
 from enum import Enum
 from typing import Any
-
-import aioshutil
-from aiofiles import ospath
-from aiofiles.os import remove, rename
 
 
 class ContentType(Enum):
@@ -38,7 +36,7 @@ async def force_remove(filename: str) -> None:
         filename: The path to the file to be removed.
     """
     with contextlib.suppress(FileNotFoundError):
-        await remove(filename)
+        await asyncio.to_thread(os.remove, filename)
 
 
 async def force_rename(src_dir: str, dst_dir: str) -> None:
@@ -49,11 +47,11 @@ async def force_rename(src_dir: str, dst_dir: str) -> None:
         dst_dir: The destination directory path.
     """
     # Make sure source directory exists
-    if await ospath.exists(src_dir):
+    if await asyncio.to_thread(os.path.exists, src_dir):
         # Remove destination directory if it exists
-        if await ospath.exists(dst_dir):
-            await aioshutil.rmtree(dst_dir, ignore_errors=True)
-        await rename(src_dir, dst_dir)
+        if await asyncio.to_thread(os.path.exists, dst_dir):
+            await asyncio.to_thread(shutil.rmtree, dst_dir, ignore_errors=True)
+        await asyncio.to_thread(os.rename, src_dir, dst_dir)
 
 
 def determine_file_extension(content_type: str) -> str | None:

--- a/src/crawlee/memory_storage_client/dataset_client.py
+++ b/src/crawlee/memory_storage_client/dataset_client.py
@@ -350,10 +350,10 @@ class DatasetClient(BaseDatasetClient):
         # Save all the new items to the disk
         for idx, item in data:
             file_path = os.path.join(entity_directory, f'{idx}.json')
-            f = await asyncio.to_thread(open, file_path, mode='wb')
+            f = await asyncio.to_thread(open, file_path, mode='w')
             try:
                 s = await json_dumps(item)
-                await asyncio.to_thread(lambda s=s, f=f: f.write(s.encode('utf-8')))
+                await asyncio.to_thread(f.write, s)
             finally:
                 await asyncio.to_thread(f.close)
 

--- a/src/crawlee/memory_storage_client/request_queue_client.py
+++ b/src/crawlee/memory_storage_client/request_queue_client.py
@@ -480,10 +480,10 @@ class RequestQueueClient(BaseRequestQueueClient):
 
         # Write the request to the file
         file_path = os.path.join(entity_directory, f'{request.id}.json')
-        f = await asyncio.to_thread(open, file_path, mode='wb')
+        f = await asyncio.to_thread(open, file_path, mode='w')
         try:
             s = await json_dumps(request.model_dump())
-            await asyncio.to_thread(lambda f=f, s=s: f.write(s.encode('utf-8')))
+            await asyncio.to_thread(f.write, s)
         finally:
             f.close()
 

--- a/tests/unit/_utils/test_file.py
+++ b/tests/unit/_utils/test_file.py
@@ -6,7 +6,6 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 import pytest
-from aiofiles.os import mkdir
 
 from crawlee._utils.file import (
     ContentType,
@@ -138,11 +137,11 @@ async def test_force_rename(tmp_path: Path) -> None:
 
     # Will remove dst_dir if it exists (also covers normal case)
     # Create the src_dir with a file in it
-    await mkdir(src_dir)
+    os.mkdir(src_dir)
     with open(src_file, 'a', encoding='utf-8'):  # noqa: ASYNC230
         pass
     # Create the dst_dir with a file in it
-    await mkdir(dst_dir)
+    os.mkdir(dst_dir)
     with open(dst_file, 'a', encoding='utf-8'):  # noqa: ASYNC230
         pass
     assert os.path.exists(src_file) is True

--- a/tests/unit/memory_storage_client/test_creation_management.py
+++ b/tests/unit/memory_storage_client/test_creation_management.py
@@ -4,8 +4,6 @@ import json
 import os
 from typing import TYPE_CHECKING
 
-import aiofiles
-
 from crawlee.consts import METADATA_FILENAME
 from crawlee.memory_storage_client._creation_management import persist_metadata_if_enabled
 
@@ -31,6 +29,6 @@ async def test_persist_metadata_correctly_writes_data(tmp_path: Path) -> None:
     entity_directory = os.path.join(tmp_path, 'data_dir')
     await persist_metadata_if_enabled(data=data, entity_directory=entity_directory, write_metadata=True)
     metadata_path = os.path.join(entity_directory, METADATA_FILENAME)
-    async with aiofiles.open(metadata_path, 'r') as f:
-        content = await f.read()
+    with open(metadata_path) as f:  # noqa: ASYNC230
+        content = f.read()
     assert json.loads(content) == data  # Check if correct data was written


### PR DESCRIPTION
- closes #412

This is slightly uglier, but friendlier to type checkers and makes Crawlee's footprint a little smaller.
