### PR TITLE
fix: Relax ServiceLocator restrictions

### DIFF
--- a/src/crawlee/_service_locator.py
+++ b/src/crawlee/_service_locator.py
@@ -39,7 +39,7 @@ class ServiceLocator:
             configuration: The configuration to set.
 
         Raises:
-            ServiceConflictError: If the configuration was already set.
+            ServiceConflictError: If the configuration has already been retrieved before.
         """
         if self._configuration_was_retrieved:
             raise ServiceConflictError(Configuration, configuration, self._configuration)
@@ -63,7 +63,7 @@ class ServiceLocator:
             event_manager: The event manager to set.
 
         Raises:
-            ServiceConflictError: If the event manager was already set.
+            ServiceConflictError: If the event manager has already been retrieved before.
         """
         if self._event_manager_was_retrieved:
             raise ServiceConflictError(EventManager, event_manager, self._event_manager)
@@ -87,7 +87,7 @@ class ServiceLocator:
             storage_client: The storage client to set.
 
         Raises:
-            ServiceConflictError: If the storage client was already set.
+            ServiceConflictError: If the storage client has already been retrieved before.
         """
         if self._storage_client_was_retrieved:
             raise ServiceConflictError(BaseStorageClient, storage_client, self._storage_client)

--- a/src/crawlee/_service_locator.py
+++ b/src/crawlee/_service_locator.py
@@ -20,15 +20,16 @@ class ServiceLocator:
         self._storage_client: BaseStorageClient | None = None
 
         # Flags to check if the services were already set.
-        self._configuration_was_set = False
-        self._event_manager_was_set = False
-        self._storage_client_was_set = False
+        self._configuration_was_retrieved = False
+        self._event_manager_was_retrieved = False
+        self._storage_client_was_retrieved = False
 
     def get_configuration(self) -> Configuration:
         """Get the configuration."""
         if self._configuration is None:
             self._configuration = Configuration()
 
+        self._configuration_was_retrieved = True
         return self._configuration
 
     def set_configuration(self, configuration: Configuration) -> None:
@@ -40,11 +41,10 @@ class ServiceLocator:
         Raises:
             ServiceConflictError: If the configuration was already set.
         """
-        if self._configuration_was_set:
+        if self._configuration_was_retrieved:
             raise ServiceConflictError(Configuration, configuration, self._configuration)
 
         self._configuration = configuration
-        self._configuration_was_set = True
 
     def get_event_manager(self) -> EventManager:
         """Get the event manager."""
@@ -53,6 +53,7 @@ class ServiceLocator:
 
             self._event_manager = LocalEventManager()
 
+        self._event_manager_was_retrieved = True
         return self._event_manager
 
     def set_event_manager(self, event_manager: EventManager) -> None:
@@ -64,11 +65,10 @@ class ServiceLocator:
         Raises:
             ServiceConflictError: If the event manager was already set.
         """
-        if self._event_manager_was_set:
+        if self._event_manager_was_retrieved:
             raise ServiceConflictError(EventManager, event_manager, self._event_manager)
 
         self._event_manager = event_manager
-        self._event_manager_was_set = True
 
     def get_storage_client(self) -> BaseStorageClient:
         """Get the storage client."""
@@ -77,6 +77,7 @@ class ServiceLocator:
 
             self._storage_client = MemoryStorageClient.from_config()
 
+        self._storage_client_was_retrieved = True
         return self._storage_client
 
     def set_storage_client(self, storage_client: BaseStorageClient) -> None:
@@ -88,11 +89,10 @@ class ServiceLocator:
         Raises:
             ServiceConflictError: If the storage client was already set.
         """
-        if self._storage_client_was_set:
+        if self._storage_client_was_retrieved:
             raise ServiceConflictError(BaseStorageClient, storage_client, self._storage_client)
 
         self._storage_client = storage_client
-        self._storage_client_was_set = True
 
 
 service_locator = ServiceLocator()

--- a/src/crawlee/errors.py
+++ b/src/crawlee/errors.py
@@ -38,11 +38,11 @@ class SessionError(Exception):
 
 @docs_group('Errors')
 class ServiceConflictError(Exception):
-    """Raised when attempting to reassign a service in service container that was already configured."""
+    """Raised when attempting to reassign a service in service container that is already in use."""
 
     def __init__(self, service: type, new_value: object, existing_value: object) -> None:
         super().__init__(
-            f'Service {service.__name__} has already been set. Existing value: {existing_value}, '
+            f'Service {service.__name__} is already in use. Existing value: {existing_value}, '
             f'attempted new value: {new_value}.'
         )
 

