### PR TITLE
fix: Default ProxyInfo port if httpx.URL port is None

### DIFF
--- a/src/crawlee/proxy_configuration.py
+++ b/src/crawlee/proxy_configuration.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from httpx import URL
@@ -121,12 +121,17 @@ class ProxyConfiguration:
         if url is None:
             return None
 
+        # httpx.URL port field is None for default ports
         default_ports = {'http': 80, 'https': 443}
+        port = url.port or default_ports.get(url.scheme)
+        if port is None:
+            raise ValueError(f'Port is None for URL: {url}')
+
         info = ProxyInfo(
             url=str(url),
             scheme=url.scheme,
             hostname=url.host,
-            port=cast(int, url.port or default_ports.get(url.scheme, None)),
+            port=port,
             username=url.username,
             password=url.password,
         )

--- a/src/crawlee/proxy_configuration.py
+++ b/src/crawlee/proxy_configuration.py
@@ -121,11 +121,12 @@ class ProxyConfiguration:
         if url is None:
             return None
 
+        default_ports = {'http': 80, 'https': 443}
         info = ProxyInfo(
             url=str(url),
             scheme=url.scheme,
             hostname=url.host,
-            port=cast(int, url.port),
+            port=cast(int, url.port or default_ports.get(url.scheme, None)),
             username=url.username,
             password=url.password,
         )

--- a/tests/unit/proxy_configuration/test_new_proxy_info.py
+++ b/tests/unit/proxy_configuration/test_new_proxy_info.py
@@ -120,3 +120,26 @@ async def test_rotates_proxies_with_sessions() -> None:
     info = await config.new_proxy_info(sessions[5], None, None)
     assert info is not None
     assert info.url == proxy_urls[2]
+
+
+@pytest.mark.parametrize(
+    ('url', 'expected_port'),
+    [
+        # Default ports based on the URL scheme
+        ('http://proxy.com', 80),
+        ('https://proxy.com', 443),
+        # Explicit ports specified in the URL
+        ('http://proxy.com:80', 80),
+        ('http://proxy.com:1234', 1234),
+    ],
+)
+async def test_sets_port(url: str, expected_port: int) -> None:
+    """Test that the port property is set correctly.
+
+    The port is inferred from the URL scheme if it is not specified in the URL.
+    """
+    config = ProxyConfiguration(proxy_urls=[url])
+
+    info = await config.new_proxy_info(None, None, None)
+    assert info is not None
+    assert info.port == expected_port


### PR DESCRIPTION

### Description

Fixes an issue where the string `:None` was being appended to Playwright Proxy configurations.

```
proxy_info: {'server': 'http://p.webshare.io:None', 'username': 'foo', 'password': 'bar'}
```

Neither Firefox or Chrome were able to use a proxy URL like `http://foo:bar@p.webshare.io:80/`, because the :80 was being stripped off by HTTPX. `httpx.URL.port` cannot be set to 80 (for HTTP) or 443 (HTTPS), see example below.

This change explicitly sets the proxy port if it's unset.

```
In [1]: from httpx import URL

In [2]: url = URL(scheme="http", host="example.com", port=8080)

In [3]: url.port
Out[3]: 8080

In [4]: url = URL(scheme="http", host="example.com", port=80)

In [5]: url.port

In [6]: url = URL(scheme="http", host="example.com", port=443)

In [7]: url.port
Out[7]: 443

In [8]: url = URL(scheme="https", host="example.com", port=443)

In [9]: url.port
```

### Issues

Closes #618 

### Testing

Tested locally, Firefox is now able to load pages using a proxy with port 80.

### Checklist

- [x] CI passed
