### PR TITLE
fix: http clients detect 4xx as errors by default

### DIFF
--- a/src/crawlee/_utils/http.py
+++ b/src/crawlee/_utils/http.py
@@ -1,0 +1,13 @@
+def is_status_code_error(value: int) -> bool:
+    """Returns `True` for 4xx or 5xx status codes, `False` otherwise."""
+    return is_status_code_client_error(value) or is_status_code_server_error(value)
+
+
+def is_status_code_client_error(value: int) -> bool:
+    """Returns `True` for 4xx status codes, `False` otherwise."""
+    return 400 <= value <= 499  # noqa: PLR2004
+
+
+def is_status_code_server_error(value: int) -> bool:
+    """Returns `True` for 5xx status codes, `False` otherwise."""
+    return value >= 500  # noqa: PLR2004

--- a/src/crawlee/basic_crawler/_basic_crawler.py
+++ b/src/crawlee/basic_crawler/_basic_crawler.py
@@ -26,12 +26,14 @@ from crawlee._log_config import CrawleeLogFormatter
 from crawlee._request import BaseRequestData, Request, RequestState
 from crawlee._types import BasicCrawlingContext, HttpHeaders, RequestHandlerRunResult, SendRequestFunction
 from crawlee._utils.byte_size import ByteSize
+from crawlee._utils.http import is_status_code_client_error
 from crawlee._utils.urls import convert_to_absolute_url, is_url_absolute
 from crawlee._utils.wait import wait_for
 from crawlee.basic_crawler._context_pipeline import ContextPipeline
 from crawlee.errors import (
     ContextPipelineInitializationError,
     ContextPipelineInterruptedError,
+    HttpStatusCodeError,
     RequestHandlerError,
     SessionError,
     UserDefinedErrorHandlerError,
@@ -527,6 +529,10 @@ class BasicCrawler(Generic[TCrawlingContext]):
         if crawling_context.request.no_retry:
             return False
 
+        # Do not retry on client errors.
+        if isinstance(error, HttpStatusCodeError) and is_status_code_client_error(error.status_code):
+            return False
+
         if isinstance(error, SessionError):
             return ((crawling_context.request.session_rotation_count or 0) + 1) < self._max_session_rotations
 
@@ -612,7 +618,9 @@ class BasicCrawler(Generic[TCrawlingContext]):
         return False
 
     async def _handle_request_retries(
-        self, crawling_context: TCrawlingContext | BasicCrawlingContext, error: Exception
+        self,
+        crawling_context: TCrawlingContext | BasicCrawlingContext,
+        error: Exception,
     ) -> None:
         request_provider = await self.get_request_provider()
         request = crawling_context.request
@@ -644,7 +652,9 @@ class BasicCrawler(Generic[TCrawlingContext]):
             self._statistics.record_request_processing_failure(request.id or request.unique_key)
 
     async def _handle_request_error(
-        self, crawling_context: TCrawlingContext | BasicCrawlingContext, error: Exception
+        self,
+        crawling_context: TCrawlingContext | BasicCrawlingContext,
+        error: Exception,
     ) -> None:
         try:
             crawling_context.request.state = RequestState.ERROR_HANDLER
@@ -829,6 +839,7 @@ class BasicCrawler(Generic[TCrawlingContext]):
                 crawling_context.session.mark_good()
 
             self._statistics.record_request_processing_finish(statistics_id)
+
         except RequestHandlerError as primary_error:
             primary_error = cast(
                 RequestHandlerError[TCrawlingContext], primary_error
@@ -838,7 +849,10 @@ class BasicCrawler(Generic[TCrawlingContext]):
                 'An exception occurred in the user-defined request handler',
                 exc_info=primary_error.wrapped_exception,
             )
-            await self._handle_request_error(primary_error.crawling_context, primary_error.wrapped_exception)
+            crawling_context = primary_error.crawling_context
+            error = primary_error.wrapped_exception
+            await self._handle_request_error(crawling_context, error)
+
         except SessionError as session_error:
             if not crawling_context.session:
                 raise RuntimeError('SessionError raised in a crawling context without a session') from session_error
@@ -868,6 +882,7 @@ class BasicCrawler(Generic[TCrawlingContext]):
 
                 self._statistics.record_request_processing_failure(statistics_id)
                 self._statistics.error_tracker.add(session_error)
+
         except ContextPipelineInterruptedError as interrupted_error:
             self._logger.debug('The context pipeline was interrupted', exc_info=interrupted_error)
 
@@ -879,12 +894,14 @@ class BasicCrawler(Generic[TCrawlingContext]):
                 logger=self._logger,
                 max_retries=3,
             )
