### PR TITLE
fix: Avoid `use_state` race conditions. Remove key argument to `use_state`

### DIFF
--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -298,7 +298,6 @@ class UseStateFunction(Protocol):
 
     def __call__(
         self,
-        key: str,
         default_value: dict[str, JsonSerializable] | None = None,
     ) -> Coroutine[None, None, dict[str, JsonSerializable]]: ...
 

--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -173,7 +173,7 @@ class BasicCrawler(Generic[TCrawlingContext]):
         - and more.
     """
 
-    CRAWLEE_STATE_KEY = 'CRAWLEE_STATE'
+    _CRAWLEE_STATE_KEY = 'CRAWLEE_STATE'
 
     def __init__(
         self,

--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -173,6 +173,8 @@ class BasicCrawler(Generic[TCrawlingContext]):
         - and more.
     """
 
+    CRAWLEE_STATE_KEY = 'CRAWLEE_STATE'
+
     def __init__(
         self,
         *,
@@ -564,11 +566,9 @@ class BasicCrawler(Generic[TCrawlingContext]):
             wait_for_all_requests_to_be_added_timeout=wait_for_all_requests_to_be_added_timeout,
         )
 
-    async def _use_state(
-        self, key: str, default_value: dict[str, JsonSerializable] | None = None
-    ) -> dict[str, JsonSerializable]:
+    async def _use_state(self, default_value: dict[str, JsonSerializable] | None = None) -> dict[str, JsonSerializable]:
         store = await self.get_key_value_store()
-        return await store.get_auto_saved_value(key, default_value)
+        return await store.get_auto_saved_value(self.CRAWLEE_STATE_KEY, default_value)
 
     async def _save_crawler_state(self) -> None:
         store = await self.get_key_value_store()

--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -568,7 +568,7 @@ class BasicCrawler(Generic[TCrawlingContext]):
 
     async def _use_state(self, default_value: dict[str, JsonSerializable] | None = None) -> dict[str, JsonSerializable]:
         store = await self.get_key_value_store()
-        return await store.get_auto_saved_value(self.CRAWLEE_STATE_KEY, default_value)
+        return await store.get_auto_saved_value(self._CRAWLEE_STATE_KEY, default_value)
 
     async def _save_crawler_state(self) -> None:
         store = await self.get_key_value_store()

--- a/tests/unit/storages/test_key_value_store.py
+++ b/tests/unit/storages/test_key_value_store.py
@@ -201,7 +201,7 @@ async def test_get_auto_saved_value_auto_save_race_conditions(key_value_store: K
         state['counter'] += 1
 
     with patch.object(key_value_store, 'get_value', delayed_get_value):
-        tasks = [asyncio.create_task(increment_counter()) for _ in range(2)]
+        tasks = [asyncio.create_task(increment_counter()), asyncio.create_task(increment_counter())]
         await asyncio.gather(*tasks)
 
     assert (await key_value_store.get_auto_saved_value('state'))['counter'] == 2

--- a/tests/unit/storages/test_key_value_store.py
+++ b/tests/unit/storages/test_key_value_store.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
+from itertools import chain, repeat
+from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
 from urllib.parse import urlparse
 
@@ -178,3 +179,29 @@ async def test_get_auto_saved_value_auto_save(key_value_store: KeyValueStore, mo
 
     value['hello'] = 'new_world'
     assert await autosaved_within_deadline(key=key_name, expected_value={'hello': 'new_world'})
+
+
+async def test_get_auto_saved_value_auto_save_race_conditions(key_value_store: KeyValueStore) -> None:
+    """Two parallel functions increment global variable obtained by `get_auto_saved_value`.
+
+    Result should be incremented by 2.
+    Method `get_auto_saved_value` must be implemented in a way that prevents race conditions in such scenario.
+    Test creates situation where first `get_auto_saved_value` call to kvs gets delayed. Such situation can happen
+    and unless handled, it can cause race condition in getting the state value."""
+    await key_value_store.set_value('state', {'counter': 0})
+
+    sleep_time_iterator = chain(iter([0.5]), repeat(0))
+
+    async def delayed_get_value(key: str, default_value: None) -> None:
+        await asyncio.sleep(next(sleep_time_iterator))
+        return await KeyValueStore.get_value(key_value_store, key=key, default_value=default_value)
+
+    async def increment_counter() -> None:
+        state = cast(dict[str, int], await key_value_store.get_auto_saved_value('state'))
+        state['counter'] += 1
+
+    with patch.object(key_value_store, 'get_value', delayed_get_value):
+        tasks = [asyncio.create_task(increment_counter()) for _ in range(2)]
+        await asyncio.gather(*tasks)
+
+    assert (await key_value_store.get_auto_saved_value('state'))['counter'] == 2


### PR DESCRIPTION
### Description
Align Python implementation of `use_state` wirth JS

Add lock when accessing the cache or kvs to prevent race conditions.
Add unit tests for race conditions.


### Breaking

Remove key argument from `use_state` and hard code it to `BasicCrawler.CRAWLEE_STATE_KEY`. 
(Change in experimental feature is not marked as hard breaking with `!`.) 

### Issues

- Closes: #856

