### PR TITLE
fix: Fix init of context managers and context handling in `BasicCrawler`

### DIFF
--- a/src/crawlee/_autoscaling/snapshotter.py
+++ b/src/crawlee/_autoscaling/snapshotter.py
@@ -18,6 +18,7 @@ from crawlee._autoscaling.types import (
     Snapshot,
 )
 from crawlee._utils.byte_size import ByteSize
+from crawlee._utils.context import ensure_context
 from crawlee._utils.docs import docs_group
 from crawlee._utils.recurring_task import RecurringTask
 from crawlee.events._types import Event, EventSystemInfoData
@@ -114,6 +115,9 @@ class Snapshotter:
 
         self._timestamp_of_last_memory_warning: datetime = datetime.now(timezone.utc) - timedelta(hours=1)
 
+        # Flag to indicate the context state.
+        self._active = False
+
     @staticmethod
     def _get_sorted_list_by_created_at(input_list: list[T]) -> SortedList[T]:
         return SortedList(input_list, key=attrgetter('created_at'))
@@ -126,12 +130,22 @@ class Snapshotter:
         logger.info(f'Setting max_memory_size of this run to {max_memory_size}.')
         return max_memory_size
 
+    @property
+    def active(self) -> bool:
+        """Indicates whether the context is active."""
+        return self._active
+
     async def __aenter__(self) -> Snapshotter:
         """Starts capturing snapshots at configured intervals."""
