### PR TITLE
fix!: merge payload and data fields of Request

### DIFF
--- a/docs/examples/code/fill_and_submit_web_form_crawler.py
+++ b/docs/examples/code/fill_and_submit_web_form_crawler.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 
 from crawlee import Request
 from crawlee.http_crawler import HttpCrawler, HttpCrawlingContext
@@ -18,7 +19,7 @@ async def main() -> None:
     request = Request.from_url(
         url='https://httpbin.org/post',
         method='POST',
-        payload=str(
+        payload=json.dumps(
             {
                 'custname': 'John Doe',
                 'custtel': '1234567890',

--- a/docs/examples/code/fill_and_submit_web_form_crawler.py
+++ b/docs/examples/code/fill_and_submit_web_form_crawler.py
@@ -18,7 +18,7 @@ async def main() -> None:
     request = Request.from_url(
         url='https://httpbin.org/post',
         method='POST',
-        data={
+        payload={
             'custname': 'John Doe',
             'custtel': '1234567890',
             'custemail': 'johndoe@example.com',

--- a/docs/examples/code/fill_and_submit_web_form_crawler.py
+++ b/docs/examples/code/fill_and_submit_web_form_crawler.py
@@ -18,15 +18,17 @@ async def main() -> None:
     request = Request.from_url(
         url='https://httpbin.org/post',
         method='POST',
-        payload={
-            'custname': 'John Doe',
-            'custtel': '1234567890',
-            'custemail': 'johndoe@example.com',
-            'size': 'large',
-            'topping': ['bacon', 'cheese', 'mushroom'],
-            'delivery': '13:00',
-            'comments': 'Please ring the doorbell upon arrival.',
-        },
+        payload=str(
+            {
+                'custname': 'John Doe',
+                'custtel': '1234567890',
+                'custemail': 'johndoe@example.com',
+                'size': 'large',
+                'topping': ['bacon', 'cheese', 'mushroom'],
+                'delivery': '13:00',
+                'comments': 'Please ring the doorbell upon arrival.',
+            }
+        ).encode(),
     )
 
     # Run the crawler with the initial list of requests.

--- a/docs/examples/code/fill_and_submit_web_form_request.py
+++ b/docs/examples/code/fill_and_submit_web_form_request.py
@@ -4,13 +4,15 @@ from crawlee import Request
 request = Request.from_url(
     url='https://httpbin.org/post',
     method='POST',
-    payload={
-        'custname': 'John Doe',
-        'custtel': '1234567890',
-        'custemail': 'johndoe@example.com',
-        'size': 'large',
-        'topping': ['bacon', 'cheese', 'mushroom'],
-        'delivery': '13:00',
-        'comments': 'Please ring the doorbell upon arrival.',
-    },
+    payload=str(
+        {
+            'custname': 'John Doe',
+            'custtel': '1234567890',
+            'custemail': 'johndoe@example.com',
+            'size': 'large',
+            'topping': ['bacon', 'cheese', 'mushroom'],
+            'delivery': '13:00',
+            'comments': 'Please ring the doorbell upon arrival.',
+        }
+    ).encode(),
 )

--- a/docs/examples/code/fill_and_submit_web_form_request.py
+++ b/docs/examples/code/fill_and_submit_web_form_request.py
@@ -1,10 +1,12 @@
+import json
+
 from crawlee import Request
 
 # Prepare a POST request to the form endpoint.
 request = Request.from_url(
     url='https://httpbin.org/post',
     method='POST',
-    payload=str(
+    payload=json.dumps(
         {
             'custname': 'John Doe',
             'custtel': '1234567890',

--- a/docs/examples/code/fill_and_submit_web_form_request.py
+++ b/docs/examples/code/fill_and_submit_web_form_request.py
@@ -4,7 +4,7 @@ from crawlee import Request
 request = Request.from_url(
     url='https://httpbin.org/post',
     method='POST',
-    data={
+    payload={
         'custname': 'John Doe',
         'custtel': '1234567890',
         'custemail': 'johndoe@example.com',

--- a/docs/examples/fill_and_submit_web_form.mdx
+++ b/docs/examples/fill_and_submit_web_form.mdx
@@ -46,7 +46,7 @@ Now, let's create a POST request with the form fields and their values using the
     {RequestExample}
 </CodeBlock>
 
-Alternatively, you can send form data as URL parameters using the `query_params` argument. It depends on the form and how it is implemented. However, sending the data as a POST request body using the `data` parameter is generally a better approach.
+Alternatively, you can send form data as URL parameters using the `query_params` argument. It depends on the form and how it is implemented. However, sending the data as a POST request body using the `payload` is generally a better approach.
 
 ## Implementing the crawler
 

--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -133,7 +133,10 @@ class BaseRequestData(BaseModel):
     query_params: Annotated[HttpQueryParams, Field(alias='queryParams', default_factory=dict)] = {}
     """URL query parameters."""
 
-    payload: Annotated[HttpPayload, Field(default_factory=dict)] = {}
+    payload: Annotated[
+        HttpPayload | None,
+        PlainValidator(lambda value: None if value is None else str(value).encode('utf-8')),
+    ] = None
     """HTTP request payload."""
 
     user_data: Annotated[
@@ -181,7 +184,6 @@ class BaseRequestData(BaseModel):
         """Create a new `BaseRequestData` instance from a URL. See `Request.from_url` for more details."""
         headers = headers or HttpHeaders()
         query_params = query_params or {}
-        payload = payload or {}
 
         unique_key = unique_key or compute_unique_key(
             url,
@@ -287,7 +289,6 @@ class Request(BaseRequestData):
         """
         headers = headers or HttpHeaders()
         query_params = query_params or {}
-        payload = payload or {}
 
         unique_key = unique_key or compute_unique_key(
             url,

--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -133,10 +133,7 @@ class BaseRequestData(BaseModel):
     query_params: Annotated[HttpQueryParams, Field(alias='queryParams', default_factory=dict)] = {}
     """URL query parameters."""
 
-    payload: Annotated[
-        HttpPayload | None,
-        PlainValidator(lambda value: None if value is None else str(value).encode('utf-8')),
-    ] = None
+    payload: HttpPayload | None = None
     """HTTP request payload."""
 
     user_data: Annotated[

--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -188,6 +188,7 @@ class BaseRequestData(BaseModel):
         unique_key = unique_key or compute_unique_key(
             url,
             method=method,
+            headers=headers,
             payload=payload,
             keep_url_fragment=keep_url_fragment,
             use_extended_unique_key=use_extended_unique_key,
@@ -293,6 +294,7 @@ class Request(BaseRequestData):
         unique_key = unique_key or compute_unique_key(
             url,
             method=method,
+            headers=headers,
             payload=payload,
             keep_url_fragment=keep_url_fragment,
             use_extended_unique_key=use_extended_unique_key,

--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -127,15 +127,14 @@ class BaseRequestData(BaseModel):
     method: HttpMethod = 'GET'
     """HTTP request method."""
 
-    headers: Annotated[HttpHeaders, Field(default_factory=HttpHeaders())] = HttpHeaders()
+    headers: Annotated[HttpHeaders, Field(default_factory=HttpHeaders)] = HttpHeaders()
     """HTTP request headers."""
 
     query_params: Annotated[HttpQueryParams, Field(alias='queryParams', default_factory=dict)] = {}
     """URL query parameters."""
 
-    payload: HttpPayload | None = None
-
-    data: Annotated[dict[str, Any], Field(default_factory=dict)] = {}
+    payload: Annotated[HttpPayload, Field(default_factory=dict)] = {}
+    """HTTP request payload."""
 
     user_data: Annotated[
         dict[str, JsonSerializable],  # Internally, the model contains `UserData`, this is just for convenience
@@ -169,6 +168,8 @@ class BaseRequestData(BaseModel):
         url: str,
         *,
         method: HttpMethod = 'GET',
+        headers: HttpHeaders | None = None,
+        query_params: HttpQueryParams | None = None,
         payload: HttpPayload | None = None,
         label: str | None = None,
         unique_key: str | None = None,
@@ -178,6 +179,10 @@ class BaseRequestData(BaseModel):
         **kwargs: Any,
     ) -> Self:
         """Create a new `BaseRequestData` instance from a URL. See `Request.from_url` for more details."""
+        headers = headers or HttpHeaders()
+        query_params = query_params or {}
+        payload = payload or {}
+
         unique_key = unique_key or compute_unique_key(
             url,
             method=method,
@@ -193,6 +198,8 @@ class BaseRequestData(BaseModel):
             unique_key=unique_key,
             id=id,
             method=method,
+            headers=headers,
+            query_params=query_params,
             payload=payload,
             **kwargs,
         )
@@ -243,6 +250,8 @@ class Request(BaseRequestData):
         url: str,
         *,
         method: HttpMethod = 'GET',
+        headers: HttpHeaders | None = None,
+        query_params: HttpQueryParams | None = None,
         payload: HttpPayload | None = None,
         label: str | None = None,
         unique_key: str | None = None,
@@ -261,6 +270,8 @@ class Request(BaseRequestData):
         Args:
             url: The URL of the request.
             method: The HTTP method of the request.
+            headers: The HTTP headers of the request.
+            query_params: The query parameters of the URL.
             payload: The data to be sent as the request body. Typically used with 'POST' or 'PUT' requests.
             label: A custom label to differentiate between request types. This is stored in `user_data`, and it is
                 used for request routing (different requests go to different handlers).
@@ -274,6 +285,10 @@ class Request(BaseRequestData):
                 computation. This is only relevant when `unique_key` is not provided.
             **kwargs: Additional request properties.
         """
+        headers = headers or HttpHeaders()
+        query_params = query_params or {}
+        payload = payload or {}
+
         unique_key = unique_key or compute_unique_key(
             url,
             method=method,
@@ -289,6 +304,8 @@ class Request(BaseRequestData):
             unique_key=unique_key,
             id=id,
             method=method,
+            headers=headers,
+            query_params=query_params,
             payload=payload,
             **kwargs,
         )
@@ -376,6 +393,36 @@ class Request(BaseRequestData):
     @forefront.setter
     def forefront(self, new_value: bool) -> None:
         self.crawlee_data.forefront = new_value
+
+    def __eq__(self, other: object) -> bool:
+        """Compare all relevant fields of the `Request` class, excluding deprecated fields `json_` and `order_no`.
+
+        TODO: Remove this method once the issue is resolved.
+        https://github.com/apify/crawlee-python/issues/94
+        """
+        if isinstance(other, Request):
+            return (
+                self.url == other.url
+                and self.unique_key == other.unique_key
+                and self.method == other.method
+                and self.headers == other.headers
+                and self.query_params == other.query_params
+                and self.payload == other.payload
+                and self.user_data == other.user_data
+                and self.retry_count == other.retry_count
+                and self.no_retry == other.no_retry
+                and self.loaded_url == other.loaded_url
+                and self.handled_at == other.handled_at
+                and self.id == other.id
+                and self.label == other.label
+                and self.state == other.state
+                and self.max_retries == other.max_retries
+                and self.session_rotation_count == other.session_rotation_count
+                and self.enqueue_strategy == other.enqueue_strategy
+                and self.last_proxy_tier == other.last_proxy_tier
+                and self.forefront == other.forefront
+            )
+        return NotImplemented
 
 
 class RequestWithLock(Request):

--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -52,7 +52,7 @@ HttpMethod: TypeAlias = Literal['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT
 
 HttpQueryParams: TypeAlias = dict[str, str]
 
-HttpPayload: TypeAlias = Union[str, bytes]
+HttpPayload: TypeAlias = dict[str, Any]
 
 
 def _normalize_headers(headers: Mapping[str, str]) -> dict[str, str]:

--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -52,7 +52,7 @@ HttpMethod: TypeAlias = Literal['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'CONNECT
 
 HttpQueryParams: TypeAlias = dict[str, str]
 
-HttpPayload: TypeAlias = dict[str, Any]
+HttpPayload: TypeAlias = bytes
 
 
 def _normalize_headers(headers: Mapping[str, str]) -> dict[str, str]:

--- a/src/crawlee/_utils/requests.py
+++ b/src/crawlee/_utils/requests.py
@@ -142,13 +142,7 @@ def compute_unique_key(
 
 
 def _get_payload_hash(payload: HttpPayload | None) -> str:
-    if payload is None:
-        payload_in_bytes = b''
-    elif isinstance(payload, str):
-        payload_in_bytes = payload.encode('utf-8')
-    else:
-        payload_in_bytes = payload
-
+    payload_in_bytes = b'' if payload is None else str(payload).encode('utf-8')
     return compute_short_hash(payload_in_bytes)
 
 

--- a/src/crawlee/_utils/requests.py
+++ b/src/crawlee/_utils/requests.py
@@ -142,7 +142,7 @@ def compute_unique_key(
 
 
 def _get_payload_hash(payload: HttpPayload | None) -> str:
-    payload_in_bytes = b'' if payload is None else str(payload).encode('utf-8')
+    payload_in_bytes = b'' if payload is None else payload
     return compute_short_hash(payload_in_bytes)
 
 

--- a/src/crawlee/http_clients/_base.py
+++ b/src/crawlee/http_clients/_base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Protocol
 
 from crawlee._utils.http import is_status_code_error
 from crawlee.errors import HttpStatusCodeError
@@ -10,7 +10,7 @@ from crawlee.errors import HttpStatusCodeError
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from crawlee._types import HttpHeaders, HttpMethod, HttpQueryParams
+    from crawlee._types import HttpHeaders, HttpMethod, HttpPayload, HttpQueryParams
     from crawlee.base_storage_client._models import Request
     from crawlee.proxy_configuration import ProxyInfo
     from crawlee.sessions import Session
@@ -115,7 +115,7 @@ class BaseHttpClient(ABC):
         method: HttpMethod = 'GET',
         headers: HttpHeaders | None = None,
         query_params: HttpQueryParams | None = None,
-        data: dict[str, Any] | None = None,
+        payload: HttpPayload | None = None,
         session: Session | None = None,
         proxy_info: ProxyInfo | None = None,
     ) -> HttpResponse:
@@ -128,7 +128,7 @@ class BaseHttpClient(ABC):
             method: The HTTP method to use.
             headers: The headers to include in the request.
             query_params: The query parameters to include in the request.
-            data: The data to be sent as the request body.
+            payload: The data to be sent as the request body.
             session: The session associated with the request.
             proxy_info: The information about the proxy to be used.
 

--- a/src/crawlee/http_clients/_httpx.py
+++ b/src/crawlee/http_clients/_httpx.py
@@ -16,7 +16,7 @@ from crawlee.sessions import Session
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from crawlee._types import HttpMethod, HttpQueryParams
+    from crawlee._types import HttpMethod, HttpPayload, HttpQueryParams
     from crawlee.base_storage_client._models import Request
     from crawlee.proxy_configuration import ProxyInfo
     from crawlee.statistics import Statistics
@@ -132,7 +132,7 @@ class HttpxHttpClient(BaseHttpClient):
             method=request.method,
             headers=headers,
             params=request.query_params,
-            data=request.data,
+            data=request.payload,
             cookies=session.cookies if session else None,
             extensions={'crawlee_session': session if self._persist_cookies_per_session else None},
         )
@@ -167,7 +167,7 @@ class HttpxHttpClient(BaseHttpClient):
         method: HttpMethod = 'GET',
         headers: HttpHeaders | None = None,
         query_params: HttpQueryParams | None = None,
-        data: dict[str, Any] | None = None,
+        payload: HttpPayload | None = None,
         session: Session | None = None,
         proxy_info: ProxyInfo | None = None,
     ) -> HttpResponse:
@@ -179,7 +179,7 @@ class HttpxHttpClient(BaseHttpClient):
             method=method,
             headers=dict(headers) if headers else None,
             params=query_params,
-            data=data,
+            data=payload,
             extensions={'crawlee_session': session if self._persist_cookies_per_session else None},
         )
 

--- a/src/crawlee/http_clients/_httpx.py
+++ b/src/crawlee/http_clients/_httpx.py
@@ -132,7 +132,7 @@ class HttpxHttpClient(BaseHttpClient):
             method=request.method,
             headers=headers,
             params=request.query_params,
-            data=request.payload,
+            content=request.payload,
             cookies=session.cookies if session else None,
             extensions={'crawlee_session': session if self._persist_cookies_per_session else None},
         )
@@ -179,7 +179,7 @@ class HttpxHttpClient(BaseHttpClient):
             method=method,
             headers=dict(headers) if headers else None,
             params=query_params,
-            data=payload,
+            content=payload,
             extensions={'crawlee_session': session if self._persist_cookies_per_session else None},
         )
 

--- a/src/crawlee/http_clients/curl_impersonate.py
+++ b/src/crawlee/http_clients/curl_impersonate.py
@@ -16,7 +16,7 @@ except ImportError as exc:
 from curl_cffi.const import CurlHttpVersion
 from typing_extensions import override
 
-from crawlee._types import HttpHeaders
+from crawlee._types import HttpHeaders, HttpPayload
 from crawlee._utils.blocked import ROTATE_PROXY_ERRORS
 from crawlee.errors import ProxyError
 from crawlee.http_clients import BaseHttpClient, HttpCrawlingResult, HttpResponse
@@ -153,7 +153,7 @@ class CurlImpersonateHttpClient(BaseHttpClient):
         method: HttpMethod = 'GET',
         headers: HttpHeaders | None = None,
         query_params: HttpQueryParams | None = None,
-        data: dict[str, Any] | None = None,
+        payload: HttpPayload | None = None,
         session: Session | None = None,
         proxy_info: ProxyInfo | None = None,
     ) -> HttpResponse:
@@ -166,7 +166,7 @@ class CurlImpersonateHttpClient(BaseHttpClient):
                 method=method.upper(),  # type: ignore # curl-cffi requires uppercase method
                 headers=dict(headers) if headers else None,
                 params=query_params,
-                data=data,
+                data=payload,
                 cookies=session.cookies if session else None,
                 allow_redirects=True,
             )

--- a/tests/unit/_utils/test_requests.py
+++ b/tests/unit/_utils/test_requests.py
@@ -91,7 +91,7 @@ def test_compute_unique_key_handles_fragments() -> None:
 
 def test_compute_unique_key_handles_payload() -> None:
     url = 'https://crawlee.dev'
-    payload = '{"key": "value"}'
+    payload = b'{"key": "value"}'
 
     # Payload without extended unique key
     uk = compute_unique_key(url, method='POST', payload=payload, use_extended_unique_key=False)
@@ -101,12 +101,8 @@ def test_compute_unique_key_handles_payload() -> None:
     uk = compute_unique_key(url, method='POST', payload=None, use_extended_unique_key=True)
     assert uk == 'POST|e3b0c442|e3b0c442|https://crawlee.dev'
 
-    # Extended unique key and payload is string
-    uk = compute_unique_key(url, method='POST', payload=payload, use_extended_unique_key=True)
-    assert uk == 'POST|e3b0c442|9724c1e2|https://crawlee.dev'
-
     # Extended unique key and payload is bytes
-    uk = compute_unique_key(url, method='POST', payload=payload.encode(), use_extended_unique_key=True)
+    uk = compute_unique_key(url, method='POST', payload=payload, use_extended_unique_key=True)
     assert uk == 'POST|e3b0c442|9724c1e2|https://crawlee.dev'
 
 

--- a/tests/unit/http_crawler/test_http_crawler.py
+++ b/tests/unit/http_crawler/test_http_crawler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, AsyncGenerator, Awaitable, Callable
 from unittest.mock import AsyncMock, Mock
+from urllib.parse import urlencode
 
 import pytest
 import respx
@@ -236,7 +237,7 @@ async def test_filling_web_form(http_client_class: type[BaseHttpClient]) -> None
     request = Request.from_url(
         url='https://httpbin.org/post',
         method='POST',
-        payload=str(form_data).encode(),
+        payload=urlencode(form_data).encode(),
     )
 
     await crawler.run([request])

--- a/tests/unit/http_crawler/test_http_crawler.py
+++ b/tests/unit/http_crawler/test_http_crawler.py
@@ -236,7 +236,7 @@ async def test_filling_web_form(http_client_class: type[BaseHttpClient]) -> None
     request = Request.from_url(
         url='https://httpbin.org/post',
         method='POST',
-        payload=form_data,
+        payload=str(form_data).encode(),
     )
 
     await crawler.run([request])

--- a/tests/unit/http_crawler/test_http_crawler.py
+++ b/tests/unit/http_crawler/test_http_crawler.py
@@ -223,7 +223,7 @@ async def test_filling_web_form(http_client_class: type[BaseHttpClient]) -> None
         'custtel': '1234567890',
         'custemail': 'johndoe@example.com',
         'size': 'large',
-        'topping': '["bacon","cheese","mushroom"]',
+        'topping': '["bacon", "cheese", "mushroom"]',
         'delivery': '13:00',
         'comments': 'Please ring the doorbell upon arrival.',
     }


### PR DESCRIPTION
### Description

- We had `data` and `payload` fields on the `Request` model.
  - `payload` was not being provided to the HTTP clients, only the `data` field.
- ~In this PR, I'm merging them together, keeping only the `data` field (use the same naming as `HTTPX` & `CurlImpersonate`).~
- In this PR, I'm merging them together, keeping only the `payload` field (use the same naming as in JS Crawlee).
- ~I also defined type aliases for HTTP data and HTTP query parameters and used them across the project.~
- ~Some struggle with Pydantic & serialization, but should be OK now...~

### Issues

- Reported by @honzajavorek on Slack
- Closes #560

### Testing

- The current set of unit tests should cover the changes.

### Checklist

- [x] CI passed
