### PR TITLE
Max depth feature

### DIFF
--- a/website/roa-loader/package-lock.json
+++ b/website/roa-loader/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "roa-loader",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "roa-loader",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "loader-utils": "^3.2.1",
+        "roa-loader": "file:"
+      }
+    },
+    "node_modules/loader-utils": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
+      "integrity": "sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/roa-loader": {
+      "resolved": "",
+      "link": true
+    }
+  }
+}

--- a/website/roa-loader/package.json
+++ b/website/roa-loader/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "loader-utils": "^3.2.1"
+    "loader-utils": "^3.2.1",
+    "roa-loader": "file:"
   }
 }


### PR DESCRIPTION
Description
This PR introduces a maximum crawl depth feature to the Crawlee library. It allows users to restrict the crawler's depth to a specified level, enabling better control over the crawling process, particularly when dealing with content aggregation sites.

Changes include:

Implementation of a depth tracking mechanism within the crawler.
Modifications to the request handling logic to support the max depth feature.
Issues
Fixes: #460 