### PR TITLE
feat: Key-value store context helpers

### DIFF
--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -1,9 +1,20 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Protocol, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Literal,
+    Optional,
+    Protocol,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
 from pydantic import ConfigDict, Field, PlainValidator, RootModel
 from typing_extensions import NotRequired, TypeAlias, TypedDict, Unpack
@@ -19,7 +30,8 @@ if TYPE_CHECKING:
     from crawlee.http_clients import HttpResponse
     from crawlee.proxy_configuration import ProxyInfo
     from crawlee.sessions._session import Session
-    from crawlee.storages._dataset import ExportToKwargs, GetDataKwargs, PushDataKwargs
+    from crawlee.storages._dataset import ExportToKwargs, GetDataKwargs
+    from crawlee.storages._key_value_store import KeyValueStore
 
     # Workaround for https://github.com/pydantic/pydantic/issues/9445
     J = TypeVar('J', bound='JsonSerializable')
@@ -188,6 +200,10 @@ class GetDataFunction(Protocol):
     ) -> Coroutine[None, None, DatasetItemsListPage]: ...
 
 
+class PushDataKwargs(TypedDict):
+    """Keyword arguments for dataset's `push_data` method."""
+
+
 class PushDataFunction(Protocol):
     """Type of a function for pushing data to the dataset.
 
@@ -202,6 +218,12 @@ class PushDataFunction(Protocol):
         dataset_name: str | None = None,
         **kwargs: Unpack[PushDataKwargs],
     ) -> Coroutine[None, None, None]: ...
+
+
+class PushDataFunctionCall(PushDataKwargs):
+    data: JsonSerializable
+    dataset_id: str | None
+    dataset_name: str | None
 
 
 class ExportToFunction(Protocol):
@@ -251,6 +273,42 @@ class SendRequestFunction(Protocol):
     ) -> Coroutine[None, None, HttpResponse]: ...
 
 
+T = TypeVar('T')
+
+
+class KeyValueStoreInterface(Protocol):
+    """The (limited) part of the `KeyValueStore` interface that should be accessible from a request handler."""
+
+    @overload
+    async def get_value(self, key: str) -> Any: ...
+
+    @overload
+    async def get_value(self, key: str, default_value: T) -> T: ...
+
+    @overload
+    async def get_value(self, key: str, default_value: T | None = None) -> T | None: ...
+
+    async def get_value(self, key: str, default_value: T | None = None) -> T | None: ...
+
+    async def set_value(
+        self,
+        key: str,
+        value: Any,
+        content_type: str | None = None,
+    ) -> None: ...
+
+
+class GetKeyValueStoreFromRequestHandlerFunction(Protocol):
+    """Type of a function for accessing a key-value store from within a request handler."""
+
+    def __call__(
+        self,
+        *,
+        id: str | None = None,
+        name: str | None = None,
+    ) -> Coroutine[None, None, KeyValueStoreInterface]: ...
+
+
 @dataclass(frozen=True)
 class BasicCrawlingContext:
     """Basic crawling context intended to be extended by crawlers."""
@@ -261,14 +319,64 @@ class BasicCrawlingContext:
     send_request: SendRequestFunction
     add_requests: AddRequestsFunction
     push_data: PushDataFunction
+    get_key_value_store: GetKeyValueStoreFromRequestHandlerFunction
     log: logging.Logger
 
 
 @dataclass()
+class KeyValueStoreValue:
+    content: Any
+    content_type: str | None
+
+
+class KeyValueStoreChangeRecords:
+    def __init__(self, actual_key_value_store: KeyValueStore) -> None:
+        self.updates = dict[str, KeyValueStoreValue]()
+        self._actual_key_value_store = actual_key_value_store
+
+    async def set_value(
+        self,
+        key: str,
+        value: Any,
+        content_type: str | None = None,
+    ) -> None:
+        self.updates[key] = KeyValueStoreValue(value, content_type)
+
+    @overload
+    async def get_value(self, key: str) -> Any: ...
+
+    @overload
+    async def get_value(self, key: str, default_value: T) -> T: ...
+
+    @overload
+    async def get_value(self, key: str, default_value: T | None = None) -> T | None: ...
+
+    async def get_value(self, key: str, default_value: T | None = None) -> T | None:
+        if key in self.updates:
+            return cast(T, self.updates[key].content)
+
+        return await self._actual_key_value_store.get_value(key, default_value)
+
+
+class GetKeyValueStoreFunction(Protocol):
+    """Type of a function for accessing the live implementation of a key-value store."""
+
+    def __call__(
+        self,
+        *,
+        id: str | None = None,
+        name: str | None = None,
+    ) -> Coroutine[None, None, KeyValueStore]: ...
+
+
 class RequestHandlerRunResult:
     """Record of calls to storage-related context helpers."""
 
-    add_requests_calls: list[AddRequestsFunctionCall] = field(default_factory=list)
+    def __init__(self, *, key_value_store_getter: GetKeyValueStoreFunction) -> None:
+        self._key_value_store_getter = key_value_store_getter
+        self.add_requests_calls = list[AddRequestsFunctionCall]()
+        self.push_data_calls = list[PushDataFunctionCall]()
+        self.key_value_store_changes = dict[tuple[Optional[str], Optional[str]], KeyValueStoreChangeRecords]()
 
     async def add_requests(
         self,
@@ -276,4 +384,39 @@ class RequestHandlerRunResult:
         **kwargs: Unpack[AddRequestsKwargs],
     ) -> None:
         """Track a call to the `add_requests` context helper."""
-        self.add_requests_calls.append(AddRequestsFunctionCall(requests=requests, **kwargs))
+        self.add_requests_calls.append(
+            AddRequestsFunctionCall(
+                requests=requests,
+                **kwargs,
+            )
+        )
+
+    async def push_data(
+        self,
+        data: JsonSerializable,
+        dataset_id: str | None = None,
+        dataset_name: str | None = None,
+        **kwargs: Unpack[PushDataKwargs],
+    ) -> None:
+        """Track a call to the `push_data` context helper."""
+        self.push_data_calls.append(
+            PushDataFunctionCall(
+                data=data,
+                dataset_id=dataset_id,
+                dataset_name=dataset_name,
+                **kwargs,
+            )
+        )
+
+    async def get_key_value_store(
+        self,
+        *,
+        id: str | None = None,
+        name: str | None = None,
+    ) -> KeyValueStoreInterface:
+        if (id, name) not in self.key_value_store_changes:
+            self.key_value_store_changes[id, name] = KeyValueStoreChangeRecords(
+                await self._key_value_store_getter(id=id, name=name)
+            )
+
+        return self.key_value_store_changes[id, name]

--- a/src/crawlee/beautifulsoup_crawler/_beautifulsoup_crawler.py
+++ b/src/crawlee/beautifulsoup_crawler/_beautifulsoup_crawler.py
@@ -81,6 +81,7 @@ class BeautifulSoupCrawler(BasicCrawler[BeautifulSoupCrawlingContext]):
             add_requests=context.add_requests,
             send_request=context.send_request,
             push_data=context.push_data,
+            get_key_value_store=context.get_key_value_store,
             log=context.log,
             http_response=result.http_response,
         )
@@ -159,6 +160,7 @@ class BeautifulSoupCrawler(BasicCrawler[BeautifulSoupCrawlingContext]):
             add_requests=context.add_requests,
             send_request=context.send_request,
             push_data=context.push_data,
+            get_key_value_store=context.get_key_value_store,
             log=context.log,
             http_response=context.http_response,
             soup=soup,

--- a/src/crawlee/http_crawler/_http_crawler.py
+++ b/src/crawlee/http_crawler/_http_crawler.py
@@ -65,6 +65,7 @@ class HttpCrawler(BasicCrawler[HttpCrawlingContext]):
             add_requests=context.add_requests,
             send_request=context.send_request,
             push_data=context.push_data,
+            get_key_value_store=context.get_key_value_store,
             log=context.log,
             http_response=result.http_response,
         )

--- a/src/crawlee/parsel_crawler/_parsel_crawler.py
+++ b/src/crawlee/parsel_crawler/_parsel_crawler.py
@@ -76,6 +76,7 @@ class ParselCrawler(BasicCrawler[ParselCrawlingContext]):
             add_requests=context.add_requests,
             send_request=context.send_request,
             push_data=context.push_data,
+            get_key_value_store=context.get_key_value_store,
             log=context.log,
             http_response=result.http_response,
         )
@@ -158,6 +159,7 @@ class ParselCrawler(BasicCrawler[ParselCrawlingContext]):
             add_requests=context.add_requests,
             send_request=context.send_request,
             push_data=context.push_data,
+            get_key_value_store=context.get_key_value_store,
             log=context.log,
             http_response=context.http_response,
             selector=parsel_selector,

--- a/src/crawlee/playwright_crawler/_playwright_crawler.py
+++ b/src/crawlee/playwright_crawler/_playwright_crawler.py
@@ -164,6 +164,7 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext]):
                 send_request=context.send_request,
                 push_data=context.push_data,
                 proxy_info=context.proxy_info,
+                get_key_value_store=context.get_key_value_store,
                 log=context.log,
                 page=crawlee_page.page,
                 infinite_scroll=lambda: infinite_scroll(crawlee_page.page),

--- a/src/crawlee/storages/_dataset.py
+++ b/src/crawlee/storages/_dataset.py
@@ -15,7 +15,7 @@ from crawlee.storages._base_storage import BaseStorage
 from crawlee.storages._key_value_store import KeyValueStore
 
 if TYPE_CHECKING:
-    from crawlee._types import JsonSerializable
+    from crawlee._types import JsonSerializable, PushDataKwargs
     from crawlee.base_storage_client import BaseStorageClient
     from crawlee.base_storage_client._models import DatasetItemsListPage
     from crawlee.configuration import Configuration
@@ -52,10 +52,6 @@ class GetDataKwargs(TypedDict):
     skip_hidden: NotRequired[bool]
     flatten: NotRequired[list[str]]
     view: NotRequired[str]
-
-
-class PushDataKwargs(TypedDict):
-    """Keyword arguments for dataset's `push_data` method."""
 
 
 class ExportToKwargs(TypedDict):

