### PR TITLE
feat: Return handler upon decorator invocation

### DIFF
--- a/src/crawlee/router.py
+++ b/src/crawlee/router.py
@@ -33,7 +33,9 @@ class Router(Generic[TCrawlingContext]):
 
         return handler
 
-    def handler(self, label: str) -> Callable[[RequestHandler[TCrawlingContext]], None]:
+    def handler(
+        self, label: str
+    ) -> Callable[[RequestHandler[TCrawlingContext]], Callable[[TCrawlingContext], Awaitable]]:
         """A decorator used to register a label-based handler.
 
         The registered will be invoked only for requests with the exact same label.
@@ -41,8 +43,9 @@ class Router(Generic[TCrawlingContext]):
         if label in self._handlers_by_label:
             raise RuntimeError(f'A handler for label `{label}` is already registered')
 
-        def wrapper(handler: Callable[[TCrawlingContext], Awaitable]) -> None:
+        def wrapper(handler: Callable[[TCrawlingContext], Awaitable]) -> Callable[[TCrawlingContext], Awaitable]:
             self._handlers_by_label[label] = handler
+            return handler
 
         return wrapper
 

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -91,6 +91,17 @@ async def test_router_specific_handler_invoked() -> None:
     mock_handler_b.assert_called()
 
 
+async def test_router_handler_not_nullified() -> None:
+    router = Router[MockContext]()
+    mock_handler = Mock()
+
+    @router.handler('A')
+    async def handler_a(_context: MockContext) -> None:
+        mock_handler()
+
+    assert handler_a is not None
+
+
 async def test_router_multi_labelled_handler() -> None:
     router = Router[MockContext]()
     mock_handler = Mock()
@@ -100,11 +111,8 @@ async def test_router_multi_labelled_handler() -> None:
     async def handler(_context: MockContext) -> None:
         mock_handler(_context.request.label)
 
-    # The handler should be invoked for both labels
     await router(MockContext(label='A'))
     mock_handler.assert_called_with('A')
     await router(MockContext(label='B'))
     mock_handler.assert_called_with('B')
     assert mock_handler.call_count == 2
-
-    assert handler is not None, 'Handler should be defined still.'

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -89,3 +89,20 @@ async def test_router_specific_handler_invoked() -> None:
     mock_default_handler.assert_not_called()
     mock_handler_a.assert_not_called()
     mock_handler_b.assert_called()
+
+
+async def test_router_multi_labelled_handler() -> None:
+    router = Router[MockContext]()
+    mock_handler = Mock()
+
+    @router.handler('A')
+    @router.handler('B')
+    async def handler(_context: MockContext) -> None:
+        mock_handler(_context.request.label)
+
+    await router(MockContext(label='A'))
+    mock_handler.assert_called_with('A')
+    await router(MockContext(label='B'))
+    mock_handler.assert_called_with('B')
+
+    assert mock_handler.call_count == 2

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -100,9 +100,11 @@ async def test_router_multi_labelled_handler() -> None:
     async def handler(_context: MockContext) -> None:
         mock_handler(_context.request.label)
 
+    # The handler should be invoked for both labels
     await router(MockContext(label='A'))
     mock_handler.assert_called_with('A')
     await router(MockContext(label='B'))
     mock_handler.assert_called_with('B')
-
     assert mock_handler.call_count == 2
+
+    assert handler is not None, 'Handler should be defined still.'


### PR DESCRIPTION
### Description
Currently, wrapping a handler with a decorator nullifies the function because it returns `None` [in the code](https://github.com/apify/crawlee-python/blob/28579996e454e19dd69ed6ee09e4293d4e056a6e/src/crawlee/router.py#L44-L45). See the "None" popup over here:
![image](https://github.com/user-attachments/assets/96df44c5-3ceb-4145-9bdd-f697bdf2da3d)

By having the router.handler function return the original input handler, we can now reuse the handler function again in other places as it's not set to `None` anymore. This allows for invoking the original function even after applying the decorator and for adding multiple decorators to the same handler function. The latter for example allows for using the same handler function for multiple labels (a use case I ran into).

### Issues
Not applicable.

### Testing

- [x] Added a test to ensure handler is not nullified
- [x] Added a test for multiple labels assigned to a single handler

### Checklist

- [x] CI passed

Please let me know your thoughts! :raised_hands: 