### PR TITLE
fix: Optimize memory consumption for `HttpxHttpClient`, fix proxy handling

### DIFF
--- a/src/crawlee/proxy_configuration.py
+++ b/src/crawlee/proxy_configuration.py
@@ -197,7 +197,7 @@ class ProxyConfiguration:
         else:
             raise RuntimeError('Invalid state')
 
-        if session_id is None or request is not None:
+        if session_id is None:
             url = urls[self._next_custom_url_index % len(urls)]
             self._next_custom_url_index += 1
             return url, proxy_tier

--- a/tests/unit/proxy_configuration/test_tiers.py
+++ b/tests/unit/proxy_configuration/test_tiers.py
@@ -84,13 +84,13 @@ async def test_successful_request_makes_tier_go_down() -> None:
 
     info = None
     for tier in tiered_proxy_urls:
-        info = await config.new_proxy_info('session_id', request_1, None)
+        info = await config.new_proxy_info(None, request_1, None)
         assert info is not None
         assert info.url == tier[0]
 
     for i in range(100):
         new_request = Request(url=f'http://some.domain/{i}', unique_key=str(i), id=str(i))
-        info = await config.new_proxy_info('session_id', new_request, None)
+        info = await config.new_proxy_info(None, new_request, None)
 
     assert info is not None
     assert info.url == tiered_proxy_urls[0][0]


### PR DESCRIPTION
### Description

- Use a shared transport and SSL context for all `httpx.AsyncClient` instances
- Fix proxy handling by implementing proper binding of `session_id` to `proxy_url`

### Issues

- Closes: #895

### Testing

- Updated test `tests/unit/proxy_configuration/test_tiers.py::test_successful_request_makes_tier_go_down`. In the previous version, when `session_id` was passed, we should not obtain a new proxy even if the tier changes. The updated test now aligns with both the documentation and the `test_retrying_request_makes_tier_go_up` test.
