### PR TITLE
chore(deps): Relax pyee dependency version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ playwright = { version = ">=1.27.0", optional = true }
 psutil = ">=6.0.0"
 pydantic = ">=2.6.0"
 pydantic-settings = ">=2.2.0"
-pyee = ">=11.1.0"
+pyee = ">=11.0.0"
 python-dateutil = ">=2.9.0"
 sortedcollections = ">=2.1.0"
 tldextract = ">=5.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ playwright = { version = ">=1.27.0", optional = true }
 psutil = ">=6.0.0"
 pydantic = ">=2.6.0"
 pydantic-settings = ">=2.2.0"
-pyee = ">=11.0.0"
+pyee = ">=9.0.0"
 python-dateutil = ">=2.9.0"
 sortedcollections = ">=2.1.0"
 tldextract = ">=5.1.0"


### PR DESCRIPTION
This prevents dependency conflicts with playwright (requires 11.0.0)
