### PR TITLE
feat: Add metadata parameter to Request for additional context

### DIFF
--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -282,6 +282,7 @@ class Request(BaseRequestData):
         keep_url_fragment: bool = False,
         use_extended_unique_key: bool = False,
         always_enqueue: bool = False,
+        metadata: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> Self:
         """Create a new `Request` instance from a URL.
@@ -308,6 +309,8 @@ class Request(BaseRequestData):
                 computation. This is only relevant when `unique_key` is not provided.
             always_enqueue: If set to `True`, the request will be enqueued even if it is already present in the queue.
                 Using this is not allowed when a custom `unique_key` is also provided and will result in a `ValueError`.
+            metadata: Additional metadata dict that gets stored in the `user_data.model_extra`.
+                Useful for passing info from request to context.
             **kwargs: Additional request properties.
         """
         if unique_key is not None and always_enqueue:
@@ -345,6 +348,8 @@ class Request(BaseRequestData):
 
         if label is not None:
             request.user_data['label'] = label
+        if metadata is not None:
+            request.user_data.update(metadata)
 
         return request
 


### PR DESCRIPTION
### Description
This PR allows you to hold metadata in the request object. the idea is that you can pull in from the context.request object later in the router. 

I could think of a few ways this would be used. In my case I'm scraping an api and I can't garnet the url / ids don't change so I want my own internal id that I want to pass along to when I persist the results. 

Someone else had a similar desire to this https://github.com/apify/crawlee-python/discussions/531 thread. 

Please let me know what y'all think. if you want me to add any more documentation for it anywhere. I have a solution that I can continue to use without this PR but i see this as a small thing I can do. Thanks for keeping it open source. 

### Testing

- TODO

### Checklist

- [ ] CI passed
