### PR TITLE
fix: respect custom HTTP headers in `PlaywrightCrawler`

### DIFF
--- a/src/crawlee/playwright_crawler/_playwright_crawler.py
+++ b/src/crawlee/playwright_crawler/_playwright_crawler.py
@@ -149,6 +149,8 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext]):
         """
         async with context.page:
             # Navigate to the URL and get response.
+            if context.request.headers:
+                await context.page.set_extra_http_headers(context.request.headers.model_dump())
             response = await context.page.goto(context.request.url)
 
             if response is None:

--- a/src/crawlee/playwright_crawler/_playwright_crawler.py
+++ b/src/crawlee/playwright_crawler/_playwright_crawler.py
@@ -148,9 +148,9 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext]):
                 infinite_scroll).
         """
         async with context.page:
-            # Navigate to the URL and get response.
             if context.request.headers:
                 await context.page.set_extra_http_headers(context.request.headers.model_dump())
+            # Navigate to the URL and get response.
             response = await context.page.goto(context.request.url)
 
             if response is None:

--- a/tests/unit/playwright_crawler/test_playwright_crawler.py
+++ b/tests/unit/playwright_crawler/test_playwright_crawler.py
@@ -135,20 +135,23 @@ async def test_firefox_headless_headers() -> None:
 
 async def test_custom_headers() -> None:
     crawler = PlaywrightCrawler()
-    headers = dict[str, str]()
-    custom_headers = {'Power-Header': 'ring', 'Library': 'storm', 'My-Test-Header': 'fuzz'}
+    response_headers = dict[str, str]()
+    request_headers = {'Power-Header': 'ring', 'Library': 'storm', 'My-Test-Header': 'fuzz'}
 
     @crawler.router.default_handler
     async def request_handler(context: PlaywrightCrawlingContext) -> None:
         response = await context.response.text()
-        response_headers = dict(json.loads(response)).get('headers', {})
+        context_response_headers = dict(json.loads(response)).get('headers', {})
 
-        for key, val in response_headers.items():
-            headers[key] = val
+        for key, val in context_response_headers.items():
+            response_headers[key] = val
 
-    await crawler.run([Request.from_url('https://httpbin.org/get', headers=custom_headers)])
-    for key, value in custom_headers.items():
-        assert headers[key] == value
+    await crawler.run([Request.from_url('https://httpbin.org/get', headers=request_headers)])
+
+    assert response_headers.get('Power-Header') == request_headers['Power-Header']
+    assert response_headers.get('Library') == request_headers['Library']
+    assert response_headers.get('My-Test-Header') == request_headers['My-Test-Header']
+    assert 'User-Agent' in response_headers
 
 
 async def test_pre_navigation_hook() -> None:

--- a/tests/unit/playwright_crawler/test_playwright_crawler.py
+++ b/tests/unit/playwright_crawler/test_playwright_crawler.py
@@ -151,7 +151,6 @@ async def test_custom_headers() -> None:
     assert response_headers.get('Power-Header') == request_headers['Power-Header']
     assert response_headers.get('Library') == request_headers['Library']
     assert response_headers.get('My-Test-Header') == request_headers['My-Test-Header']
-    assert 'User-Agent' in response_headers
 
 
 async def test_pre_navigation_hook() -> None:


### PR DESCRIPTION
### Description

add `Request.headers` support for `PlaywrightCrawler`. 

### Testing

The test uses `'https://httpbin.org/get' to ensure that the headers have been installed

### Checklist

- [x] CI passed
