### PR TITLE
Introducing Crawlee Python Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@
     <a href="https://discord.gg/jyEM2PRvMU" rel="nofollow">
         <img src="https://img.shields.io/discord/801163717915574323?label=discord" alt="Chat on discord" style="max-width: 100%;">
     </a>
+    <a href="https://gurubase.io/g/crawlee-python" rel="nofollow">
+        <img src="https://img.shields.io/badge/Gurubase-Ask%20Crawlee%20Python%20Guru-006BFF" alt="Ask Crawlee Guru on Gurubase" style="max-width: 100%;">
+    </a>
 </p>
 
 Crawlee covers your crawling and scraping end-to-end and **helps you build reliable scrapers. Fast.**


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Crawlee Python Guru](https://gurubase.io/g/crawlee-python) to Gurubase. Crawlee Python Guru uses the data from this repo and data from the [docs](https://crawlee.dev/python/docs/quick-start) to answer questions by leveraging the LLM.

In this PR, I showcased the "Crawlee Python Guru", which highlights that Crawlee Python now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Crawlee Python Guru in Gurubase, just let me know that's totally fine.