--- a/tests/unit/_memory_storage_client/test_memory_storage_client.py
+++ b/tests/unit/_memory_storage_client/test_memory_storage_client.py
@@ -230,7 +230,7 @@ async def test_not_implemented_method(tmp_path: Path) -> None:
 async def test_default_storage_path_used(monkeypatch: pytest.MonkeyPatch) -> None:
     # Reset the configuration in service locator
     service_locator._configuration = None
-    service_locator._configuration_was_set = False
+    service_locator._configuration_was_retrieved = False
 
     # Remove the env var for setting the storage directory
     monkeypatch.delenv('CRAWLEE_STORAGE_DIR', raising=False)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -42,9 +42,9 @@ def prepare_test_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Callabl
 
         # Reset the flags in the service locator to indicate that no services are explicitly set. This ensures
         # a clean state, as services might have been set during a previous test and not reset properly.
-        service_locator._configuration_was_set = False
-        service_locator._storage_client_was_set = False
-        service_locator._event_manager_was_set = False
+        service_locator._configuration_was_retrieved = False
+        service_locator._storage_client_was_retrieved = False
+        service_locator._event_manager_was_retrieved = False
 
         # Reset the services in the service locator.
         service_locator._configuration = None
@@ -61,9 +61,9 @@ def prepare_test_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Callabl
 
         # Verify that the test environment was set up correctly.
         assert os.environ.get('CRAWLEE_STORAGE_DIR') == str(tmp_path)
-        assert service_locator._configuration_was_set is False
-        assert service_locator._storage_client_was_set is False
-        assert service_locator._event_manager_was_set is False
+        assert service_locator._configuration_was_retrieved is False
+        assert service_locator._storage_client_was_retrieved is False
+        assert service_locator._event_manager_was_retrieved is False
 
     return _prepare_test_env
 

--- a/tests/unit/test_service_locator.py
+++ b/tests/unit/test_service_locator.py
@@ -9,41 +9,93 @@ from crawlee.events import LocalEventManager
 from crawlee.memory_storage_client import MemoryStorageClient
 
 
-def test_configuration() -> None:
+def test_default_configuration() -> None:
     default_config = Configuration()
     config = service_locator.get_configuration()
     assert config == default_config
 
+
+def test_custom_configuration() -> None:
     custom_config = Configuration(default_browser_path='custom_path')
     service_locator.set_configuration(custom_config)
     config = service_locator.get_configuration()
     assert config == custom_config
 
+
+def test_configuration_overwrite() -> None:
+    default_config = Configuration()
+    service_locator.set_configuration(default_config)
+
+    custom_config = Configuration(default_browser_path='custom_path')
+    service_locator.set_configuration(custom_config)
+    assert service_locator.get_configuration() == custom_config
+
+
+def test_configuration_conflict() -> None:
+    service_locator.get_configuration()
+    custom_config = Configuration(default_browser_path='custom_path')
+
     with pytest.raises(ServiceConflictError, match='Configuration has already been set.'):
         service_locator.set_configuration(custom_config)
 
 
-def test_event_manager() -> None:
+def test_default_event_manager() -> None:
     default_event_manager = service_locator.get_event_manager()
     assert isinstance(default_event_manager, LocalEventManager)
 
+
+def test_custom_event_manager() -> None:
     custom_event_manager = LocalEventManager()
     service_locator.set_event_manager(custom_event_manager)
     event_manager = service_locator.get_event_manager()
     assert event_manager == custom_event_manager
 
+
+def test_event_manager_overwrite() -> None:
+    custom_event_manager = LocalEventManager()
+    service_locator.set_event_manager(custom_event_manager)
+
+    another_custom_event_manager = LocalEventManager()
+    service_locator.set_event_manager(another_custom_event_manager)
+
+    assert custom_event_manager != another_custom_event_manager
+    assert service_locator.get_event_manager() == another_custom_event_manager
+
+
+def test_event_manager_conflict() -> None:
+    service_locator.get_event_manager()
+    custom_event_manager = LocalEventManager()
+
     with pytest.raises(ServiceConflictError, match='EventManager has already been set.'):
         service_locator.set_event_manager(custom_event_manager)
 
 
-def test_storage_client() -> None:
+def test_default_storage_client() -> None:
     default_storage_client = service_locator.get_storage_client()
     assert isinstance(default_storage_client, MemoryStorageClient)
 
+
+def test_custom_storage_client() -> None:
     custom_storage_client = MemoryStorageClient.from_config()
     service_locator.set_storage_client(custom_storage_client)
     storage_client = service_locator.get_storage_client()
     assert storage_client == custom_storage_client
