### PR TITLE
fix: call `error_handler` for `SessionError`

### DIFF
--- a/src/crawlee/basic_crawler/_basic_crawler.py
+++ b/src/crawlee/basic_crawler/_basic_crawler.py
@@ -865,6 +865,9 @@ class BasicCrawler(Generic[TCrawlingContext]):
             else:
                 self._logger.exception('Request failed and reached maximum retries', exc_info=session_error)
 
+                if self._error_handler:
+                    await self._error_handler(crawling_context, session_error)
+
                 await wait_for(
                     lambda: request_provider.mark_request_as_handled(crawling_context.request),
                     timeout=self._internal_timeout,

--- a/tests/unit/basic_crawler/test_basic_crawler.py
+++ b/tests/unit/basic_crawler/test_basic_crawler.py
@@ -189,7 +189,6 @@ async def test_calls_error_handler() -> None:
     assert calls[1][2] == 1
 
 
-@pytest.mark.only
 async def test_calls_error_handler_for_sesion_errors() -> None:
     crawler = BasicCrawler(
         max_session_rotations=1,


### PR DESCRIPTION
Closes: #546