### PR TITLE
fix: fix `BrowserPool` and `PlaywrightBrowserPlugin` closure

### DIFF
--- a/src/crawlee/browsers/_browser_pool.py
+++ b/src/crawlee/browsers/_browser_pool.py
@@ -204,6 +204,8 @@ class BrowserPool:
 
         for browser in self._active_browsers + self._inactive_browsers:
             await browser.close(force=True)
+        self._active_browsers.clear()
+        self._inactive_browsers.clear()
 
         for plugin in self._plugins:
             await plugin.__aexit__(exc_type, exc_value, exc_traceback)

--- a/src/crawlee/browsers/_playwright_browser_plugin.py
+++ b/src/crawlee/browsers/_playwright_browser_plugin.py
@@ -134,6 +134,7 @@ class PlaywrightBrowserPlugin(BaseBrowserPlugin):
             raise RuntimeError(f'The {self.__class__.__name__} is not active.')
 
         await self._playwright_context_manager.__aexit__(exc_type, exc_value, exc_traceback)
+        self._playwright_context_manager = async_playwright()
         self._active = False
 
     @override


### PR DESCRIPTION
### Description

- Fix the `BrowserPool` and `PlaywrightBrowserPlugin` closures. Without it, the application crashes when `PlaywrightCrawler` is run in sequence again.
