### PR TITLE
fix: Fix incorrect use of desired concurrency ratio

### DIFF
--- a/src/crawlee/_autoscaling/autoscaled_pool.py
+++ b/src/crawlee/_autoscaling/autoscaled_pool.py
@@ -195,7 +195,7 @@ class AutoscaledPool:
         """Inspect system load status and adjust desired concurrency if necessary. Do not call directly."""
         status = self._system_status.get_historical_system_info()
 
-        min_current_concurrency = math.floor(self._desired_concurrency_ratio * self.current_concurrency)
+        min_current_concurrency = math.floor(self._desired_concurrency_ratio * self.desired_concurrency)
         should_scale_up = (
             status.is_system_idle
             and self._desired_concurrency < self._max_concurrency

--- a/tests/unit/_autoscaling/test_autoscaled_pool.py
+++ b/tests/unit/_autoscaling/test_autoscaled_pool.py
@@ -212,7 +212,7 @@ async def test_autoscales(system_status: SystemStatus | Mock) -> None:
 async def test_autoscales_uses_desired_concurrency_ratio(system_status: SystemStatus | Mock) -> None:
     """Test that desired concurrency ratio can limit desired concurrency.
 
-    This test crates situation where only one task is ready and then no other task is ever ready.
+    This test creates situation where only one task is ready and then no other task is ever ready.
     This creates situation where the system could scale up desired concurrency, but it will not do so because
     desired_concurrency_ratio=1 means that first the system would have to increase current concurrency to same number as
     desired concurrency and due to no other task ever being ready, it will never happen. Thus desired concurrency will


### PR DESCRIPTION
### Description
Concurrency ratio was not correctly used in Python version of autoscaled pool. Align it with the Javascript implementation of autoscaled pool.
Add test.
### Issues

<!-- If applicable, reference any related GitHub issues -->

- Closes: #759 
