### PR TITLE
chore: remove upper version boundary of deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,39 +45,39 @@ keywords = [
 # https://github.com/apify/apify-sdk-python/pull/154.
 [tool.poetry.dependencies]
 python = "^3.9"
-beautifulsoup4 = { version = "^4.12.3", optional = true }
-colorama = "^0.4.6"
-cookiecutter = "^2.6.0"
-curl-cffi = { version = "^0.7.1", optional = true }
-docutils = "^0.21.0"
-eval-type-backport = "^0.2.0"
-html5lib = { version = "^1.1", optional = true }
-httpx = { version = "^0.27.0", extras = ["brotli"] }
-inquirer = "^3.3.0"
-lxml = { version = "^5.2.1", optional = true }
-more_itertools = "^10.2.0"
-playwright = { version = "^1.43.0", optional = true }
-psutil = "^6.0.0"
-pydantic = "^2.6.3"
-pydantic-settings = "^2.2.1"
-pyee = "^11.1.0"
-python-dateutil = "^2.9.0"
-sortedcollections = "^2.1.0"
-tldextract = "^5.1.2"
-typer = { version = "^0.12.3", extras = ["all"] }
-typing-extensions = "^4.1.0"
-parsel = { version = "^1.9.1", optional = true }
+beautifulsoup4 = { version = ">=4.12.0", optional = true }
+colorama = ">=0.4.0"
+cookiecutter = ">=2.6.0"
+curl-cffi = { version = ">=0.7.0", optional = true }
+docutils = ">=0.21.0"
+eval-type-backport = ">=0.2.0"
+html5lib = { version = ">=1.0", optional = true }
+httpx = { version = ">=0.27.0", extras = ["brotli"] }
+inquirer = ">=3.3.0"
+lxml = { version = ">=5.2.0", optional = true }
+more_itertools = ">=10.2.0"
+parsel = { version = ">=1.9.0", optional = true }
+playwright = { version = ">=1.43.0", optional = true }
+psutil = ">=6.0.0"
+pydantic = ">=2.6.0"
+pydantic-settings = ">=2.2.0"
+pyee = ">=11.1.0"
+python-dateutil = ">=2.9.0"
+sortedcollections = ">=2.1.0"
+tldextract = ">=5.1.0"
+typer = { version = ">=0.12.0", extras = ["all"] }
+typing-extensions = ">=4.1.0"
 
 [tool.poetry.group.dev.dependencies]
 build = "~1.2.0"
 filelock = "~3.15.0"
-ipdb = "~0.13.13"
+ipdb = "~0.13.0"
 mypy = "~1.11.0"
 pre-commit = "~3.8.0"
-proxy-py = "~2.4.4"
-pydoc-markdown = "~4.8.2"
+proxy-py = "~2.4.0"
+pydoc-markdown = "~4.8.0"
 pytest = "~8.3.0"
-pytest-asyncio = "~0.23.5"
+pytest-asyncio = "~0.23.0"
 pytest-cov = "~5.0.0"
 pytest-only = "~2.1.0"
 pytest-timeout = "~2.3.0"


### PR DESCRIPTION
### Description

- Remove the upper version boundary of dependencies
- Alphabetize them
- Remove patch-level requirements
- Relates to https://github.com/apify/apify-sdk-python/pull/254

### Issues

- N/A

### Testing

- N/A

### Checklist

- [ ] CI passed
