### PR TITLE
chore: delete TODO comment

### DIFF
--- a/src/crawlee/storages/_dataset.py
+++ b/src/crawlee/storages/_dataset.py
@@ -281,8 +281,6 @@ class Dataset(BaseStorage):
         Returns:
             List page containing filtered and paginated dataset items.
         """
-        # TODO: Improve error handling here
-        # https://github.com/apify/apify-sdk-python/issues/140
         return await self._resource_client.list_items(**kwargs)
 
     async def write_to_csv(self, destination: TextIO, **kwargs: Unpack[ExportDataCsvKwargs]) -> None:


### PR DESCRIPTION
### Description

Deleted TODO comment.

Since handle on exceeding string length used in TS implementation is not relevant for Python because there is no maximum string length

### Issues

- Closes: #455

