### PR TITLE
ci: Add workflow dispatch for pre-release workflow

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -8,7 +8,10 @@ on:
     tags-ignore:
       - "**" # Ignore all tags to prevent duplicate builds when tags are pushed.
 
-concurrency: 
+  # Or it can be triggered manually.
+  workflow_dispatch:
+
+concurrency:
   group: release
   cancel-in-progress: false
 
@@ -72,7 +75,7 @@ jobs:
     steps:
       - name: Prepare distribution
         uses: apify/workflows/prepare-pypi-distribution@main
-        with: 
+        with:
           package_name: crawlee
           is_prerelease: "yes"
           version_number: ${{ needs.release_metadata.outputs.version_number }}


### PR DESCRIPTION
To be able to solve issues like this - https://github.com/apify/apify-sdk-python/actions/runs/12671344582/job/35314370843, by manual re-run.