### PR TITLE
docs: smaller documentation fixes (GitHub links, type parsing etc.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ website/api-typedoc-generated.json
 website/apify-shared-docspec-dump.jsonl
 website/docspec-dump.jsonl
 website/module_shortcuts.json
+website/typedoc-types*
 
 storage
 pullRequestIssues.json

--- a/website/build_api_reference.sh
+++ b/website/build_api_reference.sh
@@ -1,18 +1,7 @@
 #!/bin/bash
 
-# On macOS, sed requires a space between -i and '' to specify no backup should be done
-# On Linux, sed requires no space between -i and '' to specify no backup should be done
-sed_no_backup() {
-    if [[ $(uname) = "Darwin" ]]; then
-        sed -i '' "$@"
-    else
-        sed -i'' "$@"
-    fi
-}
-
 # Create docspec dump of this package's source code through pydoc-markdown
 python ./pydoc-markdown/generate_ast.py > docspec-dump.jsonl
-sed_no_backup "s#${PWD}/..#REPO_ROOT_PLACEHOLDER#g" docspec-dump.jsonl
 
 rm -rf "${apify_shared_tempdir}"
 

--- a/website/package.json
+++ b/website/package.json
@@ -1,4 +1,5 @@
 {
+    "name": "crawlee",
     "scripts": {
         "examples": "docusaurus-examples",
         "postinstall": "npx patch-package",

--- a/website/package.json
+++ b/website/package.json
@@ -33,7 +33,7 @@
         "typescript": "5.6.2"
     },
     "dependencies": {
-        "@apify/docusaurus-plugin-typedoc-api": "^4.2.6",
+        "@apify/docusaurus-plugin-typedoc-api": "^4.2.7",
         "@apify/utilities": "^2.8.0",
         "@docusaurus/core": "^3.5.2",
         "@docusaurus/mdx-loader": "^3.5.2",

--- a/website/parse_types.py
+++ b/website/parse_types.py
@@ -1,0 +1,82 @@
+"""
+Given a JSON file containing a list of expressions, this script will parse each expression and output a JSON file containing an object with the parsed expressions.
+Called from transformDocs.js.
+
+Accepts one CLI argument: the path to the JSON file containing the expressions to parse.
+"""
+
+import ast 
+import json
+import sys
+import os
+
+base_scalar_types = {
+    "str",
+    "int",
+    "float",
+    "bool",
+    "bytearray",
+    "timedelta",
+    "None",
+}
+
+def parse_expression(ast_node, full_expression):
+    """
+    Turns the AST expression object into a typedoc-compliant dict
+    """
+
+    current_node_type = ast_node.__class__.__name__
+    
+    if (current_node_type == "BinOp" and ast_node.op.__class__.__name__ == "BitOr"):
+        return {
+            "type": "union",
+            "types": [
+                parse_expression(ast_node.left, full_expression),
+                parse_expression(ast_node.right, full_expression)
+            ]
+        }
+
+    if (current_node_type == "Tuple"):
+        return [parse_expression(e, full_expression) for e in ast_node.elts]
+    
+    if (current_node_type == "Subscript"):
+        if ('id' in ast_node.value._fields and ast_node.value.id == 'Annotated'):
+            return parse_expression(ast_node.slice.dims[0], full_expression)
+
+        main_type = parse_expression(ast_node.value, full_expression)
+        type_argument = parse_expression(ast_node.slice, full_expression)
+
+        main_type['typeArguments'] = type_argument if isinstance(type_argument, list) else [type_argument]
+        return main_type
+    
+    if (current_node_type == "Constant"):
+        return {
+            "type": "literal",
+            "value": ast_node.value
+        }
+    
+    # If the expression is not one of the types above, we simply print the expression
+    return {
+        "type": "reference",
+        "name": full_expression[ast_node.col_offset:ast_node.end_col_offset]
+    }
+
+typedoc_types_path = sys.argv[1]
+
+with open(typedoc_types_path, "r") as f:
+    typedoc_out = {}
+    expressions = f.read()
+
+    expressions = json.loads(expressions)
+
+    for expression in expressions:
+        try:
+            if(typedoc_out.get(expression) is None):
+                typedoc_out[expression] = parse_expression(ast.parse(expression).body[0].value, expression)
+        except Exception as e:
+            print(f"Invalid expression encountered while parsing: {expression}")
+            print(f"Error: {e}")
+    
+    with open(f"{os.path.splitext(typedoc_types_path)[0]}-parsed.json", "w") as f:
+        f.write(json.dumps(typedoc_out, indent=4))
+    

--- a/website/parse_types.py
+++ b/website/parse_types.py
@@ -66,9 +66,7 @@ typedoc_types_path = sys.argv[1]
 
 with open(typedoc_types_path, "r") as f:
     typedoc_out = {}
-    expressions = f.read()
-
-    expressions = json.loads(expressions)
+    expressions = json.load(f)
 
     for expression in expressions:
         try:

--- a/website/parse_types.py
+++ b/website/parse_types.py
@@ -5,7 +5,7 @@ Called from transformDocs.js.
 Accepts one CLI argument: the path to the JSON file containing the expressions to parse.
 """
 
-import ast 
+import ast
 import json
 import sys
 import os
@@ -20,46 +20,47 @@ base_scalar_types = {
     "None",
 }
 
+
 def parse_expression(ast_node, full_expression):
     """
     Turns the AST expression object into a typedoc-compliant dict
     """
 
     current_node_type = ast_node.__class__.__name__
-    
-    if (current_node_type == "BinOp" and ast_node.op.__class__.__name__ == "BitOr"):
+
+    if current_node_type == "BinOp" and ast_node.op.__class__.__name__ == "BitOr":
         return {
             "type": "union",
             "types": [
                 parse_expression(ast_node.left, full_expression),
-                parse_expression(ast_node.right, full_expression)
-            ]
+                parse_expression(ast_node.right, full_expression),
+            ],
         }
 
-    if (current_node_type == "Tuple"):
+    if current_node_type == "Tuple":
         return [parse_expression(e, full_expression) for e in ast_node.elts]
-    
-    if (current_node_type == "Subscript"):
-        if ('id' in ast_node.value._fields and ast_node.value.id == 'Annotated'):
+
+    if current_node_type == "Subscript":
+        if "id" in ast_node.value._fields and ast_node.value.id == "Annotated":
             return parse_expression(ast_node.slice.dims[0], full_expression)
 
         main_type = parse_expression(ast_node.value, full_expression)
         type_argument = parse_expression(ast_node.slice, full_expression)
 
-        main_type['typeArguments'] = type_argument if isinstance(type_argument, list) else [type_argument]
+        main_type["typeArguments"] = (
+            type_argument if isinstance(type_argument, list) else [type_argument]
+        )
         return main_type
-    
-    if (current_node_type == "Constant"):
-        return {
-            "type": "literal",
-            "value": ast_node.value
-        }
-    
+
+    if current_node_type == "Constant":
+        return {"type": "literal", "value": ast_node.value}
+
     # If the expression is not one of the types above, we simply print the expression
     return {
         "type": "reference",
-        "name": full_expression[ast_node.col_offset:ast_node.end_col_offset]
+        "name": full_expression[ast_node.col_offset : ast_node.end_col_offset],
     }
+
 
 typedoc_types_path = sys.argv[1]
 
@@ -71,12 +72,13 @@ with open(typedoc_types_path, "r") as f:
 
     for expression in expressions:
         try:
-            if(typedoc_out.get(expression) is None):
-                typedoc_out[expression] = parse_expression(ast.parse(expression).body[0].value, expression)
+            if typedoc_out.get(expression) is None:
+                typedoc_out[expression] = parse_expression(
+                    ast.parse(expression).body[0].value, expression
+                )
         except Exception as e:
             print(f"Invalid expression encountered while parsing: {expression}")
             print(f"Error: {e}")
-    
+
     with open(f"{os.path.splitext(typedoc_types_path)[0]}-parsed.json", "w") as f:
         f.write(json.dumps(typedoc_out, indent=4))
-    

--- a/website/pydoc-markdown/generate_ast.py
+++ b/website/pydoc-markdown/generate_ast.py
@@ -15,7 +15,7 @@ from docspec import dump_module
 import json
 import os
 
-project_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../src')
+project_path = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../src'))
 
 context = Context(directory='.')
 loader = PythonLoader(search_path=[project_path])
@@ -43,4 +43,11 @@ for processor in processors:
 for module in modules:
     dump.append(dump_module(module))
 
-print(json.dumps(dump, indent=4))
+repo_root_path = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../'))
+
+print(
+    json.dumps(dump, indent=4).replace(
+        repo_root_path,
+        'REPO_ROOT_PLACEHOLDER'
+    )
+)

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -5189,6 +5189,51 @@ __metadata:
   languageName: node
   linkType: hard
 
+"crawlee@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "crawlee@workspace:."
+  dependencies:
+    "@apify/docusaurus-plugin-typedoc-api": "npm:^4.2.7"
+    "@apify/eslint-config-ts": "npm:^0.4.0"
+    "@apify/tsconfig": "npm:^0.1.0"
+    "@apify/utilities": "npm:^2.8.0"
+    "@docusaurus/core": "npm:^3.5.2"
+    "@docusaurus/mdx-loader": "npm:^3.5.2"
+    "@docusaurus/module-type-aliases": "npm:3.4.0"
+    "@docusaurus/plugin-client-redirects": "npm:^3.5.2"
+    "@docusaurus/preset-classic": "npm:^3.5.2"
+    "@docusaurus/types": "npm:3.4.0"
+    "@giscus/react": "npm:^3.0.0"
+    "@mdx-js/react": "npm:^3.0.1"
+    "@types/react": "npm:^18.0.28"
+    "@typescript-eslint/eslint-plugin": "npm:8.2.0"
+    "@typescript-eslint/parser": "npm:8.2.0"
+    axios: "npm:^1.5.0"
+    buffer: "npm:^6.0.3"
+    clsx: "npm:^2.0.0"
+    crypto-browserify: "npm:^3.12.0"
+    docusaurus-gtm-plugin: "npm:^0.0.2"
+    eslint: "npm:8.57.0"
+    eslint-plugin-react: "npm:7.37.1"
+    eslint-plugin-react-hooks: "npm:4.6.2"
+    fs-extra: "npm:^11.1.0"
+    patch-package: "npm:^8.0.0"
+    path-browserify: "npm:^1.0.1"
+    prettier: "npm:^3.0.0"
+    prism-react-renderer: "npm:^2.1.0"
+    process: "npm:^0.11.10"
+    prop-types: "npm:^15.8.1"
+    raw-loader: "npm:^4.0.2"
+    react: "npm:^18.2.0"
+    react-dom: "npm:^18.2.0"
+    react-lite-youtube-embed: "npm:^2.3.52"
+    rimraf: "npm:^6.0.0"
+    stream-browserify: "npm:^3.0.0"
+    typescript: "npm:5.6.2"
+    unist-util-visit: "npm:^5.0.0"
+  languageName: unknown
+  linkType: soft
+
 "create-ecdh@npm:^4.0.0":
   version: 4.0.4
   resolution: "create-ecdh@npm:4.0.4"
@@ -12525,51 +12570,6 @@ __metadata:
   checksum: 10c0/f6f0df78817e78287c766687aed4d5accbebc308a8e7e673fb085b9977473c1f139f0c5335d353f172a915bb288098430755d2ad3c4f30612f4dd0c901cd2c3a
   languageName: node
   linkType: hard
-
-"root-workspace-0b6124@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "root-workspace-0b6124@workspace:."
-  dependencies:
-    "@apify/docusaurus-plugin-typedoc-api": "npm:^4.2.7"
-    "@apify/eslint-config-ts": "npm:^0.4.0"
-    "@apify/tsconfig": "npm:^0.1.0"
-    "@apify/utilities": "npm:^2.8.0"
-    "@docusaurus/core": "npm:^3.5.2"
-    "@docusaurus/mdx-loader": "npm:^3.5.2"
-    "@docusaurus/module-type-aliases": "npm:3.4.0"
-    "@docusaurus/plugin-client-redirects": "npm:^3.5.2"
-    "@docusaurus/preset-classic": "npm:^3.5.2"
-    "@docusaurus/types": "npm:3.4.0"
-    "@giscus/react": "npm:^3.0.0"
-    "@mdx-js/react": "npm:^3.0.1"
-    "@types/react": "npm:^18.0.28"
-    "@typescript-eslint/eslint-plugin": "npm:8.2.0"
-    "@typescript-eslint/parser": "npm:8.2.0"
-    axios: "npm:^1.5.0"
-    buffer: "npm:^6.0.3"
-    clsx: "npm:^2.0.0"
-    crypto-browserify: "npm:^3.12.0"
-    docusaurus-gtm-plugin: "npm:^0.0.2"
-    eslint: "npm:8.57.0"
-    eslint-plugin-react: "npm:7.37.1"
-    eslint-plugin-react-hooks: "npm:4.6.2"
-    fs-extra: "npm:^11.1.0"
-    patch-package: "npm:^8.0.0"
-    path-browserify: "npm:^1.0.1"
-    prettier: "npm:^3.0.0"
-    prism-react-renderer: "npm:^2.1.0"
-    process: "npm:^0.11.10"
-    prop-types: "npm:^15.8.1"
-    raw-loader: "npm:^4.0.2"
-    react: "npm:^18.2.0"
-    react-dom: "npm:^18.2.0"
-    react-lite-youtube-embed: "npm:^2.3.52"
-    rimraf: "npm:^6.0.0"
-    stream-browserify: "npm:^3.0.0"
-    typescript: "npm:5.6.2"
-    unist-util-visit: "npm:^5.0.0"
-  languageName: unknown
-  linkType: soft
 
 "rtl-detect@npm:^1.0.4":
   version: 1.1.2

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -223,9 +223,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apify/docusaurus-plugin-typedoc-api@npm:^4.2.6":
-  version: 4.2.6
-  resolution: "@apify/docusaurus-plugin-typedoc-api@npm:4.2.6"
+"@apify/docusaurus-plugin-typedoc-api@npm:^4.2.7":
+  version: 4.2.7
+  resolution: "@apify/docusaurus-plugin-typedoc-api@npm:4.2.7"
   dependencies:
     "@docusaurus/plugin-content-docs": "npm:^3.5.2"
     "@docusaurus/types": "npm:^3.5.2"
@@ -241,7 +241,7 @@ __metadata:
     "@docusaurus/mdx-loader": ^3.5.2
     react: ">=18.0.0"
     typescript: ^5.0.0
-  checksum: 10c0/93bd5e1d7ded644520bed15733b44e9e5547f04d7dd3c46a7137b950e17ceb6fabff41b85da659aeaf299d2026962a6d35be46c9041929dc5ba4388afd718aeb
+  checksum: 10c0/0ed51d0b454bb476ee72b9a6fd57eabd1ccfff20c56f0a713eab38d059c5cca1254b7b310d71a05b1b4e6c936c118ea261d59ff3e3a40724aed7a43b9d5c8940
   languageName: node
   linkType: hard
 
@@ -12530,7 +12530,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@apify/docusaurus-plugin-typedoc-api": "npm:^4.2.6"
+    "@apify/docusaurus-plugin-typedoc-api": "npm:^4.2.7"
     "@apify/eslint-config-ts": "npm:^0.4.0"
     "@apify/tsconfig": "npm:^0.1.0"
     "@apify/utilities": "npm:^2.8.0"


### PR DESCRIPTION
Fixes more issues from #324 .

Namely: 
- Fixes broken GitHub links
- Correctly parses parameter / return types with Python's `ast` module
- Handles inheritance better (copies parent's docstring on `@override` methods)
- Using `@apify/docusaurus-plugin-typedoc-api@4.2.7`, expands the `Unpack` types and further simplifies other helper types (`NotRequired`, `Optional` etc.).