### PR TITLE
fix: Relative URLS supports & If not a URL, pass #417

### DIFF
--- a/src/crawlee/_utils/urls.py
+++ b/src/crawlee/_utils/urls.py
@@ -7,7 +7,8 @@ from pydantic import AnyHttpUrl, TypeAdapter
 
 def is_url_absolute(url: str) -> bool:
     """Check if a URL is absolute."""
-    return bool(urlparse(url).netloc)
+    url_parsed = urlparse(url)
+    return bool(url_parsed.scheme) and bool(url_parsed.netloc)
 
 
 def convert_to_absolute_url(base_url: str, relative_url: str) -> str:

--- a/src/crawlee/parsel_crawler/parsel_crawler.py
+++ b/src/crawlee/parsel_crawler/parsel_crawler.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Iterable
 
 from parsel import Selector
+from pydantic import ValidationError
 from typing_extensions import Unpack
 
 from crawlee._utils.blocked import RETRY_CSS_SELECTORS
@@ -133,7 +134,17 @@ class ParselCrawler(BasicCrawler[ParselCrawlingContext]):
                     if not is_url_absolute(url):
                         url = str(convert_to_absolute_url(context.request.url, url))
 
-                    requests.append(BaseRequestData.from_url(url, user_data=link_user_data))
+                    try:
+                        request = BaseRequestData.from_url(url, user_data=link_user_data)
+                    except ValidationError as exc:
+                        context.log.debug(
+                            f'Skipping URL "{url}" due to invalid format: {exc}. '
+                            'This may be caused by a malformed URL or unsupported URL scheme. '
+                            'Please ensure the URL is correct and retry.'
+                        )
+                        continue
+
+                    requests.append(request)
 
             await context.add_requests(requests, **kwargs)
 

--- a/tests/unit/_utils/test_urls.py
+++ b/tests/unit/_utils/test_urls.py
@@ -10,6 +10,7 @@ def test_is_url_absolute() -> None:
     assert is_url_absolute('http://example.com/path') is True
     assert is_url_absolute('https://example.com/path') is True
     assert is_url_absolute('ftp://example.com/path') is True
+    assert is_url_absolute('//example.com/path') is False
     assert is_url_absolute('/path/to/resource') is False
     assert is_url_absolute('relative/path/to/resource') is False
     assert is_url_absolute('example.com/path') is False
@@ -18,6 +19,11 @@ def test_is_url_absolute() -> None:
 def test_convert_to_absolute_url() -> None:
     base_url = 'http://example.com'
     relative_url = '/path/to/resource'
+    absolute_url = convert_to_absolute_url(base_url, relative_url)
+    assert absolute_url == 'http://example.com/path/to/resource'
+
+    base_url = 'http://example.com'
+    relative_url = '//example.com/path/to/resource'
     absolute_url = convert_to_absolute_url(base_url, relative_url)
     assert absolute_url == 'http://example.com/path/to/resource'
 


### PR DESCRIPTION
### Description

<!-- The purpose of the PR, list of the changes, ... -->

- If it starts with `//`, replace it with the same protocol.
- To avoid unsupported protocols, such as `mailto` and `tel`, we only allow writing `http` and `https`.

### Issues

<!-- If applicable, reference any related GitHub issues -->

- Closes: #417 

### Testing

<!-- Describe the testing process for these changes -->

- Add a unit test for cases that start with `//`.

### Checklist

- [x] CI passed
