### PR TITLE
Added the always-enqueue paramter to bypass deduplication

### DIFF
--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -22,7 +22,7 @@ from typing_extensions import Self
 from crawlee._types import EnqueueStrategy, HttpHeaders, HttpMethod, HttpPayload, HttpQueryParams, JsonSerializable
 from crawlee._utils.requests import compute_unique_key, unique_key_to_request_id
 from crawlee._utils.urls import extract_query_params, validate_http_url
-
+from crawlee._utils.crypto import crypto_random_object_id
 
 class RequestState(IntEnum):
     """Crawlee-specific request handling state."""
@@ -249,6 +249,7 @@ class Request(BaseRequestData):
         id: str | None = None,
         keep_url_fragment: bool = False,
         use_extended_unique_key: bool = False,
+        always_enqueue: bool = False,
         **kwargs: Any,
     ) -> Self:
         """Create a new `Request` instance from a URL.
@@ -272,8 +273,15 @@ class Request(BaseRequestData):
                 the `unique_key` computation. This is only relevant when `unique_key` is not provided.
             use_extended_unique_key: Determines whether to include the HTTP method and payload in the `unique_key`
                 computation. This is only relevant when `unique_key` is not provided.
+            always_enqueue: If `True`, the request will be enqueued even if it is already present in the queue.
             **kwargs: Additional request properties.
         """
+        if unique_key is not None and always_enqueue:
+            try:
+                raise ValueError('The `always_enqueue` flag cannot be used when a custom `unique_key` is provided.')
+            except ValueError as e:
+                print(f"Error: {e}")
+        
         unique_key = unique_key or compute_unique_key(
             url,
             method=method,
@@ -282,6 +290,9 @@ class Request(BaseRequestData):
             use_extended_unique_key=use_extended_unique_key,
         )
 
+        if always_enqueue:
+            unique_key += f'_{crypto_random_object_id()}'
+            
         id = id or unique_key_to_request_id(unique_key)
 
         request = cls(


### PR DESCRIPTION
### Description
Earlier the requests that were generated from `Request.from_url` with the same `unique_key` generated on the same URLs were considered identical requests but this parameter if set to true allows deduplication of requests by creating a new `unique_key` for each request on a consistent URL

- TODO

### Issues

<!-- If applicable, reference any related GitHub issues -->

- Closes: #547 

### Testing

<!-- Describe the testing process for these changes -->

- The changes can be checked by creating requests for the same URL and each time this is performed, it should perform its operations without considering it as an identical request if `always_enqueue` is labelled `true`

### Checklist

- [x] CI passed