+
         except ContextPipelineInitializationError as initialization_error:
             self._logger.debug(
                 'An exception occurred during the initialization of crawling context',
                 exc_info=initialization_error,
             )
-            await self._handle_request_error(crawling_context, initialization_error)
+            await self._handle_request_error(crawling_context, initialization_error.wrapped_exception)
+
         except Exception as internal_error:
             self._logger.exception(
                 'An exception occurred during handling of a request. This places the crawler '

--- a/src/crawlee/basic_crawler/_basic_crawler.py
+++ b/src/crawlee/basic_crawler/_basic_crawler.py
@@ -849,9 +849,7 @@ class BasicCrawler(Generic[TCrawlingContext]):
                 'An exception occurred in the user-defined request handler',
                 exc_info=primary_error.wrapped_exception,
             )
-            crawling_context = primary_error.crawling_context
-            error = primary_error.wrapped_exception
-            await self._handle_request_error(crawling_context, error)
+            await self._handle_request_error(primary_error.crawling_context, primary_error.wrapped_exception)
 
         except SessionError as session_error:
             if not crawling_context.session:

--- a/src/crawlee/errors.py
+++ b/src/crawlee/errors.py
@@ -40,18 +40,18 @@ class HttpStatusCodeError(Exception):
     """Raised when the response status code indicates an error."""
 
     def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(f'{message} (status code: {status_code}).')
         self.status_code = status_code
         self.message = message
-        super().__init__(f'{message} (status code: {status_code}).')
 
 
 class RequestHandlerError(Exception, Generic[TCrawlingContext]):
     """Wraps an exception thrown from a request handler (router) and extends it with crawling context."""
 
     def __init__(self, wrapped_exception: Exception, crawling_context: TCrawlingContext) -> None:
+        super().__init__()
         self.wrapped_exception = wrapped_exception
         self.crawling_context = crawling_context
-        super().__init__()
 
 
 class ContextPipelineInitializationError(Exception):
@@ -61,9 +61,9 @@ class ContextPipelineInitializationError(Exception):
     """
 
     def __init__(self, wrapped_exception: Exception, crawling_context: BasicCrawlingContext) -> None:
+        super().__init__()
         self.wrapped_exception = wrapped_exception
         self.crawling_context = crawling_context
-        super().__init__()
 
 
 class ContextPipelineFinalizationError(Exception):
@@ -73,9 +73,9 @@ class ContextPipelineFinalizationError(Exception):
     """
 
     def __init__(self, wrapped_exception: Exception, crawling_context: BasicCrawlingContext) -> None:
+        super().__init__()
         self.wrapped_exception = wrapped_exception
         self.crawling_context = crawling_context
-        super().__init__()
 
 
 class ContextPipelineInterruptedError(Exception):

--- a/src/crawlee/errors.py
+++ b/src/crawlee/errors.py
@@ -39,6 +39,11 @@ class ProxyError(SessionError):
 class HttpStatusCodeError(Exception):
     """Raised when the response status code indicates an error."""
 
+    def __init__(self, message: str, status_code: int) -> None:
+        self.status_code = status_code
+        self.message = message
+        super().__init__(f'{message} (status code: {status_code}).')
+
 
 class RequestHandlerError(Exception, Generic[TCrawlingContext]):
     """Wraps an exception thrown from a request handler (router) and extends it with crawling context."""

