### PR TITLE
chore: don't add contributors as link to the changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -27,7 +27,7 @@ body = """
         - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
             {% if commit.breaking %}[**breaking**] {% endif %}\
             {{ commit.message | upper_first }} ([{{ commit.id | truncate(length = 7, end = "") }}](<REPO>/commit/{{ commit.id }}))\
-            {% if commit.github.username %} by [@{{ commit.github.username }}](https://github.com/{{ commit.github.username }}){%- endif %}\
+            {% if commit.github.username %} by @{{ commit.github.username }}{%- endif %}\
     {% endfor %}
 {% endfor %}\n
 """


### PR DESCRIPTION
### Description

Hello! I'm the creator of `git-cliff` :wave:

GitHub does not add profile links to the releases when the usernames are being used as links. So they should be in the `@username` format instead of `[@username](...)`.
This PR updates the `git-cliff` config to address that.

This issue was brought to my attention in <https://github.com/orhun/git-cliff/discussions/917>

### Issues

closes https://github.com/orhun/git-cliff/discussions/917

### Testing

Not tested, but it will work :)

### Checklist

- [ ] CI passed
