### PR TITLE
fix: pass `verify` in httpx client

### DIFF
--- a/src/crawlee/http_clients/_httpx.py
+++ b/src/crawlee/http_clients/_httpx.py
@@ -16,6 +16,7 @@ from crawlee.sessions import Session
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from ssl import SSLContext
 
     from crawlee._types import HttpMethod, HttpPayload
     from crawlee.base_storage_client._models import Request
@@ -101,6 +102,7 @@ class HttpxHttpClient(BaseHttpClient):
         ignore_http_error_status_codes: Iterable[int] = (),
         http1: bool = True,
         http2: bool = True,
+        verify: str | bool | SSLContext = True,
         header_generator: HeaderGenerator | None = _DEFAULT_HEADER_GENERATOR,
         **async_client_kwargs: Any,
     ) -> None:
@@ -112,6 +114,7 @@ class HttpxHttpClient(BaseHttpClient):
             ignore_http_error_status_codes: HTTP status codes to ignore as errors.
             http1: Whether to enable HTTP/1.1 support.
             http2: Whether to enable HTTP/2 support.
+            verify: SSL certificates used to verify the identity of requested hosts.
             header_generator: Header generator instance to use for generating common headers.
             async_client_kwargs: Additional keyword arguments for `httpx.AsyncClient`.
         """
@@ -122,6 +125,7 @@ class HttpxHttpClient(BaseHttpClient):
         )
         self._http1 = http1
         self._http2 = http2
+        self._verify = verify
         self._async_client_kwargs = async_client_kwargs
         self._header_generator = header_generator
 
@@ -219,13 +223,12 @@ class HttpxHttpClient(BaseHttpClient):
             # Prepare a default kwargs for the new client.
             kwargs: dict[str, Any] = {
                 'transport': _HttpxTransport(
-                    proxy=proxy_url,
-                    http1=self._http1,
-                    http2=self._http2,
+                    proxy=proxy_url, http1=self._http1, http2=self._http2, verify=self._verify
                 ),
                 'proxy': proxy_url,
                 'http1': self._http1,
                 'http2': self._http2,
+                'verify': self._verify,
             }
 
             # Update the default kwargs with any additional user-provided kwargs.

--- a/tests/unit/basic_crawler/test_basic_crawler.py
+++ b/tests/unit/basic_crawler/test_basic_crawler.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from collections import Counter
 from dataclasses import dataclass
 from datetime import timedelta
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, Mock


### PR DESCRIPTION
### Description

- fix for passing `verify` to `transport` in `HttpxHttpClient`

### Issues

- Closes: #798 

### Checklist

- [ ] CI passed
