### PR TITLE
feat: Pass extra configuration to json.dump()

### DIFF
--- a/docs/examples/code/export_entire_dataset_to_file_csv.py
+++ b/docs/examples/code/export_entire_dataset_to_file_csv.py
@@ -30,7 +30,7 @@ async def main() -> None:
     await crawler.run(['https://crawlee.dev'])
 
     # Export the entire dataset to a CSV file.
-    await crawler.export_data('results.csv')
+    await crawler.export_data_csv(path='results.csv')
 
 
 if __name__ == '__main__':

--- a/docs/examples/code/export_entire_dataset_to_file_json.py
+++ b/docs/examples/code/export_entire_dataset_to_file_json.py
@@ -30,7 +30,7 @@ async def main() -> None:
     await crawler.run(['https://crawlee.dev'])
 
     # Export the entire dataset to a JSON file.
-    await crawler.export_data('results.json')
+    await crawler.export_data_json(path='results.json')
 
 
 if __name__ == '__main__':

--- a/docs/examples/code/parsel_crawler.py
+++ b/docs/examples/code/parsel_crawler.py
@@ -34,7 +34,7 @@ async def main() -> None:
     await crawler.run(['https://github.com'])
 
     # Export the entire dataset to a JSON file.
-    await crawler.export_data('results.json')
+    await crawler.export_data_json(path='results.json')
 
 
 if __name__ == '__main__':

--- a/src/crawlee/basic_crawler/_basic_crawler.py
+++ b/src/crawlee/basic_crawler/_basic_crawler.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
     from crawlee.proxy_configuration import ProxyConfiguration, ProxyInfo
     from crawlee.sessions import Session
     from crawlee.statistics import FinalStatistics, StatisticsState
-    from crawlee.storages._dataset import GetDataKwargs, PushDataKwargs
+    from crawlee.storages._dataset import GetDataKwargs, PushDataKwargs, ExportDataCsvKwargs, ExportDataJsonKwargs
     from crawlee.storages._request_provider import RequestProvider
 
 TCrawlingContext = TypeVar('TCrawlingContext', bound=BasicCrawlingContext, default=BasicCrawlingContext)
@@ -475,10 +475,18 @@ class BasicCrawler(Generic[TCrawlingContext]):
     async def export_data(
         self,
         path: str | Path,
-        content_type: Literal['json', 'csv'] | None = None,
+        *,
+        content_type: Literal['csv', 'json'] = 'csv',
         dataset_id: str | None = None,
         dataset_name: str | None = None,
+        **kwargs: Any,
     ) -> None:
+        if content_type == 'csv':
+            self.export_data_csv(path, dataset_id=dataset_id, dataset_name=dataset_name, **kwargs)
+        elif content_type == 'json':
+            self.export_data_json(path, dataset_id=dataset_id, dataset_name=dataset_name, **kwargs)
+        else:
+            raise ValueError(f'Unsupported content type: {content_type}.')
         """Export data from a dataset.
 
         This helper method simplifies the process of exporting data from a dataset. It opens the specified


### PR DESCRIPTION
### Description

This PR addresses the need for customizable export configurations when using the await crawler.export_data("export.json") method.

Key Changes:

- Introduced a new option in the export_data method to accept additional keyword arguments, allowing users to pass configurations directly to `json.dump()` and other export functions.
- Created dedicated export helper methods for different formats in the `BasicCrawler`, including `export_data_json` and `export_data_csv`. This separation enhances clarity and maintainability while providing format-specific options.

This enhancement improves the flexibility of data exports, enabling users to tailor their export settings to meet specific requirements.

### Issues

Fixes #526 

### Testing

Unit test cases are added to check the updated configuration and functionality.

### Checklist

- [x] CI passed