--- a/src/crawlee/errors.py
+++ b/src/crawlee/errors.py
@@ -51,6 +51,7 @@ class RequestHandlerError(Exception, Generic[TCrawlingContext]):
     def __init__(self, wrapped_exception: Exception, crawling_context: TCrawlingContext) -> None:
         self.wrapped_exception = wrapped_exception
         self.crawling_context = crawling_context
+        super().__init__()
 
 
 class ContextPipelineInitializationError(Exception):
@@ -62,6 +63,7 @@ class ContextPipelineInitializationError(Exception):
     def __init__(self, wrapped_exception: Exception, crawling_context: BasicCrawlingContext) -> None:
         self.wrapped_exception = wrapped_exception
         self.crawling_context = crawling_context
+        super().__init__()
 
 
 class ContextPipelineFinalizationError(Exception):
@@ -73,6 +75,7 @@ class ContextPipelineFinalizationError(Exception):
     def __init__(self, wrapped_exception: Exception, crawling_context: BasicCrawlingContext) -> None:
         self.wrapped_exception = wrapped_exception
         self.crawling_context = crawling_context
+        super().__init__()
 
 
 class ContextPipelineInterruptedError(Exception):

--- a/src/crawlee/http_clients/_base.py
+++ b/src/crawlee/http_clients/_base.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
+from crawlee._utils.http import is_status_code_error
 from crawlee.errors import HttpStatusCodeError
 
 if TYPE_CHECKING:
@@ -109,22 +110,8 @@ class BaseHttpClient(ABC):
         exclude_error = status_code in ignore_http_error_status_codes
         include_error = status_code in additional_http_error_status_codes
 
-        if include_error or (self._is_status_code_error(status_code) and not exclude_error):
+        if include_error or (is_status_code_error(status_code) and not exclude_error):
             if include_error:
-                raise HttpStatusCodeError(f'Status code {status_code} (user-configured to be an error) returned.')
+                raise HttpStatusCodeError('Error status code (user-configured) returned.', status_code)
 
-            raise HttpStatusCodeError(f'Status code {status_code} returned.')
-
-    def _is_status_code_error(self, value: int) -> bool:
-        """Returns `True` for 4xx or 5xx status codes, `False` otherwise."""
-        return self._is_status_code_client_error(value) or self._is_status_code_server_error(value)
-
-    @staticmethod
-    def _is_status_code_client_error(value: int) -> bool:
-        """Returns `True` for 4xx status codes, `False` otherwise."""
-        return 400 <= value <= 499  # noqa: PLR2004
-
-    @staticmethod
-    def _is_status_code_server_error(value: int) -> bool:
-        """Returns `True` for 5xx status codes, `False` otherwise."""
-        return value >= 500  # noqa: PLR2004
+            raise HttpStatusCodeError('Error status code returned', status_code)

--- a/src/crawlee/http_clients/_httpx.py
+++ b/src/crawlee/http_clients/_httpx.py
@@ -67,10 +67,7 @@ class HttpxHttpClient(BaseHttpClient):
     This client uses the `HTTPX` library to perform HTTP requests in crawlers (`BasicCrawler` subclasses)
     and to manage sessions, proxies, and error handling.
 
-    The client raises an `HttpStatusCodeError` when it encounters an error response, defined by default as any
-    HTTP status code in the range of 400 to 599. The error handling behavior is customizable, allowing the user
-    to specify additional status codes to treat as errors or to exclude specific status codes from being considered
-    errors.
+    See the `BaseHttpClient` class for more common information about HTTP clients.
     """
 
     def __init__(
@@ -89,9 +86,11 @@ class HttpxHttpClient(BaseHttpClient):
             ignore_http_error_status_codes: HTTP status codes to ignore as errors.
             async_client_kwargs: Additional keyword arguments for `httpx.AsyncClient`.
         """
-        self._persist_cookies_per_session = persist_cookies_per_session
-        self._additional_http_error_status_codes = set(additional_http_error_status_codes)
-        self._ignore_http_error_status_codes = set(ignore_http_error_status_codes)
+        super().__init__(
+            persist_cookies_per_session=persist_cookies_per_session,
+            additional_http_error_status_codes=additional_http_error_status_codes,
+            ignore_http_error_status_codes=ignore_http_error_status_codes,
+        )
         self._async_client_kwargs = async_client_kwargs
 
         self._client_by_proxy_url = dict[Optional[str], httpx.AsyncClient]()

