### PR TITLE
refactor!: Rename PwPreNavContext to PwPreNavCrawlingContext

### DIFF
--- a/docs/examples/code/playwright_crawler.py
+++ b/docs/examples/code/playwright_crawler.py
@@ -3,7 +3,7 @@ import asyncio
 from crawlee.playwright_crawler import (
     PlaywrightCrawler,
     PlaywrightCrawlingContext,
-    PlaywrightPreNavigationCrawlingContext,
+    PlaywrightPreNavCrawlingContext,
 )
 
 
@@ -56,7 +56,7 @@ async def main() -> None:
     # browser page among other things. In this example, we log the URL being
     # navigated to.
     @crawler.pre_navigation_hook
-    async def log_navigation_url(context: PlaywrightPreNavigationCrawlingContext) -> None:
+    async def log_navigation_url(context: PlaywrightPreNavCrawlingContext) -> None:
         context.log.info(f'Navigating to {context.request.url} ...')
 
     # Run the crawler with the initial list of URLs.

--- a/docs/examples/code/playwright_crawler.py
+++ b/docs/examples/code/playwright_crawler.py
@@ -1,6 +1,10 @@
 import asyncio
 
-from crawlee.playwright_crawler import PlaywrightCrawler, PlaywrightCrawlingContext, PlaywrightPreNavigationContext
+from crawlee.playwright_crawler import (
+    PlaywrightCrawler,
+    PlaywrightCrawlingContext,
+    PlaywrightPreNavigationCrawlingContext,
+)
 
 
 async def main() -> None:
@@ -52,7 +56,7 @@ async def main() -> None:
     # browser page among other things. In this example, we log the URL being
     # navigated to.
     @crawler.pre_navigation_hook
-    async def log_navigation_url(context: PlaywrightPreNavigationContext) -> None:
+    async def log_navigation_url(context: PlaywrightPreNavigationCrawlingContext) -> None:
         context.log.info(f'Navigating to {context.request.url} ...')
 
     # Run the crawler with the initial list of URLs.

--- a/docs/upgrading/upgrading_to_v0x.md
+++ b/docs/upgrading/upgrading_to_v0x.md
@@ -28,7 +28,7 @@ This section summarizes the breaking changes between v0.4.x and v0.5.0.
 
 ### PlaywrightCrawler
 
-- The `PlaywrightPreNavigationContext` was renamed to `PlaywrightPreNavigationCrawlingContext`.
+- The `PlaywrightPreNavigationContext` was renamed to `PlaywrightPreNavCrawlingContext`.
 
 ## Upgrading to v0.4
 

--- a/docs/upgrading/upgrading_to_v0x.md
+++ b/docs/upgrading/upgrading_to_v0x.md
@@ -26,6 +26,10 @@ This section summarizes the breaking changes between v0.4.x and v0.5.0.
 
 - Removed properties `json_` and `order_no`.
 
+### PlaywrightCrawler
+
+- The `PlaywrightPreNavigationContext` was renamed to `PlaywrightPreNavigationCrawlingContext`.
+
 ## Upgrading to v0.4
 
 This section summarizes the breaking changes between v0.3.x and v0.4.0.

--- a/src/crawlee/playwright_crawler/__init__.py
+++ b/src/crawlee/playwright_crawler/__init__.py
@@ -1,11 +1,11 @@
 try:
     from ._playwright_crawler import PlaywrightCrawler
     from ._playwright_crawling_context import PlaywrightCrawlingContext
-    from ._playwright_pre_navigation_context import PlaywrightPreNavigationContext
+    from ._playwright_pre_navigation_crawling_context import PlaywrightPreNavigationCrawlingContext
 except ImportError as exc:
     raise ImportError(
         "To import anything from this subpackage, you need to install the 'playwright' extra."
         "For example, if you use pip, run `pip install 'crawlee[playwright]'`.",
     ) from exc
 
-__all__ = ['PlaywrightCrawler', 'PlaywrightCrawlingContext', 'PlaywrightPreNavigationContext']
+__all__ = ['PlaywrightCrawler', 'PlaywrightCrawlingContext', 'PlaywrightPreNavigationCrawlingContext']

--- a/src/crawlee/playwright_crawler/__init__.py
+++ b/src/crawlee/playwright_crawler/__init__.py
@@ -1,11 +1,11 @@
 try:
     from ._playwright_crawler import PlaywrightCrawler
     from ._playwright_crawling_context import PlaywrightCrawlingContext
-    from ._playwright_pre_navigation_crawling_context import PlaywrightPreNavigationCrawlingContext
+    from ._playwright_pre_nav_crawling_context import PlaywrightPreNavCrawlingContext
 except ImportError as exc:
     raise ImportError(
         "To import anything from this subpackage, you need to install the 'playwright' extra."
         "For example, if you use pip, run `pip install 'crawlee[playwright]'`.",
     ) from exc
 
