### PR TITLE
refactor: simplify type of request(s) args

### DIFF
--- a/src/crawlee/storages/_request_list.py
+++ b/src/crawlee/storages/_request_list.py
@@ -11,7 +11,7 @@ from crawlee.storages._request_provider import RequestProvider
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from crawlee._request import BaseRequestData, Request
+    from crawlee._request import Request
 
 
 class RequestList(RequestProvider):
@@ -19,7 +19,7 @@ class RequestList(RequestProvider):
 
     def __init__(
         self,
-        requests: Sequence[str | BaseRequestData | Request] | None = None,
+        requests: Sequence[str | Request] | None = None,
         name: str | None = None,
     ) -> None:
         """Initialize the RequestList.
@@ -86,7 +86,7 @@ class RequestList(RequestProvider):
     @override
     async def add_requests_batched(
         self,
-        requests: Sequence[str | BaseRequestData | Request],
+        requests: Sequence[str | Request],
         *,
         batch_size: int = 1000,
         wait_time_between_batches: timedelta = timedelta(seconds=1),

--- a/src/crawlee/storages/_request_provider.py
+++ b/src/crawlee/storages/_request_provider.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
-from crawlee._request import BaseRequestData, Request
+from crawlee._request import Request
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -58,7 +58,7 @@ class RequestProvider(ABC):
     @abstractmethod
     async def add_requests_batched(
         self,
-        requests: Sequence[str | BaseRequestData | Request],
+        requests: Sequence[str | Request],
         *,
         batch_size: int = 1000,
         wait_time_between_batches: timedelta = timedelta(seconds=1),
@@ -75,7 +75,7 @@ class RequestProvider(ABC):
             wait_for_all_requests_to_be_added_timeout: Timeout for waiting for all requests to be added.
         """
 
-    def _transform_request(self, request: str | BaseRequestData | Request) -> Request:
+    def _transform_request(self, request: str | Request) -> Request:
         """Transforms a request-like object into a Request object."""
         if isinstance(request, Request):
             return request
@@ -83,12 +83,9 @@ class RequestProvider(ABC):
         if isinstance(request, str):
             return Request.from_url(request)
 
-        if isinstance(request, BaseRequestData):
-            return Request.from_base_request_data(request)
-
         raise ValueError(f'Invalid request type: {type(request)}')
 
-    def _transform_requests(self, requests: Sequence[str | BaseRequestData | Request]) -> list[Request]:
+    def _transform_requests(self, requests: Sequence[str | Request]) -> list[Request]:
         """Transforms a list of request-like objects into a list of Request objects."""
         processed_requests = dict[str, Request]()
 

--- a/src/crawlee/storages/_request_queue.py
+++ b/src/crawlee/storages/_request_queue.py
@@ -21,7 +21,7 @@ from crawlee.storages._request_provider import RequestProvider
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-    from crawlee._request import BaseRequestData, Request
+    from crawlee._request import Request
     from crawlee.base_storage_client import BaseStorageClient
     from crawlee.configuration import Configuration
     from crawlee.events import EventManager
@@ -179,7 +179,7 @@ class RequestQueue(BaseStorage, RequestProvider):
 
     async def add_request(
         self,
-        request: Request | BaseRequestData | str,
+        request: str | Request,
         *,
         forefront: bool = False,
     ) -> ProcessedRequest:
@@ -245,7 +245,7 @@ class RequestQueue(BaseStorage, RequestProvider):
     @override
     async def add_requests_batched(
         self,
-        requests: Sequence[str | BaseRequestData | Request],
+        requests: Sequence[str | Request],
         *,
         batch_size: int = 1000,
         wait_time_between_batches: timedelta = timedelta(seconds=1),

--- a/tests/unit/storages/test_request_queue.py
+++ b/tests/unit/storages/test_request_queue.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from crawlee._request import BaseRequestData, Request
+from crawlee import Request
 from crawlee.storages import RequestQueue
 
 if TYPE_CHECKING:
@@ -133,17 +133,16 @@ async def test_reclaim_request(request_queue: RequestQueue) -> None:
 @pytest.mark.parametrize(
     'requests',
     [
-        [BaseRequestData.from_url('https://example.com')],
         [Request.from_url('https://apify.com')],
         ['https://crawlee.dev'],
         [Request.from_url(f'https://example.com/{i}') for i in range(10)],
         [f'https://example.com/{i}' for i in range(15)],
     ],
-    ids=['single-base-request', 'single-request', 'single-url', 'multiple-requests', 'multiple-urls'],
+    ids=['single-request', 'single-url', 'multiple-requests', 'multiple-urls'],
 )
 async def test_add_batched_requests(
     request_queue: RequestQueue,
-    requests: Sequence[str | BaseRequestData | Request],
+    requests: Sequence[str | Request],
 ) -> None:
     request_count = len(requests)
 


### PR DESCRIPTION
### Description

- Simplify type of request(s) args to only string or Request.
- Should be only internal change, not breaking, as `BaseRequestData` was not exposed to the public in v0.3.

### Issues

- Closes: N/A

### Testing

- N/A

### Checklist

- [x] CI passed