--- a/src/crawlee/http_clients/curl_impersonate.py
+++ b/src/crawlee/http_clients/curl_impersonate.py
@@ -54,10 +54,7 @@ class CurlImpersonateHttpClient(BaseHttpClient):
     This client uses the `curl-cffi` library to perform HTTP requests in crawlers (`BasicCrawler` subclasses)
     and to manage sessions, proxies, and error handling.
 
-    The client raises an `HttpStatusCodeError` when it encounters an error response, defined by default as any
-    HTTP status code in the range of 400 to 599. The error handling behavior is customizable, allowing the user
-    to specify additional status codes to treat as errors or to exclude specific status codes from being considered
-    errors.
+    See the `BaseHttpClient` class for more common information about HTTP clients.
     """
 
     def __init__(
@@ -76,9 +73,11 @@ class CurlImpersonateHttpClient(BaseHttpClient):
             ignore_http_error_status_codes: HTTP status codes to ignore as errors.
             async_session_kwargs: Additional keyword arguments for `curl_cffi.requests.AsyncSession`.
         """
-        self._persist_cookies_per_session = persist_cookies_per_session
-        self._additional_http_error_status_codes = set(additional_http_error_status_codes)
-        self._ignore_http_error_status_codes = set(ignore_http_error_status_codes)
+        super().__init__(
+            persist_cookies_per_session=persist_cookies_per_session,
+            additional_http_error_status_codes=additional_http_error_status_codes,
+            ignore_http_error_status_codes=ignore_http_error_status_codes,
+        )
         self._async_session_kwargs = async_session_kwargs
 
         self._client_by_proxy_url = dict[Optional[str], AsyncSession]()

--- a/src/crawlee/http_clients/curl_impersonate.py
+++ b/src/crawlee/http_clients/curl_impersonate.py
@@ -15,7 +15,7 @@ except ImportError as exc:
 from typing_extensions import override
 
 from crawlee._utils.blocked import ROTATE_PROXY_ERRORS
-from crawlee.errors import HttpStatusCodeError, ProxyError
+from crawlee.errors import ProxyError
 from crawlee.http_clients import BaseHttpClient, HttpCrawlingResult, HttpResponse
 
 if TYPE_CHECKING:
@@ -53,6 +53,11 @@ class CurlImpersonateHttpClient(BaseHttpClient):
 
     This client uses the `curl-cffi` library to perform HTTP requests in crawlers (`BasicCrawler` subclasses)
     and to manage sessions, proxies, and error handling.