-        self._event_manager.on(event=Event.SYSTEM_INFO, listener=self._snapshot_cpu)
-        self._event_manager.on(event=Event.SYSTEM_INFO, listener=self._snapshot_memory)
-        self._snapshot_event_loop_task.start()
-        self._snapshot_client_task.start()
+        if self._active:
+            logger.warning(f'The {self.__class__.__name__} is already active.')
+        else:
+            self._active = True
+            self._event_manager.on(event=Event.SYSTEM_INFO, listener=self._snapshot_cpu)
+            self._event_manager.on(event=Event.SYSTEM_INFO, listener=self._snapshot_memory)
+            self._snapshot_event_loop_task.start()
+            self._snapshot_client_task.start()
+
         return self
 
     async def __aexit__(
@@ -145,11 +159,16 @@ class Snapshotter:
         This method stops capturing snapshots of system resources (CPU, memory, event loop, and client information).
         It should be called to terminate resource capturing when it is no longer needed.
         """
-        self._event_manager.off(event=Event.SYSTEM_INFO, listener=self._snapshot_cpu)
-        self._event_manager.off(event=Event.SYSTEM_INFO, listener=self._snapshot_memory)
-        await self._snapshot_event_loop_task.stop()
-        await self._snapshot_client_task.stop()
+        if self._active:
+            self._event_manager.off(event=Event.SYSTEM_INFO, listener=self._snapshot_cpu)
+            self._event_manager.off(event=Event.SYSTEM_INFO, listener=self._snapshot_memory)
+            await self._snapshot_event_loop_task.stop()
+            await self._snapshot_client_task.stop()
+            self._active = False
+        else:
+            logger.warning(f'The {self.__class__.__name__} is not active.')
 
+    @ensure_context
     def get_memory_sample(self, duration: timedelta | None = None) -> list[Snapshot]:
         """Returns a sample of the latest memory snapshots.
 
@@ -162,6 +181,7 @@ class Snapshotter:
         snapshots = cast(list[Snapshot], self._memory_snapshots)
         return self._get_sample(snapshots, duration)
 
+    @ensure_context
     def get_event_loop_sample(self, duration: timedelta | None = None) -> list[Snapshot]:
         """Returns a sample of the latest event loop snapshots.
 
@@ -174,6 +194,7 @@ class Snapshotter:
         snapshots = cast(list[Snapshot], self._event_loop_snapshots)
         return self._get_sample(snapshots, duration)
 
+    @ensure_context
     def get_cpu_sample(self, duration: timedelta | None = None) -> list[Snapshot]:
         """Returns a sample of the latest CPU snapshots.
 
@@ -186,6 +207,7 @@ class Snapshotter:
         snapshots = cast(list[Snapshot], self._cpu_snapshots)
         return self._get_sample(snapshots, duration)
 
+    @ensure_context
     def get_client_sample(self, duration: timedelta | None = None) -> list[Snapshot]:
         """Returns a sample of the latest client snapshots.
 

--- a/src/crawlee/_utils/context.py
+++ b/src/crawlee/_utils/context.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import asyncio
+from functools import wraps
+from typing import Any, Callable, TypeVar
+
+T = TypeVar('T', bound=Callable[..., Any])
+
+
+def ensure_context(method: T) -> T:
+    """Decorator to ensure the (async) context manager is initialized before calling the method.
+
+    Args:
+        method: The method to wrap.
+
+    Returns:
+        The wrapped method with context checking applied.
+    """
+
+    @wraps(method)
+    def sync_wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+        if not hasattr(self, 'active'):
+            raise RuntimeError(f'The {self.__class__.__name__} does not have the "active" attribute.')
+
+        if not self.active:
+            raise RuntimeError(f'The {self.__class__.__name__} is not active. Use it within the context.')
+
+        return method(self, *args, **kwargs)
+
+    @wraps(method)
+    async def async_wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+        if not hasattr(self, 'active'):
+            raise RuntimeError(f'The {self.__class__.__name__} does not have the "active" attribute.')
+
+        if not self.active:
+            raise RuntimeError(f'The {self.__class__.__name__} is not active. Use it within the async context.')
+
+        return await method(self, *args, **kwargs)
+
+    return async_wrapper if asyncio.iscoroutinefunction(method) else sync_wrapper  # type: ignore[return-value]

--- a/src/crawlee/basic_crawler/_basic_crawler.py
+++ b/src/crawlee/basic_crawler/_basic_crawler.py
@@ -254,7 +254,7 @@ class BasicCrawler(Generic[TCrawlingContext]):
             else None,
             available_memory_ratio=self._configuration.available_memory_ratio,
         )
-        self._pool = AutoscaledPool(
+        self._autoscaled_pool = AutoscaledPool(
             system_status=SystemStatus(self._snapshotter),
             is_finished_function=self.__is_finished_function,
             is_task_ready_function=self.__is_task_ready_function,
@@ -441,7 +441,7 @@ class BasicCrawler(Generic[TCrawlingContext]):
 
             run_task.cancel()
 
-        run_task = asyncio.create_task(self._run_crawler())
+        run_task = asyncio.create_task(self._run_crawler(), name='run_crawler_task')
 
         with suppress(NotImplementedError):  # event loop signal handlers are not supported on Windows
             asyncio.get_running_loop().add_signal_handler(signal.SIGINT, sigint_handler)
@@ -475,18 +475,25 @@ class BasicCrawler(Generic[TCrawlingContext]):
         return final_statistics
 
     async def _run_crawler(self) -> None:
+        # Collect the context managers to be entered. Context managers that are already active are excluded,
+        # as they were likely entered by the caller, who will also be responsible for exiting them.
+        contexts_to_enter = [
+            cm
+            for cm in (
+                self._event_manager,
+                self._snapshotter,
+                self._statistics,
+                self._session_pool if self._use_session_pool else None,
+                *self._additional_context_managers,
+            )
+            if cm and getattr(cm, 'active', False) is False
+        ]
+
         async with AsyncExitStack() as exit_stack:
-            await exit_stack.enter_async_context(self._event_manager)
-            await exit_stack.enter_async_context(self._snapshotter)
-            await exit_stack.enter_async_context(self._statistics)
+            for context in contexts_to_enter:
+                await exit_stack.enter_async_context(context)
 
-            if self._use_session_pool:
-                await exit_stack.enter_async_context(self._session_pool)
-
-            for context_manager in self._additional_context_managers:
-                await exit_stack.enter_async_context(context_manager)
-
-            await self._pool.run()
+            await self._autoscaled_pool.run()
 
     async def add_requests(
         self,

--- a/src/crawlee/browsers/_base_browser_plugin.py
+++ b/src/crawlee/browsers/_base_browser_plugin.py
@@ -25,6 +25,11 @@ class BaseBrowserPlugin(ABC):
 
     @property
     @abstractmethod
+    def active(self) -> bool:
+        """Indicates whether the context is active."""
+
+    @property
+    @abstractmethod
     def browser_type(self) -> BrowserType:
         """Return the browser type name."""
 

--- a/src/crawlee/browsers/_base_browser_plugin.py
+++ b/src/crawlee/browsers/_base_browser_plugin.py
@@ -50,7 +50,11 @@ class BaseBrowserPlugin(ABC):
 
     @abstractmethod
     async def __aenter__(self) -> BaseBrowserPlugin:
-        """Enter the context manager and initialize the browser plugin."""
+        """Enter the context manager and initialize the browser plugin.
+
+        Raises:
+            RuntimeError: If the context manager is already active.
+        """
 
     @abstractmethod
     async def __aexit__(
@@ -59,7 +63,11 @@ class BaseBrowserPlugin(ABC):
         exc_value: BaseException | None,
         exc_traceback: TracebackType | None,
     ) -> None:
-        """Exit the context manager and close the browser plugin."""
+        """Exit the context manager and close the browser plugin.
+
+        Raises:
+            RuntimeError: If the context manager is not active.
+        """
 
     @abstractmethod
     async def new_browser(self) -> BaseBrowserController:

--- a/src/crawlee/browsers/_playwright_browser_plugin.py
+++ b/src/crawlee/browsers/_playwright_browser_plugin.py
@@ -87,11 +87,10 @@ class PlaywrightBrowserPlugin(BaseBrowserPlugin):
     @override
     async def __aenter__(self) -> PlaywrightBrowserPlugin:
         if self._active:
-            logger.warning(f'The {self.__class__.__name__} is already active.')
-        else:
-            self._active = True
-            self._playwright = await self._playwright_context_manager.__aenter__()
+            raise RuntimeError(f'The {self.__class__.__name__} is already active.')
 
+        self._active = True
+        self._playwright = await self._playwright_context_manager.__aenter__()
         return self
 
     @override
@@ -101,11 +100,11 @@ class PlaywrightBrowserPlugin(BaseBrowserPlugin):
         exc_value: BaseException | None,
         exc_traceback: TracebackType | None,
     ) -> None:
-        if self._active:
-            await self._playwright_context_manager.__aexit__(exc_type, exc_value, exc_traceback)
-            self._active = False
-        else:
-            logger.warning(f'The {self.__class__.__name__} is not active.')
+        if not self._active:
+            raise RuntimeError(f'The {self.__class__.__name__} is not active.')
+
+        await self._playwright_context_manager.__aexit__(exc_type, exc_value, exc_traceback)
+        self._active = False
 
     @override
     @ensure_context

--- a/src/crawlee/events/_event_manager.py
+++ b/src/crawlee/events/_event_manager.py
@@ -80,9 +80,15 @@ class EventManager:
             delay=self._persist_state_interval,
         )
 
+        # Flag to indicate the context state.
+        self._initialized = False
+
     async def __aenter__(self) -> EventManager:
         """Initializes the event manager upon entering the async context."""
-        self._emit_persist_state_event_rec_task.start()
+        if not self._initialized:
+            self._emit_persist_state_event_rec_task.start()
+            self._initialized = True
+
         return self
 
     async def __aexit__(
@@ -95,11 +101,13 @@ class EventManager:
 
         This will stop listening for the events, and it will wait for all the event listeners to finish.
         """
-        await self.wait_for_all_listeners_to_complete(timeout=self._close_timeout)
-        self._event_emitter.remove_all_listeners()
-        self._listener_tasks.clear()
-        self._listeners_to_wrappers.clear()
-        await self._emit_persist_state_event_rec_task.stop()
+        if self._initialized:
+            await self.wait_for_all_listeners_to_complete(timeout=self._close_timeout)
+            self._event_emitter.remove_all_listeners()
+            self._listener_tasks.clear()
+            self._listeners_to_wrappers.clear()
+            await self._emit_persist_state_event_rec_task.stop()
+            self._initialized = False
 
     def on(self, *, event: Event, listener: Listener) -> None:
         """Add an event listener to the event manager.
@@ -164,6 +172,9 @@ class EventManager:
             event: The event which will be emitted.
             event_data: The data which will be passed to the event listeners.
         """
+        if not self._initialized:
+            raise RuntimeError('The event manager is not initialized. Use it within an async context.')
+
         self._event_emitter.emit(event.value, event_data)
 
     async def wait_for_all_listeners_to_complete(self, *, timeout: timedelta | None = None) -> None:
@@ -173,6 +184,8 @@ class EventManager:
             timeout: The maximum time to wait for the event listeners to finish. If they do not complete within
                 the specified timeout, they will be canceled.
         """
+        if not self._initialized:
+            raise RuntimeError('The event manager is not initialized. Use it within an async context.')
 
         async def wait_for_listeners() -> None:
             """Gathers all listener tasks and awaits their completion, logging any exceptions encountered."""

--- a/src/crawlee/playwright_crawler/_utils.py
+++ b/src/crawlee/playwright_crawler/_utils.py
@@ -52,7 +52,7 @@ async def infinite_scroll(page: Page) -> None:
 
             await asyncio.sleep(1)
 
-    check_task = asyncio.create_task(check_finished())
+    check_task = asyncio.create_task(check_finished(), name='infinite_scroll_check_finished_task')
 
     try:
         while not finished:

--- a/src/crawlee/statistics/_statistics.py
+++ b/src/crawlee/statistics/_statistics.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Generic, cast
 from typing_extensions import Self, TypeVar
 
 import crawlee.service_container
+from crawlee._utils.context import ensure_context
 from crawlee._utils.docs import docs_group
 from crawlee._utils.recurring_task import RecurringTask
 from crawlee.events._types import Event, EventPersistStateData
@@ -103,20 +104,31 @@ class Statistics(Generic[TStatisticsState]):
         self._periodic_message_logger = periodic_message_logger or logger
         self._periodic_logger = RecurringTask(self._log, log_interval)
 
+        # Flag to indicate the context state.
+        self._active = False
+
+    @property
+    def active(self) -> bool:
+        """Indicates whether the context is active."""
+        return self._active
+
     async def __aenter__(self) -> Self:
         """Subscribe to events and start collecting statistics."""
-        self._instance_start = datetime.now(timezone.utc)
+        if self._active:
+            logger.warning(f'The {self.__class__.__name__} is already active.')
+        else:
+            self._active = True
+            self._instance_start = datetime.now(timezone.utc)
 
-        if self.state.crawler_started_at is None:
-            self.state.crawler_started_at = datetime.now(timezone.utc)
+            if self.state.crawler_started_at is None:
+                self.state.crawler_started_at = datetime.now(timezone.utc)
 
-        if self._key_value_store is None:
-            self._key_value_store = await KeyValueStore.open(name=self._persist_state_kvs_name)
+            if self._key_value_store is None:
+                self._key_value_store = await KeyValueStore.open(name=self._persist_state_kvs_name)
 
-        await self._maybe_load_statistics()
-        self._events.on(event=Event.PERSIST_STATE, listener=self._persist_state)
-
-        self._periodic_logger.start()
+            await self._maybe_load_statistics()
+            self._events.on(event=Event.PERSIST_STATE, listener=self._persist_state)
+            self._periodic_logger.start()
 
         return self
 
@@ -127,22 +139,29 @@ class Statistics(Generic[TStatisticsState]):
         exc_traceback: TracebackType | None,
     ) -> None:
         """Stop collecting statistics."""
-        self.state.crawler_finished_at = datetime.now(timezone.utc)
-        self._events.off(event=Event.PERSIST_STATE, listener=self._persist_state)
-        await self._periodic_logger.stop()
-        await self._persist_state(event_data=EventPersistStateData(is_migrating=False))
+        if self._active:
+            self.state.crawler_finished_at = datetime.now(timezone.utc)
+            self._events.off(event=Event.PERSIST_STATE, listener=self._persist_state)
+            await self._periodic_logger.stop()
+            await self._persist_state(event_data=EventPersistStateData(is_migrating=False))
+            self._active = False
+        else:
+            logger.warning(f'The {self.__class__.__name__} is not active.')
 
+    @ensure_context
     def register_status_code(self, code: int) -> None:
         """Increment the number of times a status code has been received."""
         self.state.requests_with_status_code.setdefault(str(code), 0)
         self.state.requests_with_status_code[str(code)] += 1
 
+    @ensure_context
     def record_request_processing_start(self, request_id_or_key: str) -> None:
         """Mark a request as started."""
         record = self._requests_in_progress.get(request_id_or_key, RequestProcessingRecord())
         record.run()
         self._requests_in_progress[request_id_or_key] = record
 
+    @ensure_context
     def record_request_processing_finish(self, request_id_or_key: str) -> None:
         """Mark a request as finished."""
         record = self._requests_in_progress.get(request_id_or_key)
@@ -162,6 +181,7 @@ class Statistics(Generic[TStatisticsState]):
 
         del self._requests_in_progress[request_id_or_key]
 
+    @ensure_context
     def record_request_processing_failure(self, request_id_or_key: str) -> None:
         """Mark a request as failed."""
         record = self._requests_in_progress.get(request_id_or_key)

--- a/src/crawlee/storages/_request_queue.py
+++ b/src/crawlee/storages/_request_queue.py
@@ -256,7 +256,9 @@ class RequestQueue(BaseStorage, RequestProvider):
                     await asyncio.sleep(wait_time_secs)
 
         # Create and start the task to process remaining batches in the background
-        remaining_batches_task = asyncio.create_task(_process_remaining_batches())
+        remaining_batches_task = asyncio.create_task(
+            _process_remaining_batches(), name='request_queue_process_remaining_batches_task'
+        )
         self._tasks.append(remaining_batches_task)
 
         # Wait for all tasks to finish if requested
@@ -519,7 +521,7 @@ class RequestQueue(BaseStorage, RequestProvider):
             return
 
         if self._list_head_and_lock_task is None:
-            task = asyncio.create_task(self._list_head_and_lock())
+            task = asyncio.create_task(self._list_head_and_lock(), name='request_queue_list_head_and_lock_task')
 
             def callback(_: Any) -> None:
                 self._list_head_and_lock_task = None

--- a/tests/unit/_autoscaling/test_autoscaled_pool.py
+++ b/tests/unit/_autoscaling/test_autoscaled_pool.py
@@ -1,4 +1,4 @@
-# ruff: noqa: FBT003 Boolean positional value in function call
+# ruff: noqa: FBT003  # Boolean positional value in function call
 
 from __future__ import annotations
 
@@ -74,7 +74,7 @@ async def test_abort_works(system_status: SystemStatus | Mock) -> None:
     )
 
     with measure_time() as elapsed:
-        run_task = asyncio.create_task(pool.run())
+        run_task = asyncio.create_task(pool.run(), name='pool run task')
         await asyncio.sleep(0.1)
         assert pool.current_concurrency == 10
         await pool.abort()

--- a/tests/unit/_autoscaling/test_snapshotter.py
+++ b/tests/unit/_autoscaling/test_snapshotter.py
@@ -111,6 +111,10 @@ async def test_methods_raise_error_when_not_active() -> None:
     with pytest.raises(RuntimeError, match='Snapshotter is not active.'):
         snapshotter.get_client_sample()
 
+    with pytest.raises(RuntimeError, match='Snapshotter is already active.'):
+        async with snapshotter, snapshotter:
+            pass
+
     async with snapshotter:
         snapshotter.get_cpu_sample()
         snapshotter.get_memory_sample()

--- a/tests/unit/browsers/test_browser_pool.py
+++ b/tests/unit/browsers/test_browser_pool.py
@@ -133,8 +133,17 @@ async def test_resource_management(httpbin: URL) -> None:
     assert page.page.is_closed()
 
 
-async def test_raises_error_when_not_initialized() -> None:
+async def test_methods_raise_error_when_not_active() -> None:
     plugin = PlaywrightBrowserPlugin()
     browser_pool = BrowserPool([plugin])
-    with pytest.raises(RuntimeError, match='Browser pool is not initialized.'):
+
+    assert browser_pool.active is False
+
+    with pytest.raises(RuntimeError, match='BrowserPool is not active.'):
         await browser_pool.new_page()
+
+    with pytest.raises(RuntimeError, match='BrowserPool is not active.'):
+        await browser_pool.new_page_with_each_plugin()
+
+    async with browser_pool:
+        assert browser_pool.active is True

--- a/tests/unit/browsers/test_browser_pool.py
+++ b/tests/unit/browsers/test_browser_pool.py
@@ -145,5 +145,9 @@ async def test_methods_raise_error_when_not_active() -> None:
     with pytest.raises(RuntimeError, match='BrowserPool is not active.'):
         await browser_pool.new_page_with_each_plugin()
 
+    with pytest.raises(RuntimeError, match='BrowserPool is already active.'):
+        async with browser_pool, browser_pool:
+            pass
+
     async with browser_pool:
         assert browser_pool.active is True

--- a/tests/unit/browsers/test_playwright_browser_plugin.py
+++ b/tests/unit/browsers/test_playwright_browser_plugin.py
@@ -60,5 +60,9 @@ async def test_methods_raise_error_when_not_active() -> None:
     with pytest.raises(RuntimeError, match='Plugin is not active'):
         await plugin.new_browser()
 
+    with pytest.raises(RuntimeError, match='Plugin is already active.'):
+        async with plugin, plugin:
+            pass
+
     async with plugin:
         assert plugin.active is True

--- a/tests/unit/browsers/test_playwright_browser_plugin.py
+++ b/tests/unit/browsers/test_playwright_browser_plugin.py
@@ -52,7 +52,13 @@ async def test_multiple_new_browsers(plugin: PlaywrightBrowserPlugin) -> None:
     assert browser_controller_1 is not browser_controller_2
 
 
-async def test_new_browser_without_initialization() -> None:
+async def test_methods_raise_error_when_not_active() -> None:
     plugin = PlaywrightBrowserPlugin()
-    with pytest.raises(RuntimeError):
+
+    assert plugin.active is False
+
+    with pytest.raises(RuntimeError, match='Plugin is not active'):
         await plugin.new_browser()
+
+    async with plugin:
+        assert plugin.active is True

--- a/tests/unit/events/test_event_manager.py
+++ b/tests/unit/events/test_event_manager.py
@@ -151,3 +151,21 @@ async def test_wait_for_all_listeners_cancelled_error(
 
             # Use monkeypatch to replace asyncio.wait with mock_async_wait
             monkeypatch.setattr('asyncio.wait', mock_async_wait)
+
+
+async def test_methods_raise_error_when_not_active(event_system_info_data: EventSystemInfoData) -> None:
+    event_manager = EventManager()
+
+    assert event_manager.active is False
+
+    with pytest.raises(RuntimeError, match='EventManager is not active.'):
+        event_manager.emit(event=Event.SYSTEM_INFO, event_data=event_system_info_data)
+
+    with pytest.raises(RuntimeError, match='EventManager is not active.'):
+        await event_manager.wait_for_all_listeners_to_complete()
+
+    async with event_manager:
+        event_manager.emit(event=Event.SYSTEM_INFO, event_data=event_system_info_data)
+        await event_manager.wait_for_all_listeners_to_complete()
+
+        assert event_manager.active is True

--- a/tests/unit/events/test_event_manager.py
+++ b/tests/unit/events/test_event_manager.py
@@ -164,6 +164,10 @@ async def test_methods_raise_error_when_not_active(event_system_info_data: Event
     with pytest.raises(RuntimeError, match='EventManager is not active.'):
         await event_manager.wait_for_all_listeners_to_complete()
 
+    with pytest.raises(RuntimeError, match='EventManager is already active.'):
+        async with event_manager, event_manager:
+            pass
+
     async with event_manager:
         event_manager.emit(event=Event.SYSTEM_INFO, event_data=event_system_info_data)
         await event_manager.wait_for_all_listeners_to_complete()

--- a/tests/unit/http_crawler/test_http_crawler.py
+++ b/tests/unit/http_crawler/test_http_crawler.py
@@ -161,36 +161,36 @@ async def test_stores_cookies(httpbin: URL) -> None:
     visit = Mock()
     track_session_usage = Mock()
 
-    session_pool = SessionPool(max_pool_size=1)
-    crawler = HttpCrawler(
-        request_provider=RequestList(
-            [
-                str(httpbin.copy_with(path='/cookies/set').copy_set_param('a', '1')),
-                str(httpbin.copy_with(path='/cookies/set').copy_set_param('b', '2')),
-                str(httpbin.copy_with(path='/cookies/set').copy_set_param('c', '3')),
-            ]
-        ),
-        # /cookies/set might redirect us to a page that we can't access - no problem, we only care about cookies
-        ignore_http_error_status_codes=[401],
-        session_pool=session_pool,
-    )
+    async with SessionPool(max_pool_size=1) as session_pool:
+        crawler = HttpCrawler(
+            request_provider=RequestList(
+                [
+                    str(httpbin.copy_with(path='/cookies/set').copy_set_param('a', '1')),
+                    str(httpbin.copy_with(path='/cookies/set').copy_set_param('b', '2')),
+                    str(httpbin.copy_with(path='/cookies/set').copy_set_param('c', '3')),
+                ]
+            ),
+            # /cookies/set might redirect us to a page that we can't access - no problem, we only care about cookies
+            ignore_http_error_status_codes=[401],
+            session_pool=session_pool,
+        )
 
-    @crawler.router.default_handler
-    async def handler(context: HttpCrawlingContext) -> None:
-        visit(context.request.url)
-        track_session_usage(context.session.id if context.session else None)
+        @crawler.router.default_handler
+        async def handler(context: HttpCrawlingContext) -> None:
+            visit(context.request.url)
+            track_session_usage(context.session.id if context.session else None)
 
-    await crawler.run()
+        await crawler.run()
 
-    visited = {call[0][0] for call in visit.call_args_list}
-    assert len(visited) == 3
+        visited = {call[0][0] for call in visit.call_args_list}
+        assert len(visited) == 3
 
-    session_ids = {call[0][0] for call in track_session_usage.call_args_list}
-    assert len(session_ids) == 1
+        session_ids = {call[0][0] for call in track_session_usage.call_args_list}
+        assert len(session_ids) == 1
 
-    session = await session_pool.get_session_by_id(session_ids.pop())
-    assert session is not None
-    assert session.cookies == {'a': '1', 'b': '2', 'c': '3'}
+        session = await session_pool.get_session_by_id(session_ids.pop())
+        assert session is not None
+        assert session.cookies == {'a': '1', 'b': '2', 'c': '3'}
 
 
 async def test_do_not_retry_on_client_errors(crawler: HttpCrawler, server: respx.MockRouter) -> None:

--- a/tests/unit/sessions/test_session_pool.py
+++ b/tests/unit/sessions/test_session_pool.py
@@ -184,5 +184,9 @@ async def test_methods_raise_error_when_not_active() -> None:
 
     await session_pool.reset_store()
 
+    with pytest.raises(RuntimeError, match='SessionPool is already active.'):
+        async with session_pool, session_pool:
+            pass
+
     async with session_pool:
         assert session_pool.active is True

--- a/tests/unit/sessions/test_session_pool.py
+++ b/tests/unit/sessions/test_session_pool.py
@@ -162,3 +162,27 @@ async def test_session_pool_persist_and_restore(event_manager: EventManager, kvs
         await sp.reset_store()
         previous_state = await kvs.get_value(key=PERSIST_STATE_KEY)
         assert previous_state is None
+
+
+async def test_methods_raise_error_when_not_active() -> None:
+    session = Session()
+    session_pool = SessionPool()
+
+    assert session_pool.active is False
+
+    with pytest.raises(RuntimeError, match='SessionPool is not active.'):
+        session_pool.get_state(as_dict=True)
+
+    with pytest.raises(RuntimeError, match='SessionPool is not active.'):
+        session_pool.add_session(session)
+
+    with pytest.raises(RuntimeError, match='SessionPool is not active.'):
+        await session_pool.get_session()
+
+    with pytest.raises(RuntimeError, match='SessionPool is not active.'):
+        await session_pool.get_session_by_id(session.id)
+
+    await session_pool.reset_store()
+
+    async with session_pool:
+        assert session_pool.active is True


### PR DESCRIPTION
### Problems

- The `EventManager` could be initialized multiple times, such as when running a `Crawler` wrapped inside an `Actor`.
- In `crawler.run`, the async context was entered and exited directly, which could lead to issues if the caller had already entered it. This scenario might occur when users provide their own instances of `BrowserPool`, `SessionPool`, `EventManager`, or others.

### Solution

- Address these issues by introducing an `active` flag to the existing context managers to prevent multiple initializations.
- Implement an `ensure_context` helper and apply it to methods where context management is required.
- Fix & improve tests to ensure these cases are covered.

### Others

- I added missing names to asyncio tasks.