### PR TITLE
feat: curl http client selects chrome impersonation by default

### DIFF
--- a/src/crawlee/http_clients/curl_impersonate.py
+++ b/src/crawlee/http_clients/curl_impersonate.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import random
 from typing import TYPE_CHECKING, Any, Optional
 
 try:
@@ -166,11 +165,11 @@ class CurlImpersonateHttpClient(BaseHttpClient):
         """
         # Check if a session for the given proxy URL has already been created.
         if proxy_url not in self._client_by_proxy_url:
-            # Prepare a default kwargs for the new session. A provided proxy URL and a randomly selected browser
-            # type for impersonation are set as default options.
+            # Prepare a default kwargs for the new session. A provided proxy URL and a chrome for impersonation
+            # are set as default options.
             kwargs: dict[str, Any] = {
                 'proxy': proxy_url,
-                'impersonate': random.choice(list(BrowserType)),
+                'impersonate': BrowserType.chrome,
             }
 
             # Update the default kwargs with any additional user-provided kwargs.

--- a/src/crawlee/http_clients/curl_impersonate.py
+++ b/src/crawlee/http_clients/curl_impersonate.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import random
 from typing import TYPE_CHECKING, Any, Optional
 
 try:
     from curl_cffi.requests import AsyncSession
     from curl_cffi.requests.errors import RequestsError
+    from curl_cffi.requests.impersonate import BrowserType
 except ImportError as exc:
     raise ImportError(
         "To import anything from this subpackage, you need to install the 'curl-impersonate' extra."
@@ -158,13 +160,24 @@ class CurlImpersonateHttpClient(BaseHttpClient):
     def _get_client(self, proxy_url: str | None) -> AsyncSession:
         """Helper to get a HTTP client for the given proxy URL.
 
-        If the client for the given proxy URL doesn't exist, it will be created and stored.
+        The method checks if an `AsyncSession` already exists for the provided proxy URL. If no session exists,
+        it creates a new one, configured with the specified proxy and additional session options. The new session
+        is then stored for future use.
         """
+        # Check if a session for the given proxy URL has already been created.
         if proxy_url not in self._client_by_proxy_url:
-            self._client_by_proxy_url[proxy_url] = AsyncSession(
-                proxy=proxy_url,
-                **self._async_session_kwargs,
-            )
+            # Prepare a default kwargs for the new session. A provided proxy URL and a randomly selected browser
+            # type for impersonation are set as default options.
+            kwargs: dict[str, Any] = {
+                'proxy': proxy_url,
+                'impersonate': random.choice(list(BrowserType)),
+            }
+
+            # Update the default kwargs with any additional user-provided kwargs.
+            kwargs.update(self._async_session_kwargs)
+
+            # Create and store the new session with the specified kwargs.
+            self._client_by_proxy_url[proxy_url] = AsyncSession(**kwargs)
 
         return self._client_by_proxy_url[proxy_url]
 


### PR DESCRIPTION
### Description

- `CurlImpersonateHttpClient` selects chrome browser type for impersonation by default.
- Before:
```json
{
    "url": "https://httpbin.org/get",
    "response": {
        "args": {},
        "headers": {
            "Accept": "*/*",
            "Accept-Encoding": "gzip, deflate, br",
            "Content-Type": "application/x-www-form-urlencoded",
            "Host": "httpbin.org",
            "X-Amzn-Trace-Id": "Root=1-66d04355-5df0396b08e2931c125389aa"
        },
        "origin": "78.80.81.196",
        "url": "https://httpbin.org/get"
    }
}
```
- After:
```json
{
    "url": "https://httpbin.org/get",
    "response": {
        "args": {},
        "headers": {
            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
            "Accept-Encoding": "gzip, deflate, br, zstd",
            "Accept-Language": "en-US,en;q=0.9",
            "Content-Type": "application/x-www-form-urlencoded",
            "Host": "httpbin.org",
            "Priority": "u=0, i",
            "Sec-Ch-Ua": "\"Chromium\";v=\"124\", \"Google Chrome\";v=\"124\", \"Not-A.Brand\";v=\"99\"",
            "Sec-Ch-Ua-Mobile": "?0",
            "Sec-Ch-Ua-Platform": "\"macOS\"",
            "Sec-Fetch-Dest": "document",
            "Sec-Fetch-Mode": "navigate",
            "Sec-Fetch-Site": "none",
            "Sec-Fetch-User": "?1",
            "Upgrade-Insecure-Requests": "1",
            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
            "X-Amzn-Trace-Id": "Root=1-66d04c27-057e04e635efbbde18e0d85b"
        },
        "origin": "78.80.81.196",
        "url": "https://httpbin.org/get"
    }
}
```

### Issues

- N/A

### Testing

- N/A

### Checklist

- [x] CI passed
