### PR TITLE
docs: improve autogenerated API docs

### DIFF
--- a/src/crawlee/configuration.py
+++ b/src/crawlee/configuration.py
@@ -18,8 +18,8 @@ class Configuration(BaseSettings):
     """Configuration of the Crawler.
 
     Args:
-        internal_timeout: timeout for internal operations such as marking a request as processed
-        verbose_log: allows verbose logging
+        internal_timeout: Timeout for internal operations such as marking a request as processed.
+        verbose_log: Allows verbose logging.
         default_storage_id: The default storage ID.
         purge_on_start: Whether to purge the storage on start.
     """

--- a/website/build_api_reference.sh
+++ b/website/build_api_reference.sh
@@ -11,7 +11,7 @@ sed_no_backup() {
 }
 
 # Create docspec dump of this package's source code through pydoc-markdown
-poetry run pydoc-markdown --quiet --dump > docspec-dump.jsonl
+python ./pydoc-markdown/generate_ast.py > docspec-dump.jsonl
 sed_no_backup "s#${PWD}/..#REPO_ROOT_PLACEHOLDER#g" docspec-dump.jsonl
 
 rm -rf "${apify_shared_tempdir}"

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -80,6 +80,7 @@ module.exports = {
                 sortSidebar: groupSort,
                 pathToCurrentVersionTypedocJSON: `${__dirname}/api-typedoc-generated.json`,
                 routeBasePath: 'api',
+                python: true,
             },
         ],
         // [

--- a/website/package.json
+++ b/website/package.json
@@ -33,7 +33,7 @@
         "typescript": "5.6.2"
     },
     "dependencies": {
-        "@apify/docusaurus-plugin-typedoc-api": "^4.2.2",
+        "@apify/docusaurus-plugin-typedoc-api": "^4.2.6",
         "@apify/utilities": "^2.8.0",
         "@docusaurus/core": "^3.5.2",
         "@docusaurus/mdx-loader": "^3.5.2",
@@ -56,5 +56,5 @@
         "stream-browserify": "^3.0.0",
         "unist-util-visit": "^5.0.0"
     },
-    "packageManager": "yarn@4.4.1"
+    "packageManager": "yarn@4.5.1"
 }

--- a/website/pydoc-markdown/generate_ast.py
+++ b/website/pydoc-markdown/generate_ast.py
@@ -1,0 +1,46 @@
+"""
+Replaces the default pydoc-markdown shell script with a custom Python script calling the pydoc-markdown API directly.
+
+This script generates an AST from the Python source code in the `src` directory and prints it as a JSON object.
+"""
+
+from pydoc_markdown.interfaces import Context
+from pydoc_markdown.contrib.loaders.python import PythonLoader
+from pydoc_markdown.contrib.processors.filter import FilterProcessor
+from pydoc_markdown.contrib.processors.crossref import CrossrefProcessor
+from pydoc_markdown.contrib.renderers.markdown import MarkdownReferenceResolver
+from google_docstring_processor import ApifyGoogleProcessor
+from docspec import dump_module
+
+import json
+import os
+
+project_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../src')
+
+context = Context(directory='.')
+loader = PythonLoader(search_path=[project_path])
+filter = FilterProcessor(
+    documented_only=False,
+    skip_empty_modules=False,
+)
+crossref = CrossrefProcessor()
+google = ApifyGoogleProcessor()
+
+loader.init(context)
+filter.init(context)
+google.init(context)
+crossref.init(context)
+
+processors = [filter, google, crossref]
+
+dump = []
+
+modules = list(loader.load())
+
+for processor in processors:
+    processor.process(modules, None)
+
+for module in modules:
+    dump.append(dump_module(module))
+
+print(json.dumps(dump, indent=4))

