### PR TITLE
docs: fix multiline `Args` documentation

### DIFF
--- a/src/crawlee/crawlers/_playwright/_playwright_crawler.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_crawler.py
@@ -84,12 +84,12 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext]):
             browser_type: The type of browser to launch ('chromium', 'firefox', or 'webkit').
                 This option should not be used if `browser_pool` is provided.
             browser_launch_options: Keyword arguments to pass to the browser launch method. These options are provided
-                directly to Playwright's `browser_type.launch` method. For more details, refer to the Playwright
-                documentation: https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch.
+                directly to Playwright's `browser_type.launch` method. For more details, refer to the
+                [Playwright documentation](https://playwright.dev/python/docs/api/class-browsertype#browser-type-launch).
                 This option should not be used if `browser_pool` is provided.
             browser_new_context_options: Keyword arguments to pass to the browser new context method. These options
                 are provided directly to Playwright's `browser.new_context` method. For more details, refer to the
-                Playwright documentation: https://playwright.dev/python/docs/api/class-browser#browser-new-context.
+                [Playwright documentation](https://playwright.dev/python/docs/api/class-browser#browser-new-context).
                 This option should not be used if `browser_pool` is provided.
             headless: Whether to run the browser in headless mode.
                 This option should not be used if `browser_pool` is provided.

--- a/website/package.json
+++ b/website/package.json
@@ -34,7 +34,7 @@
         "typescript": "5.7.2"
     },
     "dependencies": {
-        "@apify/docusaurus-plugin-typedoc-api": "^4.3.5",
+        "@apify/docusaurus-plugin-typedoc-api": "^4.3.6",
         "@apify/utilities": "^2.8.0",
         "@docusaurus/core": "^3.5.2",
         "@docusaurus/mdx-loader": "^3.5.2",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -365,9 +365,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apify/docusaurus-plugin-typedoc-api@npm:^4.3.5":
-  version: 4.3.5
-  resolution: "@apify/docusaurus-plugin-typedoc-api@npm:4.3.5"
+"@apify/docusaurus-plugin-typedoc-api@npm:^4.3.6":
+  version: 4.3.6
+  resolution: "@apify/docusaurus-plugin-typedoc-api@npm:4.3.6"
   dependencies:
     "@docusaurus/plugin-content-docs": "npm:^3.5.2"
     "@docusaurus/types": "npm:^3.5.2"
@@ -384,7 +384,7 @@ __metadata:
     "@docusaurus/mdx-loader": ^3.5.2
     react: ">=18.0.0"
     typescript: ^5.0.0
-  checksum: 10c0/f68d0e6fb3014e7d3777916c061fb2fcc1a83aba43ef06b3c1781cf9aded858c35343247ab90021d0d04b1897fa8d6f091168032c497506e5ab544b29fe8d219
+  checksum: 10c0/fa5a231de6200c50dc14b8d7b3abb45f8cc90cef46da9fefc43a44d55e9788142f7bb02cd7101c02c67d4ce9f421ef2c36817c45f4c7c7d5d5af3f67f21d8c7f
   languageName: node
   linkType: hard
 
@@ -5754,7 +5754,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "crawlee@workspace:."
   dependencies:
-    "@apify/docusaurus-plugin-typedoc-api": "npm:^4.3.5"
+    "@apify/docusaurus-plugin-typedoc-api": "npm:^4.3.6"
     "@apify/eslint-config-ts": "npm:^0.4.0"
     "@apify/tsconfig": "npm:^0.1.0"
     "@apify/utilities": "npm:^2.8.0"


### PR DESCRIPTION
|before|after|
|---|---|
| ![obrazek](https://github.com/user-attachments/assets/be234c13-2cc6-443d-a0b9-990389868467) | ![obrazek](https://github.com/user-attachments/assets/87134dd0-0778-41a1-b5fc-209ad639f3cc) |

Bumps the `@apify/docusaurus-plugin-typedoc-api` package to the version with patched comment parsing (see https://github.com/apify/docusaurus-plugin-typedoc-api/pull/37)

The second commit turns naked links to Markdown links with the `[]()` syntax. This is purely for aesthetics (I didn't like seeing the same long URL twice under each other). If this is undesired - e.g. breaks something or goes against our style guide - I'm happy to revert.