### PR TITLE
docs: document inherited symbols properly

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -34,7 +34,7 @@
         "typescript": "5.7.2"
     },
     "dependencies": {
-        "@apify/docusaurus-plugin-typedoc-api": "^4.3.0",
+        "@apify/docusaurus-plugin-typedoc-api": "^4.3.5",
         "@apify/utilities": "^2.8.0",
         "@docusaurus/core": "^3.5.2",
         "@docusaurus/mdx-loader": "^3.5.2",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -365,9 +365,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apify/docusaurus-plugin-typedoc-api@npm:^4.3.0":
-  version: 4.3.2
-  resolution: "@apify/docusaurus-plugin-typedoc-api@npm:4.3.2"
+"@apify/docusaurus-plugin-typedoc-api@npm:^4.3.5":
+  version: 4.3.5
+  resolution: "@apify/docusaurus-plugin-typedoc-api@npm:4.3.5"
   dependencies:
     "@docusaurus/plugin-content-docs": "npm:^3.5.2"
     "@docusaurus/types": "npm:^3.5.2"
@@ -384,7 +384,7 @@ __metadata:
     "@docusaurus/mdx-loader": ^3.5.2
     react: ">=18.0.0"
     typescript: ^5.0.0
-  checksum: 10c0/1b779911a244e43f35d83d672c5f0668587b020c8137a242cfa2ffa01ed321ecb64b73f0f534d0ab8cf9212da4bfc4e9b077989234570e0a73c323980832c5d7
+  checksum: 10c0/f68d0e6fb3014e7d3777916c061fb2fcc1a83aba43ef06b3c1781cf9aded858c35343247ab90021d0d04b1897fa8d6f091168032c497506e5ab544b29fe8d219
   languageName: node
   linkType: hard
 
@@ -5699,7 +5699,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "crawlee@workspace:."
   dependencies:
-    "@apify/docusaurus-plugin-typedoc-api": "npm:^4.3.0"
+    "@apify/docusaurus-plugin-typedoc-api": "npm:^4.3.5"
     "@apify/eslint-config-ts": "npm:^0.4.0"
     "@apify/tsconfig": "npm:^0.1.0"
     "@apify/utilities": "npm:^2.8.0"


### PR DESCRIPTION
Bumps the version of `@apify/docusaurus-plugin-typedoc-api` to use the patches from https://github.com/apify/docusaurus-plugin-typedoc-api/pull/34

![obrazek](https://github.com/user-attachments/assets/2a893358-26bb-4bd5-bc33-99921138eb2c)


This means that the documentation correctly resolves the `(grand)+parent `-inherited symbols.