### PR TITLE
feat: Add support for `pre_navigation_hooks` in PlaywrightCrawler

### DIFF
--- a/src/crawlee/playwright_crawler/__init__.py
+++ b/src/crawlee/playwright_crawler/__init__.py
@@ -1,5 +1,5 @@
 try:
-    from ._playwright_crawler import PlaywrightCrawler
+    from ._playwright_crawler import PlaywrightCrawler, PlaywrightHook
     from ._playwright_crawling_context import PlaywrightCrawlingContext
 except ImportError as exc:
     raise ImportError(
@@ -7,4 +7,4 @@ except ImportError as exc:
         "For example, if you use pip, run `pip install 'crawlee[playwright]'`.",
     ) from exc
 
-__all__ = ['PlaywrightCrawler', 'PlaywrightCrawlingContext']
+__all__ = ['PlaywrightCrawler', 'PlaywrightCrawlingContext', 'PlaywrightHook']


### PR DESCRIPTION
### Description

This implementation adds support for preNavigationHooks in the PlaywrightCrawler

Use the new pre_navigation_hooks:

`async def example_hook(context: PlaywrightCrawlingContext, goto_options: dict) -> None:
    await context.page.evaluate("window.foo = 'bar';")
    goto_options['timeout'] = 60000  # Set a custom timeout for navigation

crawler = PlaywrightCrawler(
    # other options...
    pre_navigation_hooks=[example_hook]
)`

### Issues

[#427](https://github.com/apify/crawlee-python/issues/427)

- [ ] CI passed
