### PR TITLE
fix: `abort-on-error` for successive runs

### DIFF
--- a/src/crawlee/basic_crawler/_basic_crawler.py
+++ b/src/crawlee/basic_crawler/_basic_crawler.py
@@ -957,6 +957,7 @@ class BasicCrawler(Generic[TCrawlingContext]):
         is_finished = await request_provider.is_finished()
 
         if self._abort_on_error and self._failed:
+            self._failed = False
             return True
 
         return is_finished


### PR DESCRIPTION
### Description

- Fix a situation where consecutive launches in the same session would immediately abort after an error exit


