### PR TITLE
chore: Use specific rule codes when ignoring type issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,6 @@ ignore = [
     "G004",     # Logging statement uses f-string
     "ISC001",   # This rule may cause conflicts when used with the formatter
     "FIX",      # flake8-fixme
-    "PGH003",   # Use specific rule codes when ignoring type issues
     "PLR0911",  # Too many return statements
     "PLR0913",  # Too many arguments in function definition
     "PLR0915",  # Too many statements
@@ -208,11 +207,13 @@ exclude = [
     "docs/introduction/code/08_main.py",
 ]
 
-[tool.mypy-scrapy]
-ignore_missing_imports = true
-
-[tool.mypy-sortedcollections]
-ignore_missing_imports = true
+[tool.basedpyright]
+pythonVersion = "3.9"
+typeCheckingMode = "standard"
+include = ["src", "tests", "docs"]
+ignore = [
+    "docs/introduction/code/08_main.py",
+]
 
 [tool.coverage.report]
 exclude_lines = [
@@ -220,9 +221,6 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "assert_never()",
 ]
-
-[tool.basedpyright]
-typeCheckingMode = "standard"
 
 [tool.ipdb]
 context = 7

--- a/src/crawlee/_cli.py
+++ b/src/crawlee/_cli.py
@@ -6,10 +6,10 @@ from pathlib import Path
 from typing import Annotated, Optional, cast
 
 import httpx
-import inquirer  # type: ignore
+import inquirer  # type: ignore[import-untyped]
 import typer
-from cookiecutter.main import cookiecutter  # type: ignore
-from inquirer.render.console import ConsoleRender  # type: ignore
+from cookiecutter.main import cookiecutter  # type: ignore[import-untyped]
+from inquirer.render.console import ConsoleRender  # type: ignore[import-untyped]
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 TEMPLATE_LIST_URL = 'https://api.github.com/repos/apify/crawlee-python/contents/templates'

--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -68,7 +68,7 @@ class UserData(BaseModel, MutableMapping[str, JsonSerializable]):
     """
 
     model_config = ConfigDict(extra='allow')
-    __pydantic_extra__: dict[str, JsonSerializable] = Field(init=False)  # pyright: ignore
+    __pydantic_extra__: dict[str, JsonSerializable] = Field(init=False)
 
     crawlee_data: Annotated[CrawleeRequestData | None, Field(alias='__crawlee')] = None
     """Crawlee-specific configuration stored in the `user_data`."""
@@ -90,7 +90,7 @@ class UserData(BaseModel, MutableMapping[str, JsonSerializable]):
     def __delitem__(self, key: str) -> None:
         del self.__pydantic_extra__[key]
 
-    def __iter__(self) -> Iterator[str]:  # type: ignore
+    def __iter__(self) -> Iterator[str]:  # type: ignore[override]
         yield from self.__pydantic_extra__
 
     def __len__(self) -> int:

--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -92,7 +92,7 @@ class HttpHeaders(RootModel, Mapping[str, str]):
         combined_headers = {**other, **self.root}
         return HttpHeaders(combined_headers)
 
-    def __iter__(self) -> Iterator[str]:  # type: ignore
+    def __iter__(self) -> Iterator[str]:  # type: ignore[override]
         yield from self.root
 
     def __len__(self) -> int:

--- a/src/crawlee/http_clients/curl_impersonate.py
+++ b/src/crawlee/http_clients/curl_impersonate.py
@@ -131,7 +131,7 @@ class CurlImpersonateHttpClient(BaseHttpClient):
         try:
             response = await client.request(
                 url=request.url,
-                method=request.method.upper(),  # type: ignore # curl-cffi requires uppercase method
+                method=request.method.upper(),  # type: ignore[arg-type] # curl-cffi requires uppercase method
                 headers=request.headers,
                 data=request.payload,
                 cookies=session.cookies if session else None,
@@ -177,7 +177,7 @@ class CurlImpersonateHttpClient(BaseHttpClient):
         try:
             response = await client.request(
                 url=url,
-                method=method.upper(),  # type: ignore # curl-cffi requires uppercase method
+                method=method.upper(),  # type: ignore[arg-type] # curl-cffi requires uppercase method
                 headers=dict(headers) if headers else None,
                 data=payload,
                 cookies=session.cookies if session else None,

--- a/src/crawlee/memory_storage_client/_creation_management.py
+++ b/src/crawlee/memory_storage_client/_creation_management.py
@@ -119,7 +119,7 @@ def find_or_create_client_by_id_or_name_inner(
         raise TypeError('Invalid resource client class.')
 
     memory_storage_client.add_resource_client_to_cache(resource_client)
-    return resource_client  # pyright: ignore
+    return resource_client
 
 
 async def get_or_create_inner(

--- a/src/crawlee/memory_storage_client/_memory_storage_client.py
+++ b/src/crawlee/memory_storage_client/_memory_storage_client.py
@@ -166,7 +166,7 @@ class MemoryStorageClient(BaseStorageClient):
             if storage_client.id == id or (
                 storage_client.name and name and storage_client.name.lower() == name.lower()
             ):
-                return storage_client  # pyright: ignore
+                return storage_client
 
         return None
 

--- a/src/crawlee/memory_storage_client/_request_queue_client.py
+++ b/src/crawlee/memory_storage_client/_request_queue_client.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 from logging import getLogger
 from typing import TYPE_CHECKING
 
-from sortedcollections import ValueSortedDict  # type: ignore
+from sortedcollections import ValueSortedDict  # type: ignore[import-untyped]
 from typing_extensions import override
 
 from crawlee._types import StorageTypes

--- a/src/crawlee/storages/_creation_management.py
+++ b/src/crawlee/storages/_creation_management.py
@@ -32,11 +32,11 @@ def _get_from_cache_by_name(
 ) -> TResource | None:
     """Try to restore storage from cache by name."""
     if issubclass(storage_class, Dataset):
-        return _cache_dataset_by_name.get(name)  # pyright: ignore
+        return _cache_dataset_by_name.get(name)
     if issubclass(storage_class, KeyValueStore):
-        return _cache_kvs_by_name.get(name)  # pyright: ignore
+        return _cache_kvs_by_name.get(name)
     if issubclass(storage_class, RequestQueue):
-        return _cache_rq_by_name.get(name)  # pyright: ignore
+        return _cache_rq_by_name.get(name)
     raise ValueError(f'Unknown storage class: {storage_class.__name__}')
 
 
@@ -46,11 +46,11 @@ def _get_from_cache_by_id(
 ) -> TResource | None:
     """Try to restore storage from cache by ID."""
     if issubclass(storage_class, Dataset):
-        return _cache_dataset_by_id.get(id)  # pyright: ignore
+        return _cache_dataset_by_id.get(id)
     if issubclass(storage_class, KeyValueStore):
-        return _cache_kvs_by_id.get(id)  # pyright: ignore
+        return _cache_kvs_by_id.get(id)
     if issubclass(storage_class, RequestQueue):
-        return _cache_rq_by_id.get(id)  # pyright: ignore
+        return _cache_rq_by_id.get(id)
     raise ValueError(f'Unknown storage: {storage_class.__name__}')
 
 

--- a/src/crawlee/storages/_dataset.py
+++ b/src/crawlee/storages/_dataset.py
@@ -208,13 +208,13 @@ class Dataset(BaseStorage):
         self._resource_client = client.dataset(self._id)
         self._resource_collection_client = client.datasets()
 
-    @override
     @property
+    @override
     def id(self) -> str:
         return self._id
 
-    @override
     @property
+    @override
     def name(self) -> str | None:
         return self._name
 

--- a/src/crawlee/storages/_key_value_store.py
+++ b/src/crawlee/storages/_key_value_store.py
@@ -66,13 +66,13 @@ class KeyValueStore(BaseStorage):
         # Get resource clients from storage client
         self._resource_client = client.key_value_store(self._id)
 
-    @override
     @property
+    @override
     def id(self) -> str:
         return self._id
 
-    @override
     @property
+    @override
     def name(self) -> str | None:
         return self._name
 

--- a/src/crawlee/storages/_request_queue.py
+++ b/src/crawlee/storages/_request_queue.py
@@ -141,13 +141,13 @@ class RequestQueue(BaseStorage, RequestProvider):
         self._recently_handled: BoundedSet[str] = BoundedSet(max_length=self._RECENTLY_HANDLED_CACHE_SIZE)
         self._requests_cache: LRUCache[CachedRequest] = LRUCache(max_length=self._MAX_CACHED_REQUESTS)
 
-    @override
     @property
+    @override
     def id(self) -> str:
         return self._id
 
-    @override
     @property
+    @override
     def name(self) -> str | None:
         return self._name
 

--- a/tests/unit/_memory_storage_client/test_memory_storage_client.py
+++ b/tests/unit/_memory_storage_client/test_memory_storage_client.py
@@ -1,4 +1,4 @@
-# TODO: type ignores and crawlee_storage_dir
+# TODO: Update crawlee_storage_dir args once the Pydantic bug is fixed
 # https://github.com/apify/crawlee-python/issues/146
 
 from __future__ import annotations
@@ -19,13 +19,13 @@ async def test_write_metadata(tmp_path: Path) -> None:
     dataset_no_metadata_name = 'test-no-metadata'
     ms = MemoryStorageClient(
         Configuration(
-            crawlee_storage_dir=str(tmp_path),  # type: ignore
+            crawlee_storage_dir=str(tmp_path),  # type: ignore[call-arg]
             write_metadata=True,
         ),
     )
     ms_no_metadata = MemoryStorageClient(
         Configuration(
-            crawlee_storage_dir=str(tmp_path),  # type: ignore
+            crawlee_storage_dir=str(tmp_path),  # type: ignore[call-arg]
             write_metadata=False,
         )
     )
@@ -50,7 +50,7 @@ async def test_write_metadata(tmp_path: Path) -> None:
 async def test_persist_storage(persist_storage: bool, tmp_path: Path) -> None:  # noqa: FBT001
     ms = MemoryStorageClient(
         Configuration(
-            crawlee_storage_dir=str(tmp_path),  # type: ignore
+            crawlee_storage_dir=str(tmp_path),  # type: ignore[call-arg]
             persist_storage=persist_storage,
         )
     )
@@ -82,20 +82,20 @@ async def test_persist_storage(persist_storage: bool, tmp_path: Path) -> None:  
 
 def test_persist_storage_set_to_false_via_string_env_var(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv('CRAWLEE_PERSIST_STORAGE', 'false')
-    ms = MemoryStorageClient(Configuration(crawlee_storage_dir=str(tmp_path)))  # type: ignore
+    ms = MemoryStorageClient(Configuration(crawlee_storage_dir=str(tmp_path)))  # type: ignore[call-arg]
     assert ms.persist_storage is False
 
 
 def test_persist_storage_set_to_false_via_numeric_env_var(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv('CRAWLEE_PERSIST_STORAGE', '0')
-    ms = MemoryStorageClient(Configuration(crawlee_storage_dir=str(tmp_path)))  # type: ignore
+    ms = MemoryStorageClient(Configuration(crawlee_storage_dir=str(tmp_path)))  # type: ignore[call-arg]
     assert ms.persist_storage is False
 
 
 def test_persist_storage_true_via_constructor_arg(tmp_path: Path) -> None:
     ms = MemoryStorageClient(
         Configuration(
-            crawlee_storage_dir=str(tmp_path),  # type: ignore
+            crawlee_storage_dir=str(tmp_path),  # type: ignore[call-arg]
             persist_storage=True,
         )
     )
@@ -104,14 +104,14 @@ def test_persist_storage_true_via_constructor_arg(tmp_path: Path) -> None:
 
 def test_default_write_metadata_behavior(tmp_path: Path) -> None:
     # Default behavior
-    ms = MemoryStorageClient(Configuration(crawlee_storage_dir=str(tmp_path)))  # type: ignore
+    ms = MemoryStorageClient(Configuration(crawlee_storage_dir=str(tmp_path)))  # type: ignore[call-arg]
     assert ms.write_metadata is True
 
 
 def test_write_metadata_set_to_false_via_env_var(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     # Test if env var changes write_metadata to False
     monkeypatch.setenv('CRAWLEE_WRITE_METADATA', 'false')
-    ms = MemoryStorageClient(Configuration(crawlee_storage_dir=str(tmp_path)))  # type: ignore
+    ms = MemoryStorageClient(Configuration(crawlee_storage_dir=str(tmp_path)))  # type: ignore[call-arg]
     assert ms.write_metadata is False
 
 
@@ -120,7 +120,7 @@ def test_write_metadata_false_via_constructor_arg_overrides_env_var(tmp_path: Pa
     ms = MemoryStorageClient(
         Configuration(
             write_metadata=False,
-            crawlee_storage_dir=str(tmp_path),  # type: ignore
+            crawlee_storage_dir=str(tmp_path),  # type: ignore[call-arg]
         )
     )
     assert ms.write_metadata is False
@@ -130,7 +130,7 @@ async def test_purge_datasets(tmp_path: Path) -> None:
     ms = MemoryStorageClient(
         Configuration(
             write_metadata=True,
-            crawlee_storage_dir=str(tmp_path),  # type: ignore
+            crawlee_storage_dir=str(tmp_path),  # type: ignore[call-arg]
         )
     )
     # Create default and non-default datasets
@@ -153,7 +153,7 @@ async def test_purge_key_value_stores(tmp_path: Path) -> None:
     ms = MemoryStorageClient(
         Configuration(
             write_metadata=True,
-            crawlee_storage_dir=str(tmp_path),  # type: ignore
+            crawlee_storage_dir=str(tmp_path),  # type: ignore[call-arg]
         )
     )
 
@@ -188,7 +188,7 @@ async def test_purge_request_queues(tmp_path: Path) -> None:
     ms = MemoryStorageClient(
         Configuration(
             write_metadata=True,
-            crawlee_storage_dir=str(tmp_path),  # type: ignore
+            crawlee_storage_dir=str(tmp_path),  # type: ignore[call-arg]
         )
     )
     # Create default and non-default request queues
@@ -210,7 +210,7 @@ async def test_not_implemented_method(tmp_path: Path) -> None:
     ms = MemoryStorageClient(
         Configuration(
             write_metadata=True,
-            crawlee_storage_dir=str(tmp_path),  # type: ignore
+            crawlee_storage_dir=str(tmp_path),  # type: ignore[call-arg]
         )
     )
     ddt = ms.dataset('test')
@@ -238,6 +238,6 @@ async def test_storage_path_from_env_var_overrides_default(monkeypatch: pytest.M
 async def test_parametrized_storage_path_overrides_env_var() -> None:
     # We expect the parametrized value to be used
     ms = MemoryStorageClient(
-        Configuration(crawlee_storage_dir='./parametrized_storage_dir'),  # type: ignore
+        Configuration(crawlee_storage_dir='./parametrized_storage_dir'),  # type: ignore[call-arg]
     )
     assert ms.storage_dir == './parametrized_storage_dir'

--- a/tests/unit/_utils/test_byte_size.py
+++ b/tests/unit/_utils/test_byte_size.py
@@ -52,11 +52,11 @@ def test_additions() -> None:
 
     # Addition of ByteSize instance and an int
     with pytest.raises(TypeError):
-        size1 + 1024
+        _ = size1 + 1024
 
     # Addition of ByteSize instance and an float
     with pytest.raises(TypeError):
-        size2 + 123.45
+        _ = size2 + 123.45
 
 
 def test_subtractions() -> None:
@@ -71,11 +71,11 @@ def test_subtractions() -> None:
 
     # Subtraction of ByteSize instance and an int
     with pytest.raises(TypeError):
-        size1 - 1024
+        _ = size1 - 1024
 
     # Subtraction of ByteSize instance and an float
     with pytest.raises(TypeError):
-        size2 - 123.45
+        _ = size2 - 123.45
 
 
 def test_multiplication() -> None:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,4 @@
-# TODO: type ignores and crawlee_storage_dir
+# TODO: Update crawlee_storage_dir args once the Pydantic bug is fixed
 # https://github.com/apify/crawlee-python/issues/146
 
 from __future__ import annotations
@@ -63,7 +63,7 @@ def memory_storage_client(tmp_path: Path) -> MemoryStorageClient:
     cfg = Configuration(
         write_metadata=True,
         persist_storage=True,
-        crawlee_storage_dir=str(tmp_path),  # type: ignore
+        crawlee_storage_dir=str(tmp_path),  # type: ignore[call-arg]
     )
     return MemoryStorageClient(cfg)
 

--- a/tests/unit/fingerprint_suite/test_header_generator.py
+++ b/tests/unit/fingerprint_suite/test_header_generator.py
@@ -63,7 +63,7 @@ def test_get_user_agent_header_invalid_browser_type() -> None:
     header_generator = HeaderGenerator()
 
     with pytest.raises(ValueError, match='Unsupported browser type'):
-        header_generator.get_user_agent_header(browser_type='invalid_browser')  # type: ignore
+        header_generator.get_user_agent_header(browser_type='invalid_browser')  # type: ignore[arg-type]
 
 
 def test_get_sec_ch_ua_headers_chromium() -> None:
@@ -100,4 +100,4 @@ def test_get_sec_ch_ua_headers_invalid_browser_type() -> None:
     header_generator = HeaderGenerator()
 
     with pytest.raises(ValueError, match='Unsupported browser type'):
-        header_generator.get_sec_ch_ua_headers(browser_type='invalid_browser')  # type: ignore
+        header_generator.get_sec_ch_ua_headers(browser_type='invalid_browser')  # type: ignore[arg-type]

--- a/tests/unit/sessions/test_models.py
+++ b/tests/unit/sessions/test_models.py
@@ -91,7 +91,7 @@ def test_create_session_pool_with_direct_sessions(session_direct: SessionModel) 
         retired_session_count=0,
         sessions=[session_direct],
     )
-    session_pool.sessions = [session_direct]
+    assert session_pool.sessions == [session_direct]
 
 
 def test_create_session_pool_with_args_sessions(session_args_camel: dict, session_args_snake: dict) -> None:
@@ -106,4 +106,4 @@ def test_create_session_pool_with_args_sessions(session_args_camel: dict, sessio
         retired_session_count=0,
         sessions=[session_args_camel, session_args_snake],
     )
-    session_pool_camel.sessions = [SessionModel(**session_args_camel), SessionModel(**session_args_snake)]
+    assert session_pool_camel.sessions == [SessionModel(**session_args_camel), SessionModel(**session_args_snake)]


### PR DESCRIPTION
- Rm ignore of `PGH003` rule and update type ignores to be specific.
- Fix 2 asserts in the tests.
- Use underscore names for unused variables in tests.