### PR TITLE
chore: Remove unused ID arg from `BaseRequestData.from_url`

### DIFF
--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -187,7 +187,6 @@ class BaseRequestData(BaseModel):
         payload: HttpPayload | str | None = None,
         label: str | None = None,
         unique_key: str | None = None,
-        id: str | None = None,
         keep_url_fragment: bool = False,
         use_extended_unique_key: bool = False,
         **kwargs: Any,
@@ -208,12 +207,9 @@ class BaseRequestData(BaseModel):
             use_extended_unique_key=use_extended_unique_key,
         )
 
-        id = id or unique_key_to_request_id(unique_key)
-
         request = cls(
             url=url,
             unique_key=unique_key,
-            id=id,
             method=method,
             headers=headers,
             payload=payload,


### PR DESCRIPTION
- `BaseRequestData` does not have the `id` attribute.
- It is not breaking, as 
  - `from_url` accepts `**kwargs`, 
  - and `BaseRequestData` is not exposed to the public.