--- a/tests/unit/basic_crawler/test_basic_crawler.py
+++ b/tests/unit/basic_crawler/test_basic_crawler.py
@@ -602,6 +602,20 @@ async def test_context_push_and_export_data(httpbin: str, tmp_path: Path) -> Non
     assert (tmp_path / 'dataset.csv').read_bytes() == b'id,test\r\n0,test\r\n1,test\r\n2,test\r\n'
 
 
+async def test_context_update_kv_store() -> None:
+    crawler = BasicCrawler()
+
+    @crawler.router.default_handler
+    async def handler(context: BasicCrawlingContext) -> None:
+        store = await context.get_key_value_store()
+        await store.set_value('foo', 'bar')
+
+    await crawler.run(['https://hello.world'])
+
+    store = await crawler.get_key_value_store()
+    assert (await store.get_value('foo')) == 'bar'
+
+
 async def test_max_requests_per_crawl(httpbin: str) -> None:
     start_urls = [f'{httpbin}/1', f'{httpbin}/2', f'{httpbin}/3', f'{httpbin}/4', f'{httpbin}/5']
     processed_urls = []

--- a/tests/unit/basic_crawler/test_basic_crawler.py
+++ b/tests/unit/basic_crawler/test_basic_crawler.py
@@ -562,6 +562,22 @@ async def test_context_push_and_get_data(httpbin: str) -> None:
     assert stats.requests_finished == 1
 
 
