### PR TITLE
feat: Add `pre_navigation_hooks` to `PlaywrightCrawler`

### DIFF
--- a/docs/examples/code/playwright_crawler.py
+++ b/docs/examples/code/playwright_crawler.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from crawlee.playwright_crawler import PlaywrightCrawler, PlaywrightCrawlingContext
+from crawlee.playwright_crawler import PlaywrightCrawler, PlaywrightCrawlingContext, PlaywrightPreNavigationContext
 
 
 async def main() -> None:
@@ -46,6 +46,14 @@ async def main() -> None:
 
         # Find a link to the next page and enqueue it if it exists.
         await context.enqueue_links(selector='.morelink')
+
+    # Define a hook that will be called each time before navigating to a new URL.
+    # The hook receives a context parameter, providing access to the request and
+    # browser page among other things. In this example, we log the URL being
+    # navigated to.
+    @crawler.pre_navigation_hook
+    async def log_navigation_url(context: PlaywrightPreNavigationContext) -> None:
+        context.log.info(f'Navigating to {context.request.url} ...')
 
     # Run the crawler with the initial list of URLs.
     await crawler.run(['https://news.ycombinator.com/'])

--- a/docs/examples/playwright_crawler.mdx
+++ b/docs/examples/playwright_crawler.mdx
@@ -12,6 +12,8 @@ This example demonstrates how to use <ApiLink to="class/PlaywrightCrawler">`Play
 
 The <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink> manages the browser and page instances, simplifying the process of interacting with web pages. In the request handler, Playwright's API is used to extract data from each post on the page. Specifically, it retrieves the title, rank, and URL of each post. Additionally, the handler enqueues links to the next pages to ensure continuous scraping. This setup is ideal for scraping dynamic web pages where JavaScript execution is required to render the content.
 
+A **pre-navigation hook** can be used to perform actions before navigating to the URL. This hook provides further flexibility in controlling environment and preparing for navigation.
+
 <CodeBlock className="language-python">
     {PlaywrightCrawlerExample}
 </CodeBlock>

--- a/src/crawlee/playwright_crawler/__init__.py
+++ b/src/crawlee/playwright_crawler/__init__.py
@@ -1,10 +1,11 @@
 try:
     from ._playwright_crawler import PlaywrightCrawler
     from ._playwright_crawling_context import PlaywrightCrawlingContext
+    from ._playwright_pre_navigation_context import PlaywrightPreNavigationContext
 except ImportError as exc:
     raise ImportError(
         "To import anything from this subpackage, you need to install the 'playwright' extra."
         "For example, if you use pip, run `pip install 'crawlee[playwright]'`.",
     ) from exc
 
-__all__ = ['PlaywrightCrawler', 'PlaywrightCrawlingContext']
+__all__ = ['PlaywrightCrawler', 'PlaywrightCrawlingContext', 'PlaywrightPreNavigationContext']

--- a/src/crawlee/playwright_crawler/_playwright_crawling_context.py
+++ b/src/crawlee/playwright_crawler/_playwright_crawling_context.py
@@ -3,21 +3,20 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Awaitable, Callable
 
-from crawlee._types import BasicCrawlingContext, EnqueueLinksFunction
+from crawlee.playwright_crawler._playwright_pre_navigation_context import PlaywrightPreNavigationContext
 
 if TYPE_CHECKING:
-    from playwright.async_api import Page, Response
+    from playwright.async_api import Response
+
+    from crawlee._types import EnqueueLinksFunction
 
 
 @dataclass(frozen=True)
-class PlaywrightCrawlingContext(BasicCrawlingContext):
+class PlaywrightCrawlingContext(PlaywrightPreNavigationContext):
     """The crawling context used by the `PlaywrightCrawler`.
 
     It provides access to key objects as well as utility functions for handling crawling tasks.
     """
-
-    page: Page
-    """The Playwright `Page` object for the current page."""
 
     response: Response
     """The Playwright `Response` object containing the response details for the current URL."""

--- a/src/crawlee/playwright_crawler/_playwright_pre_navigation_context.py
+++ b/src/crawlee/playwright_crawler/_playwright_pre_navigation_context.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from crawlee._types import BasicCrawlingContext
+
+if TYPE_CHECKING:
+    from playwright.async_api import Page
+
+
+@dataclass(frozen=True)
+class PlaywrightPreNavigationContext(BasicCrawlingContext):
+    """Context used by PlaywrightCrawler.
+
+    It Provides access to the `Page` object for the current browser page.
+    """
+
+    page: Page
+    """The Playwright `Page` object for the current page."""

--- a/tests/unit/playwright_crawler/test_playwright_crawler.py
+++ b/tests/unit/playwright_crawler/test_playwright_crawler.py
@@ -131,3 +131,18 @@ async def test_firefox_headless_headers() -> None:
     assert 'headless' not in headers['User-Agent'].lower()
 
     assert headers['User-Agent'] == PW_FIREFOX_HEADLESS_DEFAULT_USER_AGENT
+
+
+async def test_pre_navigation_hook() -> None:
+    crawler = PlaywrightCrawler()
+    mock_hook = mock.AsyncMock(return_value=None)
+
+    crawler.pre_navigation_hook(mock_hook)
+
+    @crawler.router.default_handler
+    async def request_handler(_context: PlaywrightCrawlingContext) -> None:
+        pass
+
+    await crawler.run(['https://example.com', 'https://httpbin.org'])
+
+    assert mock_hook.call_count == 2


### PR DESCRIPTION
### Description

<!-- The purpose of the PR, list of the changes, ... -->

Add a new decorator for processing pre navigation hooks

Example Use:
```python
from crawlee.playwright_crawler import PlaywrightCrawler
from .routes import router

async def main() -> None:
    """The crawler entry point."""
    crawler = PlaywrightCrawler(
        request_handler=router,
        max_requests_per_crawl=50,
    )

    @crawler.pre_navigation_hook
    async def hooky(context) -> None:
        print(f'Hook1')

    @crawler.pre_navigation_hook
    async def hooky2(context) -> None:
        print(f'Hook2')

    await crawler.run(
        [
            'https://crawlee.dev',
        ]
    )
```

### Issues

<!-- If applicable, reference any related GitHub issues -->

- Closes: #427

### Checklist

- [x] CI passed
