### PR TITLE
ci: Skip running code checks on release

### DIFF
--- a/.github/workflows/run_release.yaml
+++ b/.github/workflows/run_release.yaml
@@ -26,10 +26,6 @@ on:
         default: ''
 
 jobs:
-  run_code_checks:
-    name: Run code checks
-    uses: ./.github/workflows/run_code_checks.yaml
-
   # This job determines if the conditions are met for a release to occur. It will proceed if triggered manually,
   # for any published release, or if the commit on push does not begin with "docs" or "chore".
   should_release:
@@ -71,7 +67,7 @@ jobs:
 
   update_changelog:
     name: Update changelog
-    needs: [run_code_checks, should_release]
+    needs: [should_release]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Everything that is merged to master passed through code checks before, and they're needlessly long.