+
+
+def test_storage_client_overwrite() -> None:
+    custom_storage_client = MemoryStorageClient.from_config()
+    service_locator.set_storage_client(custom_storage_client)
+
+    another_custom_storage_client = MemoryStorageClient.from_config()
+    service_locator.set_storage_client(another_custom_storage_client)
+
+    assert custom_storage_client != another_custom_storage_client
+    assert service_locator.get_storage_client() == another_custom_storage_client
+
+
+def test_storage_client_conflict() -> None:
+    service_locator.get_storage_client()
+    custom_storage_client = MemoryStorageClient.from_config()
 
     with pytest.raises(ServiceConflictError, match='StorageClient has already been set.'):
         service_locator.set_storage_client(custom_storage_client)

--- a/tests/unit/test_service_locator.py
+++ b/tests/unit/test_service_locator.py
@@ -12,14 +12,14 @@ from crawlee.memory_storage_client import MemoryStorageClient
 def test_default_configuration() -> None:
     default_config = Configuration()
     config = service_locator.get_configuration()
-    assert config == default_config
+    assert config == default_config  # == because these are in fact different instances, which should be fine
 
 
 def test_custom_configuration() -> None:
     custom_config = Configuration(default_browser_path='custom_path')
     service_locator.set_configuration(custom_config)
     config = service_locator.get_configuration()
-    assert config == custom_config
+    assert config is custom_config
 
 
 def test_configuration_overwrite() -> None:
@@ -28,7 +28,7 @@ def test_configuration_overwrite() -> None:
 
     custom_config = Configuration(default_browser_path='custom_path')
     service_locator.set_configuration(custom_config)
-    assert service_locator.get_configuration() == custom_config
+    assert service_locator.get_configuration() is custom_config
 
 
 def test_configuration_conflict() -> None:
@@ -48,7 +48,7 @@ def test_custom_event_manager() -> None:
     custom_event_manager = LocalEventManager()
     service_locator.set_event_manager(custom_event_manager)
     event_manager = service_locator.get_event_manager()
-    assert event_manager == custom_event_manager
+    assert event_manager is custom_event_manager
 
 
 def test_event_manager_overwrite() -> None:
@@ -59,7 +59,7 @@ def test_event_manager_overwrite() -> None:
     service_locator.set_event_manager(another_custom_event_manager)
 
     assert custom_event_manager != another_custom_event_manager
-    assert service_locator.get_event_manager() == another_custom_event_manager
+    assert service_locator.get_event_manager() is another_custom_event_manager
 
 
 def test_event_manager_conflict() -> None:
@@ -79,7 +79,7 @@ def test_custom_storage_client() -> None:
     custom_storage_client = MemoryStorageClient.from_config()
     service_locator.set_storage_client(custom_storage_client)
     storage_client = service_locator.get_storage_client()
-    assert storage_client == custom_storage_client
+    assert storage_client is custom_storage_client
 
 
 def test_storage_client_overwrite() -> None:
@@ -90,7 +90,7 @@ def test_storage_client_overwrite() -> None:
     service_locator.set_storage_client(another_custom_storage_client)
 
     assert custom_storage_client != another_custom_storage_client
-    assert service_locator.get_storage_client() == another_custom_storage_client
+    assert service_locator.get_storage_client() is another_custom_storage_client
 
 
 def test_storage_client_conflict() -> None:

--- a/tests/unit/test_service_locator.py
+++ b/tests/unit/test_service_locator.py
@@ -35,7 +35,7 @@ def test_configuration_conflict() -> None:
     service_locator.get_configuration()
     custom_config = Configuration(default_browser_path='custom_path')
 
-    with pytest.raises(ServiceConflictError, match='Configuration has already been set.'):
+    with pytest.raises(ServiceConflictError, match='Configuration is already in use.'):
         service_locator.set_configuration(custom_config)
 
 
@@ -66,7 +66,7 @@ def test_event_manager_conflict() -> None:
     service_locator.get_event_manager()
     custom_event_manager = LocalEventManager()
 
-    with pytest.raises(ServiceConflictError, match='EventManager has already been set.'):
+    with pytest.raises(ServiceConflictError, match='EventManager is already in use.'):
         service_locator.set_event_manager(custom_event_manager)
 
 
@@ -97,5 +97,5 @@ def test_storage_client_conflict() -> None:
     service_locator.get_storage_client()
     custom_storage_client = MemoryStorageClient.from_config()
 
-    with pytest.raises(ServiceConflictError, match='StorageClient has already been set.'):
+    with pytest.raises(ServiceConflictError, match='StorageClient is already in use.'):
         service_locator.set_storage_client(custom_storage_client)


### PR DESCRIPTION
- this makes it possible to overwrite services in the service locator before they are retrieved for the first time
- closes #806 