-__all__ = ['PlaywrightCrawler', 'PlaywrightCrawlingContext', 'PlaywrightPreNavigationCrawlingContext']
+__all__ = ['PlaywrightCrawler', 'PlaywrightCrawlingContext', 'PlaywrightPreNavCrawlingContext']

--- a/src/crawlee/playwright_crawler/_playwright_crawler.py
+++ b/src/crawlee/playwright_crawler/_playwright_crawler.py
@@ -14,9 +14,7 @@ from crawlee.basic_crawler import BasicCrawler, BasicCrawlerOptions, ContextPipe
 from crawlee.browsers import BrowserPool
 from crawlee.errors import SessionError
 from crawlee.playwright_crawler._playwright_crawling_context import PlaywrightCrawlingContext
-from crawlee.playwright_crawler._playwright_pre_navigation_crawling_context import (
-    PlaywrightPreNavigationCrawlingContext,
-)
+from crawlee.playwright_crawler._playwright_pre_nav_crawling_context import PlaywrightPreNavCrawlingContext
 from crawlee.playwright_crawler._utils import infinite_scroll
 
 if TYPE_CHECKING:
@@ -121,21 +119,21 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext]):
         )
         kwargs['_additional_context_managers'] = [self._browser_pool]
         kwargs.setdefault('_logger', logging.getLogger(__name__))
-        self._pre_navigation_hooks: list[Callable[[PlaywrightPreNavigationCrawlingContext], Awaitable[None]]] = []
+        self._pre_navigation_hooks: list[Callable[[PlaywrightPreNavCrawlingContext], Awaitable[None]]] = []
 
         super().__init__(**kwargs)
 
     async def _open_page(
         self,
         context: BasicCrawlingContext,
-    ) -> AsyncGenerator[PlaywrightPreNavigationCrawlingContext, None]:
+    ) -> AsyncGenerator[PlaywrightPreNavCrawlingContext, None]:
         if self._browser_pool is None:
             raise ValueError('Browser pool is not initialized.')
 
         # Create a new browser page
         crawlee_page = await self._browser_pool.new_page(proxy_info=context.proxy_info)
 
-        pre_navigation_context = PlaywrightPreNavigationCrawlingContext(
+        pre_navigation_context = PlaywrightPreNavCrawlingContext(
             request=context.request,
             session=context.session,
             add_requests=context.add_requests,
@@ -155,7 +153,7 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext]):
 
     async def _navigate(
         self,
-        context: PlaywrightPreNavigationCrawlingContext,
+        context: PlaywrightPreNavCrawlingContext,
     ) -> AsyncGenerator[PlaywrightCrawlingContext, None]:
         """Executes an HTTP request utilizing the `BrowserPool` and the `Playwright` library.
 
@@ -276,7 +274,7 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext]):
 
         yield context
 
-    def pre_navigation_hook(self, hook: Callable[[PlaywrightPreNavigationCrawlingContext], Awaitable[None]]) -> None:
+    def pre_navigation_hook(self, hook: Callable[[PlaywrightPreNavCrawlingContext], Awaitable[None]]) -> None:
         """Register a hook to be called before each navigation.
 
         Args:

--- a/src/crawlee/playwright_crawler/_playwright_crawler.py
+++ b/src/crawlee/playwright_crawler/_playwright_crawler.py
@@ -14,7 +14,9 @@ from crawlee.basic_crawler import BasicCrawler, BasicCrawlerOptions, ContextPipe
 from crawlee.browsers import BrowserPool
 from crawlee.errors import SessionError
 from crawlee.playwright_crawler._playwright_crawling_context import PlaywrightCrawlingContext
-from crawlee.playwright_crawler._playwright_pre_navigation_context import PlaywrightPreNavigationContext
+from crawlee.playwright_crawler._playwright_pre_navigation_crawling_context import (
+    PlaywrightPreNavigationCrawlingContext,
+)
 from crawlee.playwright_crawler._utils import infinite_scroll
 
 if TYPE_CHECKING:
@@ -119,18 +121,21 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext]):
         )
         kwargs['_additional_context_managers'] = [self._browser_pool]
         kwargs.setdefault('_logger', logging.getLogger(__name__))
-        self._pre_navigation_hooks: list[Callable[[PlaywrightPreNavigationContext], Awaitable[None]]] = []
+        self._pre_navigation_hooks: list[Callable[[PlaywrightPreNavigationCrawlingContext], Awaitable[None]]] = []
 
         super().__init__(**kwargs)
 
