### PR TITLE
feat!: Update `use_state` side efefcts to go through `RequestHandlerRunResult`

### DIFF
--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Mapping
+from copy import deepcopy
 from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, Protocol, TypeVar, Union, cast, overload
@@ -298,7 +299,6 @@ class UseStateFunction(Protocol):
 
     def __call__(
         self,
-        key: str,
         default_value: dict[str, JsonSerializable] | None = None,
     ) -> Coroutine[None, None, dict[str, JsonSerializable]]: ...
 
@@ -404,11 +404,18 @@ class GetKeyValueStoreFunction(Protocol):
 class RequestHandlerRunResult:
     """Record of calls to storage-related context helpers."""
 
+    CRAWLEE_STATE_KEY = 'CRAWLEE_STATE'
+
     def __init__(self, *, key_value_store_getter: GetKeyValueStoreFunction) -> None:
         self._key_value_store_getter = key_value_store_getter
         self.add_requests_calls = list[AddRequestsKwargs]()
         self.push_data_calls = list[PushDataFunctionCall]()
         self.key_value_store_changes = dict[tuple[Optional[str], Optional[str]], KeyValueStoreChangeRecords]()
+
+        # This is handle to dict available to user. If it gets mutated, it needs to be reflected in changes.
+        self._user_use_state: None | dict[str, JsonSerializable] = None
+        # Last known use_state by RequestHandlerRunResult. Used for mutation detection by user.
+        self._last_known_use_state: None | dict[str, JsonSerializable] = None
 
     async def add_requests(
         self,
@@ -451,3 +458,23 @@ class RequestHandlerRunResult:
             )
 
         return self.key_value_store_changes[id, name]
+
+    async def use_state(self, default_value: dict[str, JsonSerializable] | None = None) -> dict[str, JsonSerializable]:
+        """Helper method for accessing state dictionary."""
+        _default: dict[str, JsonSerializable] = default_value or {}
+        default_kvs_changes = await self.get_key_value_store()
+        use_state: dict[str, JsonSerializable] = await default_kvs_changes.get_value(self.CRAWLEE_STATE_KEY, _default)
+        if use_state is _default:
+            # Set default value if there is no value in change records or actual kvs.
+            await default_kvs_changes.set_value(self.CRAWLEE_STATE_KEY, _default)
+        # This will be same dict that is available to the user and can be mutated at any point.
+        self._user_use_state = use_state
+        # This will not be available to the user and should not be changed.
+        self._last_known_use_state = deepcopy(self._user_use_state)
+        return use_state
+
+    async def update_mutated_use_state(self) -> None:
+        """Update use_state if it was mutated by the user."""
+        if self._user_use_state != self._last_known_use_state:
+            default_kvs_changes = await self.get_key_value_store()
+            await default_kvs_changes.set_value(self.CRAWLEE_STATE_KEY, self._user_use_state)


### PR DESCRIPTION
### Description
Update use_state side efefcts to go through RequestHandlerRunResult
Hardcode key for use state. (Same key hardcoded in JS implementation.)
Update tests.

### Issues

- Closes: #856 

