### PR TITLE
feat: If custom logger is set, pass to the AutoScaledPool

### DIFF
--- a/src/crawlee/basic_crawler/_basic_crawler.py
+++ b/src/crawlee/basic_crawler/_basic_crawler.py
@@ -257,6 +257,7 @@ class BasicCrawler(Generic[TCrawlingContext]):
             is_task_ready_function=self.__is_task_ready_function,
             run_task_function=self.__run_task_function,
             concurrency_settings=concurrency_settings,
+            logger=_logger,
         )
 
         self._use_session_pool = use_session_pool


### PR DESCRIPTION
### Description
Even if I use a custom logger object to set the logs in my Crawlee instance, for the AutoScaled logs, it still uses the default logger. Ideally, when I am passing it to Crawlee, then it should also be internally shared across other subclasses.

Changed the AutoScaledPool constructor to also accept logger instance, if not sent, then create a new logger.

### Issues
Can be loosely said to improve logging for (https://github.com/apify/crawlee-python/issues/157)

### Testing
Need a little help/time to figure out why `test_emit_system_info_event` is breaking.

### Checklist
- [ ] CI passed