--- a/website/pydoc-markdown/google_docstring_processor.py
+++ b/website/pydoc-markdown/google_docstring_processor.py
@@ -1,0 +1,183 @@
+# -*- coding: utf8 -*-
+# Copyright (c) 2019 Niklas Rosenstein
+# !!! Modified 2024 Jindřich Bär
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+import dataclasses
+import re
+import typing as t
+
+import docspec
+
+from pydoc_markdown.contrib.processors.sphinx import generate_sections_markdown
+from pydoc_markdown.interfaces import Processor, Resolver
+
+import json
+
+
+@dataclasses.dataclass
+class ApifyGoogleProcessor(Processor):
+    """
+    This class implements the preprocessor for Google and PEP 257 docstrings. It converts
+    docstrings formatted in the Google docstyle to Markdown syntax.
+
+    References:
+
+    * https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html
+    * https://www.python.org/dev/peps/pep-0257/
+
+    Example:
+
+    ```
+    Attributes:
+        module_level_variable1 (int): Module level variables may be documented in
+            either the ``Attributes`` section of the module docstring, or in an
+            inline docstring immediately following the variable.
+
+            Either form is acceptable, but the two should not be mixed. Choose
+            one convention to document module level variables and be consistent
+            with it.
+
+    Todo:
+        * For module TODOs
+        * You have to also use ``sphinx.ext.todo`` extension
+    ```
+
+    Renders as:
+
+    Attributes:
+        module_level_variable1 (int): Module level variables may be documented in
+            either the ``Attributes`` section of the module docstring, or in an
+            inline docstring immediately following the variable.
+
+            Either form is acceptable, but the two should not be mixed. Choose
+            one convention to document module level variables and be consistent
+            with it.
+
+    Todo:
+        * For module TODOs
+        * You have to also use ``sphinx.ext.todo`` extension
+
+    @doc:fmt:google
+    """
+
+    _param_res = [
+        re.compile(r"^(?P<param>\S+):\s+(?P<desc>.+)$"),
+        re.compile(r"^(?P<param>\S+)\s+\((?P<type>[^)]+)\):\s+(?P<desc>.+)$"),
+        re.compile(r"^(?P<param>\S+)\s+--\s+(?P<desc>.+)$"),
+        re.compile(r"^(?P<param>\S+)\s+\{\[(?P<type>\S+)\]\}\s+--\s+(?P<desc>.+)$"),
+        re.compile(r"^(?P<param>\S+)\s+\{(?P<type>\S+)\}\s+--\s+(?P<desc>.+)$"),
+    ]
+
+    _keywords_map = {
+        "Args:": "Arguments",
+        "Arguments:": "Arguments",
+        "Attributes:": "Attributes",
+        "Example:": "Example",
+        "Examples:": "Examples",
+        "Keyword Args:": "Arguments",
+        "Keyword Arguments:": "Arguments",
+        "Methods:": "Methods",
+        "Note:": "Notes",
+        "Notes:": "Notes",
+        "Other Parameters:": "Arguments",
+        "Parameters:": "Arguments",
+        "Return:": "Returns",
+        "Returns:": "Returns",
+        "Raises:": "Raises",
+        "References:": "References",
+        "See Also:": "See Also",
+        "Todo:": "Todo",
+        "Warning:": "Warnings",
+        "Warnings:": "Warnings",
+        "Warns:": "Warns",
+        "Yield:": "Yields",
+        "Yields:": "Yields",
+    }
+
+    def check_docstring_format(self, docstring: str) -> bool:
+        for section_name in self._keywords_map:
+            if section_name in docstring:
+                return True
+        return False
+
+    def process(self, modules: t.List[docspec.Module], resolver: t.Optional[Resolver]) -> None:
+        docspec.visit(modules, self._process)
+
+    def _process(self, node: docspec.ApiObject):
+        if not node.docstring:
+            return
+
+        lines = []
+        sections = []
+        current_lines: t.List[str] = []
+        in_codeblock = False
+        keyword = None
+        multiline_argument_offset = -1
+
+        def _commit():
+            if keyword:
+                sections.append({keyword: list(current_lines)})
+            else:
+                lines.extend(current_lines)
+            current_lines.clear()
+
+        for line in node.docstring.content.split("\n"):
+            multiline_argument_offset += 1
+            if line.lstrip().startswith("```"):
+                in_codeblock = not in_codeblock
+                current_lines.append(line)
+                continue
+
+            if in_codeblock:
+                current_lines.append(line)
+                continue
+
+            line = line.strip()
+            if line in self._keywords_map:
+                _commit()
+                keyword = self._keywords_map[line]
+                continue
+
+            if keyword is None:
+                lines.append(line)
+                continue
+
+            for param_re in self._param_res:
+                param_match = param_re.match(line)
+                if param_match:
+                    current_lines.append(param_match.groupdict())
+                    multiline_argument_offset = 0
+                    break
+
+            if not param_match:
+                if multiline_argument_offset == 1:
+                    current_lines[-1]["desc"] += "\n" + line
+                    multiline_argument_offset = 0
+                else:
+                    current_lines.append(line)
+
+        _commit()
+        node.docstring.content = json.dumps({
+            "text": "\n".join(lines),
+            "sections": sections,
+        }, indent=None)
+        
+

--- a/website/pydoc-markdown/google_docstring_processor.py
+++ b/website/pydoc-markdown/google_docstring_processor.py
@@ -144,6 +144,8 @@ class ApifyGoogleProcessor(Processor):
             if line.lstrip().startswith("```"):
                 in_codeblock = not in_codeblock
                 current_lines.append(line)
+                if not in_codeblock:
+                    _commit()
                 continue
 
             if in_codeblock:

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -541,3 +541,16 @@ div[class^=announcementBar_] button {
     box-shadow: var(--ifm-alert-shadow);
     padding: var(--ifm-alert-padding-vertical) var(--ifm-alert-padding-horizontal);
 }
