### PR TITLE
feat: Add `always_enqueue` option to bypass URL deduplication

### DIFF
--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -306,6 +306,7 @@ class Request(BaseRequestData):
             use_extended_unique_key: Determines whether to include the HTTP method and payload in the `unique_key`
                 computation. This is only relevant when `unique_key` is not provided.
             always_enqueue: If set to `True`, the request will be enqueued even if it is already present in the queue.
+                Using this is not allowed when a custom `unique_key` is also provided and will result in a `ValueError`.
             **kwargs: Additional request properties.
         """
         if unique_key is not None and always_enqueue:

--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -324,7 +324,7 @@ class Request(BaseRequestData):
         )
         
         if always_enqueue:
-            unique_key += f'_{crypto_random_object_id()}'
+            unique_key = f'{unique_key}_{crypto_random_object_id()}'
 
         id = id or unique_key_to_request_id(unique_key)
 

--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -20,9 +20,9 @@ from pydantic import (
 from typing_extensions import Self
 
 from crawlee._types import EnqueueStrategy, HttpHeaders, HttpMethod, HttpPayload, HttpQueryParams, JsonSerializable
+from crawlee._utils.crypto import crypto_random_object_id
 from crawlee._utils.requests import compute_unique_key, unique_key_to_request_id
 from crawlee._utils.urls import extract_query_params, validate_http_url
-from crawlee._utils.crypto import crypto_random_object_id
 
 
 class RequestState(IntEnum):
@@ -322,7 +322,7 @@ class Request(BaseRequestData):
             keep_url_fragment=keep_url_fragment,
             use_extended_unique_key=use_extended_unique_key,
         )
-        
+
         if always_enqueue:
             unique_key = f'{unique_key}_{crypto_random_object_id()}'
 

--- a/tests/unit/storages/test_request_queue.py
+++ b/tests/unit/storages/test_request_queue.py
@@ -214,3 +214,40 @@ async def test_complex_user_data_serialization(request_queue: RequestQueue) -> N
         'maxRetries': 1,
         'state': RequestState.ERROR_HANDLER,
     }
+
+
+async def test_deduplication_of_requests_with_custom_unique_key() -> None:
+    with pytest.raises(ValueError, match='always_enqueue cannot be used with a custom unique_key'):
+        await Request.from_url('https://apify.com', unique_key='apify', always_enqueue=True)
+
+    await Request.from_url('https://apify.com', unique_key='apify', always_enqueue=False)
+
+    with pytest.raises(ValueError, match='Request with unique key "apify" is already present in the queue!'):
+        await Request.from_url('https://apify.com', unique_key='apify', always_enqueue=False)
+
+
+async def test_deduplication_of_requests_with_invalid_custom_unique_key() -> None:
+    request_1 = Request.from_url('https://apify.com', always_enqueue=True)
+    request_2 = Request.from_url('https://apify.com', always_enqueue=True)
+
+    rq = await RequestQueue.open(name='my-rq')
+    await rq.add_request(request_1)
+    await rq.add_request(request_2)
+
+    assert await rq.get_total_count() == 2
+
+    assert await rq.fetch_next_request() == request_1
+    assert await rq.fetch_next_request() == request_2
+
+
+async def test_deduplication_of_requests_with_valid_custom_unique_key() -> None:
+    request_1 = Request.from_url('https://apify.com')
+    request_2 = Request.from_url('https://apify.com')
+
+    rq = await RequestQueue.open(name='my-rq')
+    await rq.add_request(request_1)
+    await rq.add_request(request_2)
+
+    assert await rq.get_total_count() == 1
+
+    assert await rq.fetch_next_request() == request_1

--- a/tests/unit/storages/test_request_queue.py
+++ b/tests/unit/storages/test_request_queue.py
@@ -217,13 +217,8 @@ async def test_complex_user_data_serialization(request_queue: RequestQueue) -> N
 
 
 async def test_deduplication_of_requests_with_custom_unique_key() -> None:
-    with pytest.raises(ValueError, match='always_enqueue cannot be used with a custom unique_key'):
-        await Request.from_url('https://apify.com', unique_key='apify', always_enqueue=True)
-
-    await Request.from_url('https://apify.com', unique_key='apify', always_enqueue=False)
-
-    with pytest.raises(ValueError, match='Request with unique key "apify" is already present in the queue!'):
-        await Request.from_url('https://apify.com', unique_key='apify', always_enqueue=False)
+    with pytest.raises(ValueError, match='`always_enqueue` cannot be used with a custom `unique_key`'):
+        Request.from_url('https://apify.com', unique_key='apify', always_enqueue=True)
 
 
 async def test_deduplication_of_requests_with_invalid_custom_unique_key() -> None:


### PR DESCRIPTION
### Description

This PR implements a new input parameter, always_enqueue, in the Request.from_url constructor. This feature allows users to bypass the request deduplication process, ensuring that each request is always enqueued and processed.

Key Changes:

- Added the always_enqueue parameter to the Request.from_url method.
- When always_enqueue is set to true, a random unique key is generated for each request, preventing it from being considered a duplicate.
- This enhancement provides users with a convenient way to enqueue requests without worrying about deduplication.

With this addition, users can seamlessly manage their requests while maintaining flexibility in their queuing strategy.

### Issues

Fixes #547 

### Testing

The modifications can be verified by making requests to the same URL. The operations should execute each time this is done without treating it as a duplicate request when `always_enqueue` is set to true.

### Checklist

- [x] CI passed