+async def test_context_push_and_get_data_handler_error() -> None:
+    crawler = BasicCrawler()
+
+    @crawler.router.default_handler
+    async def handler(context: BasicCrawlingContext) -> None:
+        await context.push_data('{"b": 2}')
+        raise RuntimeError('Watch me crash')
+
+    stats = await crawler.run(['https://a.com'])
+
+    assert (await crawler.get_data()).items == []
+    assert stats.requests_total == 1
+    assert stats.requests_finished == 0
+    assert stats.requests_failed == 1
+
+
 async def test_crawler_push_and_export_data(tmp_path: Path) -> None:
     crawler = BasicCrawler()
     dataset = await Dataset.open()

--- a/tests/unit/basic_crawler/test_context_pipeline.py
+++ b/tests/unit/basic_crawler/test_context_pipeline.py
@@ -35,6 +35,7 @@ async def test_calls_consumer_without_middleware() -> None:
         session=Session(),
         proxy_info=AsyncMock(),
         push_data=AsyncMock(),
+        get_key_value_store=AsyncMock(),
         log=logging.getLogger(),
     )
 
@@ -60,6 +61,7 @@ async def test_calls_consumers_and_middlewares() -> None:
             session=context.session,
             proxy_info=AsyncMock(),
             push_data=AsyncMock(),
+            get_key_value_store=AsyncMock(),
             log=logging.getLogger(),
         )
         events.append('middleware_a_out')
@@ -75,6 +77,7 @@ async def test_calls_consumers_and_middlewares() -> None:
             session=context.session,
             proxy_info=AsyncMock(),
             push_data=AsyncMock(),
+            get_key_value_store=AsyncMock(),
             log=logging.getLogger(),
         )
         events.append('middleware_b_out')
@@ -88,6 +91,7 @@ async def test_calls_consumers_and_middlewares() -> None:
         session=Session(),
         proxy_info=AsyncMock(),
         push_data=AsyncMock(),
+        get_key_value_store=AsyncMock(),
         log=logging.getLogger(),
     )
     await pipeline(context, consumer)
@@ -112,6 +116,7 @@ async def test_wraps_consumer_errors() -> None:
         session=Session(),
         proxy_info=AsyncMock(),
         push_data=AsyncMock(),
+        get_key_value_store=AsyncMock(),
         log=logging.getLogger(),
     )
 
@@ -139,6 +144,7 @@ async def test_handles_exceptions_in_middleware_initialization() -> None:
         session=Session(),
         proxy_info=AsyncMock(),
         push_data=AsyncMock(),
+        get_key_value_store=AsyncMock(),
         log=logging.getLogger(),
     )
 
@@ -169,6 +175,7 @@ async def test_handles_exceptions_in_middleware_finalization() -> None:
         session=Session(),
         proxy_info=AsyncMock(),
         push_data=AsyncMock(),
+        get_key_value_store=AsyncMock(),
         log=logging.getLogger(),
     )
 

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -20,6 +20,7 @@ class MockContext(BasicCrawlingContext):
             add_requests=AsyncMock(),
             proxy_info=AsyncMock(),
             push_data=AsyncMock(),
+            get_key_value_store=AsyncMock(),
             log=logging.getLogger(),
         )
 


### PR DESCRIPTION
- This adds a `get_key_value_store(id, name)` context helper to `BasicCrawlingContext`
- Also, push_data calls are held until the request handler terminates successfully (same as in JS version)
    - This is necessary for adaptive crawling (#249), among other things