-    async def _open_page(self, context: BasicCrawlingContext) -> AsyncGenerator[PlaywrightPreNavigationContext, None]:
+    async def _open_page(
+        self,
+        context: BasicCrawlingContext,
+    ) -> AsyncGenerator[PlaywrightPreNavigationCrawlingContext, None]:
         if self._browser_pool is None:
             raise ValueError('Browser pool is not initialized.')
 
         # Create a new browser page
         crawlee_page = await self._browser_pool.new_page(proxy_info=context.proxy_info)
 
-        pre_navigation_context = PlaywrightPreNavigationContext(
+        pre_navigation_context = PlaywrightPreNavigationCrawlingContext(
             request=context.request,
             session=context.session,
             add_requests=context.add_requests,
@@ -150,7 +155,7 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext]):
 
     async def _navigate(
         self,
-        context: PlaywrightPreNavigationContext,
+        context: PlaywrightPreNavigationCrawlingContext,
     ) -> AsyncGenerator[PlaywrightCrawlingContext, None]:
         """Executes an HTTP request utilizing the `BrowserPool` and the `Playwright` library.
 
@@ -271,7 +276,7 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext]):
 
         yield context
 
-    def pre_navigation_hook(self, hook: Callable[[PlaywrightPreNavigationContext], Awaitable[None]]) -> None:
+    def pre_navigation_hook(self, hook: Callable[[PlaywrightPreNavigationCrawlingContext], Awaitable[None]]) -> None:
         """Register a hook to be called before each navigation.
 
         Args:

--- a/src/crawlee/playwright_crawler/_playwright_crawling_context.py
+++ b/src/crawlee/playwright_crawler/_playwright_crawling_context.py
@@ -4,7 +4,9 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable
 
 from crawlee._utils.docs import docs_group
-from crawlee.playwright_crawler._playwright_pre_navigation_context import PlaywrightPreNavigationContext
+from crawlee.playwright_crawler._playwright_pre_navigation_crawling_context import (
+    PlaywrightPreNavigationCrawlingContext,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
@@ -16,7 +18,7 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 @docs_group('Data structures')
-class PlaywrightCrawlingContext(PlaywrightPreNavigationContext):
+class PlaywrightCrawlingContext(PlaywrightPreNavigationCrawlingContext):
     """The crawling context used by the `PlaywrightCrawler`.
 
     It provides access to key objects as well as utility functions for handling crawling tasks.

--- a/src/crawlee/playwright_crawler/_playwright_crawling_context.py
+++ b/src/crawlee/playwright_crawler/_playwright_crawling_context.py
@@ -4,9 +4,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable
 
 from crawlee._utils.docs import docs_group
-from crawlee.playwright_crawler._playwright_pre_navigation_crawling_context import (
-    PlaywrightPreNavigationCrawlingContext,
-)
+from crawlee.playwright_crawler._playwright_pre_nav_crawling_context import PlaywrightPreNavCrawlingContext
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
@@ -18,7 +16,7 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 @docs_group('Data structures')
-class PlaywrightCrawlingContext(PlaywrightPreNavigationCrawlingContext):
+class PlaywrightCrawlingContext(PlaywrightPreNavCrawlingContext):
     """The crawling context used by the `PlaywrightCrawler`.
 
     It provides access to key objects as well as utility functions for handling crawling tasks.

--- a/src/crawlee/playwright_crawler/_playwright_pre_nav_crawling_context.py
+++ b/src/crawlee/playwright_crawler/_playwright_pre_nav_crawling_context.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 @docs_group('Data structures')
-class PlaywrightPreNavigationCrawlingContext(BasicCrawlingContext):
+class PlaywrightPreNavCrawlingContext(BasicCrawlingContext):
     """The pre navigation crawling context used by the `PlaywrightCrawler`.
 
     It provides access to the `Page` object, before the navigation to the URL is performed.

--- a/src/crawlee/playwright_crawler/_playwright_pre_navigation_crawling_context.py
+++ b/src/crawlee/playwright_crawler/_playwright_pre_navigation_crawling_context.py
@@ -12,10 +12,10 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 @docs_group('Data structures')
-class PlaywrightPreNavigationContext(BasicCrawlingContext):
-    """Context used by PlaywrightCrawler.
+class PlaywrightPreNavigationCrawlingContext(BasicCrawlingContext):
+    """The pre navigation crawling context used by the `PlaywrightCrawler`.
 
-    It Provides access to the `Page` object for the current browser page.
+    It provides access to the `Page` object, before the navigation to the URL is performed.
     """
 
     page: Page


### PR DESCRIPTION
- Rename `PlaywrightPreNavigationContext` to `PlaywrightPreNavigationCrawlingContext`.
- Of course, this is really long. Do we want to make it shorter, e.g.: `PlaywrightPreNavCrawlingContext`?
- Or make shorter all the crawling contexts... e.g. use just `CrawlContext`, (`PlaywrightPreNavCrawlContext`)
- Opinions?