+
+.tsd-parameters li {
+    margin-bottom: 16px;
+}
+
+.tsd-parameters-title {
+    font-size: 16px;
+    margin-bottom: 16px !important;
+}
+
+.tsd-returns-title {
+    font-size: 16px;
+}

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -554,3 +554,7 @@ div[class^=announcementBar_] button {
 .tsd-returns-title {
     font-size: 16px;
 }
+
+.tsd-api-options {
+    display: none;
+}

--- a/website/transformDocs.js
+++ b/website/transformDocs.js
@@ -78,7 +78,7 @@ const groupSort = (g1, g2) => {
 
 function getGroupName(object) {
     const groupPredicates = {
-        'Errors': (x) => x.name.toLowerCase().includes('error'),
+        'Errors': (x) => x.name.toLowerCase().endsWith('error'),
         'Main Classes': (x) => [
             'BasicCrawler', 'HttpCrawler', 'BeautifulSoupCrawler', 'ParselCrawler', 'PlaywrightCrawler', 'Dataset',
             'KeyValueStore', 'RequestQueue', 'MemoryStorageClient', 'HttpxHttpClient', 'CurlImpersonateHttpClient',
@@ -224,10 +224,6 @@ function convertObject(obj, parent, module) {
                 docstring.returns = docstring.returns.join('\n');
             } catch {
                 // Do nothing
-            }
-
-            if (member.name === 'Configuration') {
-                console.log('configuration!');
             }
 
             if (!docstring.text) {

--- a/website/transformDocs.js
+++ b/website/transformDocs.js
@@ -140,7 +140,7 @@ function sortChildren(typedocMember) {
     typedocMember.groups.sort((a, b) => groupSort(a.title, b.title));
 }
 
-// Objects with decorators named 'ignore_docs' or with empty docstrings will be ignored
+// Objects with decorators named 'ignore_docs' will be ignored
 function isHidden(member) {
     return member.decorations?.some(d => d.name === 'ignore_docs') || member.name === 'ignore_docs';
 }
@@ -201,10 +201,6 @@ function convertObject(obj, parent, module) {
             let moduleName = module.name;
             if (fullName in moduleShortcuts) {
                 moduleName = moduleShortcuts[fullName].replace(`.${member.name}`, '');
-            }
-
-            if(member.name === 'Actor' || (member.name.endsWith('Client') && !member.name.endsWith('StorageClient')) || member.name === 'ListPage') {
-                continue;
             }
 
             if (member.name === '_ActorType') {

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -223,23 +223,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apify/docusaurus-plugin-typedoc-api@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "@apify/docusaurus-plugin-typedoc-api@npm:4.2.2"
+"@apify/docusaurus-plugin-typedoc-api@npm:^4.2.6":
+  version: 4.2.6
+  resolution: "@apify/docusaurus-plugin-typedoc-api@npm:4.2.6"
   dependencies:
     "@docusaurus/plugin-content-docs": "npm:^3.5.2"
     "@docusaurus/types": "npm:^3.5.2"
     "@docusaurus/utils": "npm:^3.5.2"
+    "@types/react": "npm:^18.3.11"
     "@vscode/codicons": "npm:^0.0.35"
     marked: "npm:^9.1.6"
     marked-smartypants: "npm:^1.1.5"
     typedoc: "npm:^0.25.7"
+    zx: "npm:^8.1.4"
   peerDependencies:
     "@docusaurus/core": ^3.5.2
     "@docusaurus/mdx-loader": ^3.5.2
     react: ">=18.0.0"
     typescript: ^5.0.0
-  checksum: 10c0/abd2ca2691c2266e21f9380dceeb698d8ba1be9919de0161f53e5a7d9a0f403794a255d7dbfb359ba9456447d43bf52278d61c8bd3a17462600b0707b5de77ab
+  checksum: 10c0/93bd5e1d7ded644520bed15733b44e9e5547f04d7dd3c46a7137b950e17ceb6fabff41b85da659aeaf299d2026962a6d35be46c9041929dc5ba4388afd718aeb
   languageName: node
   linkType: hard
 
@@ -3061,6 +3063,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/fs-extra@npm:>=11":
+  version: 11.0.4
+  resolution: "@types/fs-extra@npm:11.0.4"
+  dependencies:
+    "@types/jsonfile": "npm:*"
+    "@types/node": "npm:*"
+  checksum: 10c0/9e34f9b24ea464f3c0b18c3f8a82aefc36dc524cc720fc2b886e5465abc66486ff4e439ea3fb2c0acebf91f6d3f74e514f9983b1f02d4243706bdbb7511796ad
+  languageName: node
+  linkType: hard
+
 "@types/gtag.js@npm:^0.0.12":
   version: 0.0.12
   resolution: "@types/gtag.js@npm:0.0.12"
@@ -3153,6 +3165,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/jsonfile@npm:*":
+  version: 6.1.4
+  resolution: "@types/jsonfile@npm:6.1.4"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/b12d068b021e4078f6ac4441353965769be87acf15326173e2aea9f3bf8ead41bd0ad29421df5bbeb0123ec3fc02eb0a734481d52903704a1454a1845896b9eb
+  languageName: node
+  linkType: hard
+
 "@types/mdast@npm:^4.0.0, @types/mdast@npm:^4.0.2":
   version: 4.0.4
   resolution: "@types/mdast@npm:4.0.4"
@@ -3198,6 +3219,15 @@ __metadata:
   dependencies:
     undici-types: "npm:~6.19.2"
   checksum: 10c0/45aa75c5e71645fac42dced4eff7f197c3fdfff6e8a9fdacd0eb2e748ff21ee70ffb73982f068a58e8d73b2c088a63613142c125236cdcf3c072ea97eada1559
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:>=20":
+  version: 22.7.7
+  resolution: "@types/node@npm:22.7.7"
+  dependencies:
+    undici-types: "npm:~6.19.2"
+  checksum: 10c0/07268a1e990ad9d9b1865092881317ea679a46eb6706d83a8874eec75fdddae6cfd6452e4e68b651561183e2a8f8548276f3155744bc402c2545978c19b70d65
   languageName: node
   linkType: hard
 
@@ -3282,6 +3312,16 @@ __metadata:
     "@types/prop-types": "npm:*"
     csstype: "npm:^3.0.2"
   checksum: 10c0/5c52e1e6f540cff21e3c2a5212066d02e005f6fb21e4a536a29097fae878db9f407cd7a4b43778f51359349c5f692e08bc77ddb5f5cecbfca9ca4d4e3c91a48e
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:^18.3.11":
+  version: 18.3.11
+  resolution: "@types/react@npm:18.3.11"
+  dependencies:
+    "@types/prop-types": "npm:*"
+    csstype: "npm:^3.0.2"
+  checksum: 10c0/ce80512246ca5bda69db85b9f4f1835189334acfb6b2c4f3eda8cabff1ff1a3ea9ce4f3b895bdbc18c94140aa45592331aa3fdeb557f525c1b048de7ce84fc0e
   languageName: node
   linkType: hard
 
@@ -12490,7 +12530,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@apify/docusaurus-plugin-typedoc-api": "npm:^4.2.2"
+    "@apify/docusaurus-plugin-typedoc-api": "npm:^4.2.6"
     "@apify/eslint-config-ts": "npm:^0.4.0"
     "@apify/tsconfig": "npm:^0.1.0"
     "@apify/utilities": "npm:^2.8.0"
@@ -14558,5 +14598,22 @@ __metadata:
   version: 2.0.4
   resolution: "zwitch@npm:2.0.4"
   checksum: 10c0/3c7830cdd3378667e058ffdb4cf2bb78ac5711214e2725900873accb23f3dfe5f9e7e5a06dcdc5f29605da976fc45c26d9a13ca334d6eea2245a15e77b8fc06e
+  languageName: node
+  linkType: hard
+
+"zx@npm:^8.1.4":
+  version: 8.1.9
+  resolution: "zx@npm:8.1.9"
+  dependencies:
+    "@types/fs-extra": "npm:>=11"
+    "@types/node": "npm:>=20"
+  dependenciesMeta:
+    "@types/fs-extra":
+      optional: true
+    "@types/node":
+      optional: true
+  bin:
+    zx: build/cli.js
+  checksum: 10c0/b11f0e75b8ed618ededc88ecba1d01bc1415bb6966bd68539f8b47bb13d7bf43bf7b64a80798b0cafb308742a19c14df2b08a09ca60703f227bc1a6122547556
   languageName: node
   linkType: hard


### PR DESCRIPTION
- Reapplies the changes from `docs: add Google-style docstring parser` from [SDK](https://github.com/apify/apify-sdk-python/commit/2e000e9c6889d5c41f28a07414cd84505e9d00b1) (renders commented function arguments)

![obrazek](https://github.com/user-attachments/assets/bc24a827-716e-46c9-9ed3-d8db3fdba9e6)


- Renders the object attributes (from the class docstring)
- Documents class inheritance properly now
![obrazek](https://github.com/user-attachments/assets/3ad63da3-25fd-4069-b071-28bb90fd85a1)

- Renders inherited symbols (e.g. `BasicCrawler` symbols in `HttpCrawler`)

---

Missing:
- `Unpack[]`, union types and similar -> we might need `griffe` to parse the code better, `pydoc-markdown` stops at the return type "name", doesn't parse the syntax.
- Validation against the linked issue, see whether there's anything else missing

Relates #324 
