### PR TITLE
docs: Enhance argument docstrings for PlaywrightCrawler

### DIFF
--- a/src/crawlee/browsers/_browser_pool.py
+++ b/src/crawlee/browsers/_browser_pool.py
@@ -99,19 +99,23 @@ class BrowserPool:
     def with_default_plugin(
         cls,
         *,
-        headless: bool | None = None,
         browser_type: BrowserType | None = None,
         browser_options: Mapping[str, Any] | None = None,
         page_options: Mapping[str, Any] | None = None,
+        headless: bool | None = None,
         **kwargs: Any,
     ) -> BrowserPool:
         """Create a new instance with a single `PlaywrightBrowserPlugin` configured with the provided options.
 
         Args:
-            headless: Whether to run the browser in headless mode.
             browser_type: The type of browser to launch ('chromium', 'firefox', or 'webkit').
-            browser_options: Keyword arguments to pass to the browser launch method.
-            page_options: Keyword arguments to pass to the new page method.
+            browser_options: Keyword arguments to pass to the browser launch method. These options are provided
+                directly to Playwright's `browser_type.launch` method. For more details, refer to the Playwright
+                documentation: https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch.
+            page_options: Keyword arguments to pass to the new page method. These options are provided directly to
+                Playwright's `browser_context.new_page` method. For more details, refer to the Playwright documentation:
+                https://playwright.dev/python/docs/api/class-browsercontext#browser-context-new-page.
+            headless: Whether to run the browser in headless mode.
             kwargs: Additional arguments for default constructor.
         """
         plugin_options: dict = defaultdict(dict)

--- a/src/crawlee/browsers/_playwright_browser_plugin.py
+++ b/src/crawlee/browsers/_playwright_browser_plugin.py
@@ -42,9 +42,13 @@ class PlaywrightBrowserPlugin(BaseBrowserPlugin):
         """A default constructor.
 
         Args:
-            browser_type: The type of the browser to launch.
-            browser_options: Keyword arguments to pass to the browser launch method.
-            page_options: Keyword arguments to pass to the new page method.
+            browser_type: The type of browser to launch ('chromium', 'firefox', or 'webkit').
+            browser_options: Keyword arguments to pass to the browser launch method. These options are provided
+                directly to Playwright's `browser_type.launch` method. For more details, refer to the Playwright
+                documentation: https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch.
+            page_options: Keyword arguments to pass to the new page method. These options are provided directly to
+                Playwright's `browser_context.new_page` method. For more details, refer to the Playwright documentation:
+                https://playwright.dev/python/docs/api/class-browsercontext#browser-context-new-page.
             max_open_pages_per_browser: The maximum number of pages that can be opened in a single browser instance.
                 Once reached, a new browser instance will be launched to handle the excess.
         """

--- a/src/crawlee/playwright_crawler/_playwright_crawler.py
+++ b/src/crawlee/playwright_crawler/_playwright_crawler.py
@@ -82,9 +82,13 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext]):
             browser_pool: A `BrowserPool` instance to be used for launching the browsers and getting pages.
             browser_type: The type of browser to launch ('chromium', 'firefox', or 'webkit').
                 This option should not be used if `browser_pool` is provided.
-            browser_options: Keyword arguments to pass to the browser launch method.
+            browser_options: Keyword arguments to pass to the browser launch method. These options are provided
+                directly to Playwright's `browser_type.launch` method. For more details, refer to the Playwright
+                documentation: https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch.
                 This option should not be used if `browser_pool` is provided.
-            page_options: Keyword arguments to pass to the new page method.
+            page_options: Keyword arguments to pass to the new page method. These options are provided directly to
+                Playwright's `browser_context.new_page` method. For more details, refer to the Playwright documentation:
+                https://playwright.dev/python/docs/api/class-browsercontext#browser-context-new-page.
                 This option should not be used if `browser_pool` is provided.
             headless: Whether to run the browser in headless mode.
                 This option should not be used if `browser_pool` is provided.


### PR DESCRIPTION
- Enhance argument docstrings for PlaywrightCrawler.
- Mostly `browser_options` and `page_options`, and add links to the PW docs.
- This previous state was clearly insufficient, e.g. https://github.com/apify/crawlee-python/issues/751.