### PR TITLE
chore(deps): Relax Playwright version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ inquirer = ">=3.3.0"
 lxml = { version = ">=5.2.0", optional = true }
 more_itertools = ">=10.2.0"
 parsel = { version = ">=1.9.0", optional = true }
-playwright = { version = ">=1.43.0", optional = true }
+playwright = { version = ">=1.27.0", optional = true }
 psutil = ">=6.0.0"
 pydantic = ">=2.6.0"
 pydantic-settings = ">=2.2.0"


### PR DESCRIPTION
1.27 is the lowest version I'm comfortable supporting - it adds helper functions to locators that we may want to use in the future. It's ~2 years old, so it should be OK.