+
+    The client raises an `HttpStatusCodeError` when it encounters an error response, defined by default as any
+    HTTP status code in the range of 400 to 599. The error handling behavior is customizable, allowing the user
+    to specify additional status codes to treat as errors or to exclude specific status codes from being considered
+    errors.
     """
 
     def __init__(
@@ -107,16 +112,11 @@ class CurlImpersonateHttpClient(BaseHttpClient):
         if statistics:
             statistics.register_status_code(response.status_code)
 
-        exclude_error = response.status_code in self._ignore_http_error_status_codes
-        include_error = response.status_code in self._additional_http_error_status_codes
-
-        if include_error or (self._is_server_code(response.status_code) and not exclude_error):
-            if include_error:
-                raise HttpStatusCodeError(
-                    f'Status code {response.status_code} (user-configured to be an error) returned',
-                )
-
-            raise HttpStatusCodeError(f'Status code {response.status_code} returned')
+        self._raise_for_error_status_code(
+            response.status_code,
+            self._additional_http_error_status_codes,
+            self._ignore_http_error_status_codes,
+        )
 
         request.loaded_url = response.url
 
@@ -153,6 +153,12 @@ class CurlImpersonateHttpClient(BaseHttpClient):
             if self._is_proxy_error(exc):
                 raise ProxyError from exc
             raise
+
+        self._raise_for_error_status_code(
+            response.status_code,
+            self._additional_http_error_status_codes,
+            self._ignore_http_error_status_codes,
+        )
 
         return _CurlImpersonateResponse(response)
 

--- a/tests/unit/http_crawler/test_http_crawler.py
+++ b/tests/unit/http_crawler/test_http_crawler.py
@@ -173,7 +173,7 @@ async def test_stores_cookies(httpbin: str) -> None:
     assert session.cookies == {'a': '1', 'b': '2', 'c': '3'}
 
 
-async def test_do_not_retry_on_client_erros(crawler: HttpCrawler, server: respx.MockRouter) -> None:
+async def test_do_not_retry_on_client_errors(crawler: HttpCrawler, server: respx.MockRouter) -> None:
     await crawler.add_requests(['https://test.io/bad_request'])
     stats = await crawler.run()
 

--- a/tests/unit/parsel_crawler/test_parsel_crawler.py
+++ b/tests/unit/parsel_crawler/test_parsel_crawler.py
@@ -199,7 +199,12 @@ async def test_enqueue_links_with_max_crawl(server: respx.MockRouter) -> None:
 
 
 async def test_handle_blocked_request(server: respx.MockRouter) -> None:
-    crawler = ParselCrawler(request_provider=RequestList(['https://test.io/fdyr']), max_session_rotations=1)
+    crawler = ParselCrawler(
+        request_provider=RequestList(['https://test.io/fdyr']),
+        max_session_rotations=1,
+        retry_on_blocked=False,
+        max_request_retries=0,
+    )
     stats = await crawler.run()
     assert server['incapsula_endpoint'].called
     assert stats.requests_failed == 1
@@ -210,6 +215,7 @@ async def test_handle_blocked_status_code(server: respx.MockRouter) -> None:
         request_provider=RequestList(['https://test.io/blocked']),
         max_session_rotations=1,
         retry_on_blocked=False,
+        max_request_retries=0,
     )
 
     # Patch internal calls and run crawler

--- a/tests/unit/parsel_crawler/test_parsel_crawler.py
+++ b/tests/unit/parsel_crawler/test_parsel_crawler.py
@@ -206,7 +206,11 @@ async def test_handle_blocked_request(server: respx.MockRouter) -> None:
 
 
 async def test_handle_blocked_status_code(server: respx.MockRouter) -> None:
-    crawler = ParselCrawler(request_provider=RequestList(['https://test.io/blocked']), max_session_rotations=1)
+    crawler = ParselCrawler(
+        request_provider=RequestList(['https://test.io/blocked']),
+        max_session_rotations=1,
+        retry_on_blocked=False,
+    )
 
     # Patch internal calls and run crawler
     with mock.patch.object(

--- a/tests/unit/parsel_crawler/test_parsel_crawler.py
+++ b/tests/unit/parsel_crawler/test_parsel_crawler.py
@@ -202,9 +202,8 @@ async def test_handle_blocked_request(server: respx.MockRouter) -> None:
     crawler = ParselCrawler(
         request_provider=RequestList(['https://test.io/fdyr']),
         max_session_rotations=1,
-        retry_on_blocked=False,
-        max_request_retries=0,
     )
+
     stats = await crawler.run()
     assert server['incapsula_endpoint'].called
     assert stats.requests_failed == 1
@@ -214,8 +213,6 @@ async def test_handle_blocked_status_code(server: respx.MockRouter) -> None:
     crawler = ParselCrawler(
         request_provider=RequestList(['https://test.io/blocked']),
         max_session_rotations=1,
-        retry_on_blocked=False,
-        max_request_retries=0,
     )
 
     # Patch internal calls and run crawler


### PR DESCRIPTION
### Description

- Error codes between 400 and 599 are considered as errors by default.
- Before this change only codes between 500 and 599 were handled by default.

### Issues

- Closes: #496

### Testing

- I added a new test to test that 4xx status codes are not being retried.

### Checklist

- [x] CI passed
