### PR TITLE
fix: Fix serialization payload in Request. Fix Docs for Post Request

### DIFF
--- a/docs/examples/code/fill_and_submit_web_form_crawler.py
+++ b/docs/examples/code/fill_and_submit_web_form_crawler.py
@@ -1,5 +1,5 @@
 import asyncio
-import urllib.parse
+from urllib.parse import urlencode
 
 from crawlee import Request
 from crawlee.http_crawler import HttpCrawler, HttpCrawlingContext
@@ -20,7 +20,7 @@ async def main() -> None:
         url='https://httpbin.org/post',
         method='POST',
         headers={'content-type': 'application/x-www-form-urlencoded'},
-        payload=urllib.parse.urlencode(
+        payload=urlencode(
             {
                 'custname': 'John Doe',
                 'custtel': '1234567890',

--- a/docs/examples/code/fill_and_submit_web_form_crawler.py
+++ b/docs/examples/code/fill_and_submit_web_form_crawler.py
@@ -1,5 +1,5 @@
 import asyncio
-import json
+import urllib.parse
 
 from crawlee import Request
 from crawlee.http_crawler import HttpCrawler, HttpCrawlingContext
@@ -19,7 +19,8 @@ async def main() -> None:
     request = Request.from_url(
         url='https://httpbin.org/post',
         method='POST',
-        payload=json.dumps(
+        headers={'content-type': 'application/x-www-form-urlencoded'},
+        payload=urllib.parse.urlencode(
             {
                 'custname': 'John Doe',
                 'custtel': '1234567890',

--- a/docs/examples/code/fill_and_submit_web_form_request.py
+++ b/docs/examples/code/fill_and_submit_web_form_request.py
@@ -1,4 +1,4 @@
-import urllib.parse
+from urllib.parse import urlencode
 
 from crawlee import Request
 
@@ -7,7 +7,7 @@ request = Request.from_url(
     url='https://httpbin.org/post',
     method='POST',
     headers={'content-type': 'application/x-www-form-urlencoded'},
-    payload=urllib.parse.urlencode(
+    payload=urlencode(
         {
             'custname': 'John Doe',
             'custtel': '1234567890',

--- a/docs/examples/code/fill_and_submit_web_form_request.py
+++ b/docs/examples/code/fill_and_submit_web_form_request.py
@@ -1,4 +1,4 @@
-import json
+import urllib.parse
 
 from crawlee import Request
 
@@ -6,7 +6,8 @@ from crawlee import Request
 request = Request.from_url(
     url='https://httpbin.org/post',
     method='POST',
-    payload=json.dumps(
+    headers={'content-type': 'application/x-www-form-urlencoded'},
+    payload=urllib.parse.urlencode(
         {
             'custname': 'John Doe',
             'custtel': '1234567890',

--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -16,6 +16,8 @@ from pydantic import (
     PlainSerializer,
     PlainValidator,
     TypeAdapter,
+    field_serializer,
+    field_validator,
 )
 from typing_extensions import Self
 
@@ -175,6 +177,20 @@ class BaseRequestData(BaseModel):
 
     handled_at: Annotated[datetime | None, Field(alias='handledAt')] = None
     """Timestamp when the request was handled."""
+
+    @field_validator('payload', mode='before')
+    @classmethod
+    def _payload_validation(cls, v: str | bytes | None) -> bytes | None:
+        if isinstance(v, str):
+            v = v.encode()
+        return v
+
+    @field_serializer('payload')
+    @classmethod
+    def _payload_serializer(cls, v: bytes | None) -> str | None:
+        if isinstance(v, bytes):
+            return v.decode()
+        return None
 
     @classmethod
     def from_url(

--- a/tests/unit/_memory_storage_client/test_request_queue_client.py
+++ b/tests/unit/_memory_storage_client/test_request_queue_client.py
@@ -106,7 +106,6 @@ async def test_request_state_serialization(request_queue_client: RequestQueueCli
 
     assert request == got_request
     assert request.payload == got_request.payload
-    assert got_request.payload != b"b'test'"
 
 
 async def test_add_record(request_queue_client: RequestQueueClient) -> None:

--- a/tests/unit/_memory_storage_client/test_request_queue_client.py
+++ b/tests/unit/_memory_storage_client/test_request_queue_client.py
@@ -105,6 +105,8 @@ async def test_request_state_serialization(request_queue_client: RequestQueueCli
     got_request = await request_queue_client.get_request(request.id)
 
     assert request == got_request
+    assert request.payload == got_request.payload
+    assert got_request.payload != b"b'test'"
 
 
 async def test_add_record(request_queue_client: RequestQueueClient) -> None:

--- a/tests/unit/_memory_storage_client/test_request_queue_client.py
+++ b/tests/unit/_memory_storage_client/test_request_queue_client.py
@@ -93,13 +93,12 @@ async def test_list_head(request_queue_client: RequestQueueClient) -> None:
 
 
 async def test_request_state_serialization(request_queue_client: RequestQueueClient) -> None:
-    request = Request.from_url('https://crawlee.dev')
+    request = Request.from_url('https://crawlee.dev', payload=b'test')
     request.state = RequestState.UNPROCESSED
 
     await request_queue_client.add_request(request)
 
     result = await request_queue_client.list_head()
-
     assert len(result.items) == 1
     assert result.items[0] == request
 


### PR DESCRIPTION
### Description

An incorrect serialization for `payload` is happening now. `payload` is represented as a byte string, but bytes cannot be serialized to json. Therefore, when loading and unloading from the queue (`_persist_single_request_to_storage`, `_json_to_request`) we get strings of format “b'test'”

Also corrected the documentation, as when filling forms the data should be passed not in json format and have the appropriate header.

### Issues

- Closes: #668 

### Testing

Updated `test_request_state_serialization` to also take `payload` into account when serializing and deserializing `Request`

### Checklist

- [x] CI passed
