### PR TITLE
docs: update setting up and running in cloud

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
 .PHONY: clean install-dev build publish-to-pypi lint type-check unit-tests unit-tests-cov integration-tests format check-code build-api-reference run-docs
 
-DIRS_WITH_CODE = src tests docs website
-
 # This is default for local testing, but GitHub workflows override it to a higher value in CI
 INTEGRATION_TESTS_CONCURRENCY = 1
 
@@ -22,11 +20,11 @@ publish-to-pypi:
 	poetry publish --no-interaction -vv
 
 lint:
-	poetry run ruff format --check $(DIRS_WITH_CODE)
-	poetry run ruff check $(DIRS_WITH_CODE)
+	poetry run ruff format --check
+	poetry run ruff check
 
 type-check:
-	poetry run mypy $(DIRS_WITH_CODE)
+	poetry run mypy
 
 unit-tests:
 	poetry run pytest --numprocesses=auto --verbose --cov=src/crawlee tests/unit
@@ -38,8 +36,8 @@ integration-tests:
 	poetry run pytest --numprocesses=$(INTEGRATION_TESTS_CONCURRENCY) tests/integration
 
 format:
-	poetry run ruff check --fix $(DIRS_WITH_CODE)
-	poetry run ruff format $(DIRS_WITH_CODE)
+	poetry run ruff check --fix
+	poetry run ruff format
 
 # The check-code target runs a series of checks equivalent to those performed by pre-commit hooks
 # and the run_checks.yaml GitHub Actions workflow.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ We also have a TypeScript implementation of the Crawlee, which you can explore a
 
 We recommend visiting the [Introduction tutorial](https://crawlee.dev/python/docs/introduction) in Crawlee documentation for more information.
 
-Crawlee is available as the [`crawlee`](https://pypi.org/project/crawlee/) PyPI package. The core functionality is included in the base package, with additional features available as optional extras to minimize package size and dependencies. To install Crawlee with all features, run the following command:
+Crawlee is available as [`crawlee`](https://pypi.org/project/crawlee/) package on PyPI. This package includes the core functionality, while additional features are available as optional extras to keep dependencies and package size minimal.
+
+To install Crawlee with all features, run the following command:
 
 ```sh
 pip install 'crawlee[all]'

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Crawlee is available as [`crawlee`](https://pypi.org/project/crawlee/) package o
 To install Crawlee with all features, run the following command:
 
 ```sh
-pip install 'crawlee[all]'
+python -m pip install 'crawlee[all]'
 ```
 
 Then, install the [Playwright](https://playwright.dev/) dependencies:

--- a/docs/deployment/apify_platform.mdx
+++ b/docs/deployment/apify_platform.mdx
@@ -25,7 +25,7 @@ We do not test Crawlee in other cloud environments such as Lambda or on specific
 
 ## Logging into Apify platform from Crawlee
 
-To access your [Apify account](https://console.apify.com/sign-up) from Crawlee, you must provide credentials - your [API token](https://console.apify.com/account?tab=integrations). You can do that either by utilizing [Apify CLI](https://github.com/apify/apify-cli) or with environment variables.
+To access your [Apify account](https://console.apify.com/sign-up) from Crawlee, you must provide credentials - your [API token](https://console.apify.com/account?tab=integrations). You can do that either by utilizing [Apify CLI](https://docs.apify.com/cli/) or with environment variables.
 
 Once you provide credentials to your Apify CLI installation, you will be able to use all the Apify platform features, such as calling Actors, saving to cloud storages, using Apify proxies, setting up webhooks and so on.
 
@@ -140,7 +140,7 @@ If you don't plan to force usage of the platform storages when running the Actor
 {/*
 ### Getting public url of an item in the platform storage
 
-If you need to share a link to some file stored in a [Key-Value](https://docs.apify.com/sdk/python/reference/class/KeyValueStore) Store on Apify Platform, you can use [`get_public_url()`](https://docs.apify.com/sdk/python/reference/class/KeyValueStore#get_public_url) method. It accepts only one parameter: `key` - the key of the item you want to share.
+If you need to share a link to some file stored in a [Key-Value](https://docs.apify.com/sdk/python/reference/class/KeyValueStore) Store on Apify platform, you can use [`get_public_url()`](https://docs.apify.com/sdk/python/reference/class/KeyValueStore#get_public_url) method. It accepts only one parameter: `key` - the key of the item you want to share.
 
 <CodeBlock language="python">
     {GetPublicUrlSource}

--- a/docs/deployment/apify_platform.mdx
+++ b/docs/deployment/apify_platform.mdx
@@ -6,8 +6,6 @@ description: Apify platform - large-scale and high-performance web scraping
 
 import ApiLink from '@site/src/components/ApiLink';
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
 import CodeBlock from '@theme/CodeBlock';
 
 import LogWithConfigExample from '!!raw-loader!./code/apify/log_with_config_example.py';

--- a/docs/guides/http_clients.mdx
+++ b/docs/guides/http_clients.mdx
@@ -36,13 +36,13 @@ In Crawlee we currently have two HTTP clients: <ApiLink to="class/HttpxHttpClien
 Since <ApiLink to="class/HttpxHttpClient">`HttpxHttpClient`</ApiLink> is the default HTTP client, you don't need to install additional packages to use it. If you want to use <ApiLink to="class/CurlImpersonateHttpClient">`CurlImpersonateHttpClient`</ApiLink>, you need to install `crawlee` with the `curl-impersonate` extra.
 
 ```sh
-pip install 'crawlee[curl-impersonate]'
+python -m pip install 'crawlee[curl-impersonate]'
 ```
 
 or install all available extras:
 
 ```sh
-pip install 'crawlee[all]'
+python -m pip install 'crawlee[all]'
 ```
 
 ## How HTTP clients work

--- a/docs/guides/storages.mdx
+++ b/docs/guides/storages.mdx
@@ -33,7 +33,7 @@ Crawlee offers multiple storage types for managing and persisting your crawling 
 Storage clients in Crawlee are subclasses of <ApiLink to="class/BaseStorageClient">`BaseStorageClient`</ApiLink>. They handle interactions with different storage backends. For instance:
 
 - <ApiLink to="class/MemoryStorageClient">`MemoryStorageClient`</ApiLink>: Stores data in memory and persists it to the local file system.
-- [`ApifyStorageClient`](https://docs.apify.com/sdk/python/reference/class/ApifyStorageClient): Manages storage on the [Apify Platform](https://apify.com). Apify storage client is implemented in the [Apify SDK](https://github.com/apify/apify-sdk-python).
+- [`ApifyStorageClient`](https://docs.apify.com/sdk/python/reference/class/ApifyStorageClient): Manages storage on the [Apify platform](https://apify.com). Apify storage client is implemented in the [Apify SDK](https://github.com/apify/apify-sdk-python).
 
 Each storage client is responsible for maintaining the storages in a specific environment. This abstraction makes it easier to switch between different environments, e.g. between local development and cloud production setup.
 
@@ -52,7 +52,7 @@ where:
 - `{STORAGE_ID}`: The ID of the specific storage instance (default: `default`).
 
 :::info NOTE
-The current <ApiLink to="class/MemoryStorageClient">`MemoryStorageClient`</ApiLink> and its interface is quite old and not great. We plan to refactor it, together with the whole <ApiLink to="class/BaseStorageClient">`BaseStorageClient`</ApiLink> interface in the near future and it better and and easier to use. We also plan to introduce new storage clients for different storage backends - e.g. for [SQLLite](https://www.sqlite.org/).
+The current <ApiLink to="class/MemoryStorageClient">`MemoryStorageClient`</ApiLink> and its interface is quite old and not great. We plan to refactor it, together with the whole <ApiLink to="class/BaseStorageClient">`BaseStorageClient`</ApiLink> interface in the near future and it better and and easier to use. We also plan to introduce new storage clients for different storage backends - e.g. for [SQLLite](https://sqlite.org/).
 :::
 
 You can override default storage IDs using these environment variables: `CRAWLEE_DEFAULT_DATASET_ID`, `CRAWLEE_DEFAULT_KEY_VALUE_STORE_ID`, or `CRAWLEE_DEFAULT_REQUEST_QUEUE_ID`.
@@ -117,7 +117,7 @@ The <ApiLink to="class/RequestQueue">`RequestQueue`</ApiLink> implements the <Ap
 
 If you need custom functionality, you can create your own request storage by subclassing the <ApiLink to="class/RequestManager">`RequestManager`</ApiLink> class and implementing its required methods.
 
-For a detailed explanation of the <ApiLink to="class/RequestManager">`RequestManager`</ApiLink> and other related components, refer to the [Request loaders guide](https://www.crawlee.dev/python/docs/guides/request-loaders).
+For a detailed explanation of the <ApiLink to="class/RequestManager">`RequestManager`</ApiLink> and other related components, refer to the [Request loaders guide](https://crawlee.dev/python/docs/guides/request-loaders).
 
 ## Dataset
 

--- a/docs/introduction/01_setting_up.mdx
+++ b/docs/introduction/01_setting_up.mdx
@@ -4,13 +4,22 @@ title: Setting up
 ---
 
 import ApiLink from '@site/src/components/ApiLink';
+import CodeBlock from '@theme/CodeBlock';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-To run Crawlee on your computer, ensure you meet the following requirements:
+This guide will help you get started with Crawlee by setting it up on your computer. Follow the steps below to ensure a smooth installation process.
 
-1. [Python](https://www.python.org/) 3.9 or higher installed,
-2. [Pip](https://pip.pypa.io/en/stable/) installed.
+## Prerequisites
 
-You can verify these by running the following commands:
+Before installing Crawlee itself, make sure that your system meets the following requirements:
+
+- **Python 3.9 or higher**: Crawlee requires Python 3.9 or a newer version. You can download Python from the [official website](https://www.python.org/downloads/).
+- **Python package manager**: While this guide uses Pip (the most common package manager), you can also use any package manager you want. You can download Pip from the [official website](https://pip.pypa.io/en/stable/installation/).
+
+### Verifying prerequisites
+
+To check if Python and the Pip package manager are installed, run the following commands:
 
 ```sh
 python --version
@@ -20,9 +29,15 @@ python --version
 pip --version
 ```
 
-## Installation
+If these commands return the respective versions, you're ready to continue.
 
-Crawlee is available as the [`crawlee`](https://pypi.org/project/crawlee/) PyPI package. To install the core package, use:
+## Installing Crawlee
+
+Crawlee is available as the [`crawlee`](https://pypi.org/project/crawlee/) package on PyPI. The core package includes the core functionality, while additional features are available as optional extras to keep dependencies and package size minimal.
+
+### Basic installation
+
+To install the core package, run:
 
 ```sh
 pip install crawlee
@@ -34,21 +49,17 @@ After installation, verify that Crawlee is installed correctly by checking its v
 python -c 'import crawlee; print(crawlee.__version__)'
 ```
 
-Crawlee offers several optional features through package extras. You can choose to install only the dependencies you need or install everything if you don't mind the package size.
+### Full installation
 
-### Install all features
-
-If you do not care about the package size, install Crawlee with all features:
+If you want to install Crawlee with all optional features, and/or you do not mind the package size, run the following command:
 
 ```sh
 pip install 'crawlee[all]'
 ```
 
-### Installing only specific extras
+### Installing specific extras
 
 Depending on your use case, you may want to install specific extras to enable additional functionality:
-
-#### BeautifulSoup
 
 For using the <ApiLink to="class/BeautifulSoupCrawler">`BeautifulSoupCrawler`</ApiLink>, install the `beautifulsoup` extra:
 
@@ -56,23 +67,17 @@ For using the <ApiLink to="class/BeautifulSoupCrawler">`BeautifulSoupCrawler`</A
 pip install 'crawlee[beautifulsoup]'
 ```
 
-#### Parsel
-
 For using the <ApiLink to="class/ParselCrawler">`ParselCrawler`</ApiLink>, install the `parsel` extra:
 
 ```sh
 pip install 'crawlee[parsel]'
 ```
 
-#### Curl impersonate
-
 For using the <ApiLink to="class/CurlImpersonateHttpClient">`CurlImpersonateHttpClient`</ApiLink>, install the `curl-impersonate` extra:
 
 ```sh
 pip install 'crawlee[curl-impersonate]'
 ```
-
-#### Playwright
 
 If you plan to use a (headless) browser with <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>, install Crawlee with the `playwright` extra:
 
@@ -94,25 +99,53 @@ You can install multiple extras at once by using a comma as a separator:
 pip install 'crawlee[beautifulsoup,curl-impersonate]'
 ```
 
-## With Crawlee CLI
+## Start a new project
 
-The quickest way to get started with Crawlee is by using the Crawlee CLI and selecting one of the prepared templates. First, ensure you have [Pipx](https://pipx.pypa.io/) installed:
+The quickest way to get started with Crawlee is by using the Crawlee CLI and selecting one of the prepared templates. The CLI helps you set up a new project in seconds.
 
-```sh
-pipx --help
-```
+### Using Crawlee CLI with Pipx
 
-Then, run the CLI and choose from the available templates:
+First, ensure you have Pipx installed. You can check if Pipx is installed by running:
 
 ```sh
-pipx run crawlee create my-crawler
+pipx --version
 ```
+
+If Pipx is not installed, follow the official [installation guide](https://pipx.pypa.io/stable/installation/).
+
+Then, run the Crawlee CLI using Pipx and choose from the available templates:
+
+```sh
+pipx run crawlee create my_crawler
+```
+
+### Using Crawlee CLI directly
 
 If you already have `crawlee` installed, you can spin it up by running:
 
 ```sh
-crawlee create my-crawler
+crawlee create my_crawler
 ```
+
+Follow the interactive prompts in the CLI to choose a crawler type and set up your new project.
+
+### Running your project
+
+To run your newly created project, navigate to the project directory, activate the virtual environment, and execute the Python interpreter with the project module:
+
+```sh
+cd -m my_crawler
+```
+
+```sh
+source .venv/bin/activate
+```
+
+```sh
+python -m my_crawler
+```
+
+Congratulations! You have successfully set up and executed your first Crawlee project.
 
 ## Next steps
 

--- a/docs/introduction/01_setting_up.mdx
+++ b/docs/introduction/01_setting_up.mdx
@@ -26,7 +26,7 @@ python --version
 ```
 
 ```sh
-pip --version
+python -m pip --version
 ```
 
 If these commands return the respective versions, you're ready to continue.
@@ -40,7 +40,7 @@ Crawlee is available as [`crawlee`](https://pypi.org/project/crawlee/) package o
 To install the core package, run:
 
 ```sh
-pip install crawlee
+python -m pip install crawlee
 ```
 
 After installation, verify that Crawlee is installed correctly by checking its version:
@@ -54,7 +54,7 @@ python -c 'import crawlee; print(crawlee.__version__)'
 If you do not mind the package size, you can run the following command to install Crawlee with all optional features:
 
 ```sh
-pip install 'crawlee[all]'
+python -m pip install 'crawlee[all]'
 ```
 
 ### Installing specific extras
@@ -64,25 +64,25 @@ Depending on your use case, you may want to install specific extras to enable ad
 For using the <ApiLink to="class/BeautifulSoupCrawler">`BeautifulSoupCrawler`</ApiLink>, install the `beautifulsoup` extra:
 
 ```sh
-pip install 'crawlee[beautifulsoup]'
+python -m pip install 'crawlee[beautifulsoup]'
 ```
 
 For using the <ApiLink to="class/ParselCrawler">`ParselCrawler`</ApiLink>, install the `parsel` extra:
 
 ```sh
-pip install 'crawlee[parsel]'
+python -m pip install 'crawlee[parsel]'
 ```
 
 For using the <ApiLink to="class/CurlImpersonateHttpClient">`CurlImpersonateHttpClient`</ApiLink>, install the `curl-impersonate` extra:
 
 ```sh
-pip install 'crawlee[curl-impersonate]'
+python -m pip install 'crawlee[curl-impersonate]'
 ```
 
 If you plan to use a (headless) browser with <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>, install Crawlee with the `playwright` extra:
 
 ```sh
-pip install 'crawlee[playwright]'
+python -m pip install 'crawlee[playwright]'
 ```
 
 After installing the playwright extra, install the necessary Playwright dependencies:
@@ -96,7 +96,7 @@ playwright install
 You can install multiple extras at once by using a comma as a separator:
 
 ```sh
-pip install 'crawlee[beautifulsoup,curl-impersonate]'
+python -m pip install 'crawlee[beautifulsoup,curl-impersonate]'
 ```
 
 ## Start a new project
@@ -133,17 +133,18 @@ Follow the interactive prompts in the CLI to choose a crawler type and set up yo
 
 To run your newly created project, navigate to the project directory, activate the virtual environment, and execute the Python interpreter with the project module:
 
-```sh
-cd -m my_crawler
-```
-
-```sh
-source .venv/bin/activate
-```
-
-```sh
-python -m my_crawler
-```
+<Tabs>
+  <TabItem value="Linux" label="Linux" default>
+      <CodeBlock language="sh">cd my_crawler/</CodeBlock>
+      <CodeBlock language="sh">source .venv/bin/activate</CodeBlock>
+      <CodeBlock language="sh">python -m my_crawler</CodeBlock>
+  </TabItem>
+<TabItem value="Windows" label="Windows" default>
+      <CodeBlock language="sh">cd my_crawler/</CodeBlock>
+      <CodeBlock language="sh">venv\Scripts\activate</CodeBlock>
+      <CodeBlock language="sh">python -m my_crawler</CodeBlock>
+  </TabItem>
+</Tabs>
 
 Congratulations! You have successfully set up and executed your first Crawlee project.
 

--- a/docs/introduction/01_setting_up.mdx
+++ b/docs/introduction/01_setting_up.mdx
@@ -14,12 +14,12 @@ This guide will help you get started with Crawlee by setting it up on your compu
 
 Before installing Crawlee itself, make sure that your system meets the following requirements:
 
-- **Python 3.9 or higher**: Crawlee requires Python 3.9 or a newer version. You can download Python from the [official website](https://www.python.org/downloads/).
-- **Python package manager**: While this guide uses Pip (the most common package manager), you can also use any package manager you want. You can download Pip from the [official website](https://pip.pypa.io/en/stable/installation/).
+- **Python 3.9 or higher**: Crawlee requires Python 3.9 or a newer version. You can download Python from the [official website](https://python.org/downloads/).
+- **Python package manager**: While this guide uses [pip](https://pip.pypa.io/) (the most common package manager), you can also use any package manager you want. You can download pip from the [official website](https://pip.pypa.io/en/stable/installation/).
 
 ### Verifying prerequisites
 
-To check if Python and the Pip package manager are installed, run the following commands:
+To check if Python and pip are installed, run the following commands:
 
 ```sh
 python --version
@@ -33,7 +33,7 @@ If these commands return the respective versions, you're ready to continue.
 
 ## Installing Crawlee
 
-Crawlee is available as the [`crawlee`](https://pypi.org/project/crawlee/) package on PyPI. The core package includes the core functionality, while additional features are available as optional extras to keep dependencies and package size minimal.
+Crawlee is available as [`crawlee`](https://pypi.org/project/crawlee/) package on PyPI. This package includes the core functionality, while additional features are available as optional extras to keep dependencies and package size minimal.
 
 ### Basic installation
 
@@ -51,7 +51,7 @@ python -c 'import crawlee; print(crawlee.__version__)'
 
 ### Full installation
 
-If you want to install Crawlee with all optional features, and/or you do not mind the package size, run the following command:
+If you do not mind the package size, you can run the following command to install Crawlee with all optional features:
 
 ```sh
 pip install 'crawlee[all]'

--- a/docs/introduction/08_refactoring.mdx
+++ b/docs/introduction/08_refactoring.mdx
@@ -71,6 +71,6 @@ It's good practice in any programming language to split your logic into bite-siz
 
 ## Next steps
 
-In the next and final step, you'll see how to deploy your Crawlee project to the cloud. If you used the CLI to bootstrap your project, you already have a **Dockerfile** ready, and the next section will show you how to deploy it to the [Apify Platform](../deployment/apify-platform) with ease.
+In the next and final step, you'll see how to deploy your Crawlee project to the cloud. If you used the CLI to bootstrap your project, you already have a **Dockerfile** ready, and the next section will show you how to deploy it to the [Apify platform](../deployment/apify-platform) with ease.
 
 */}

--- a/docs/introduction/08_refactoring.mdx
+++ b/docs/introduction/08_refactoring.mdx
@@ -67,10 +67,6 @@ Initially, using a simple `if` / `else` statement for selecting different logic 
 
 It's good practice in any programming language to split your logic into bite-sized chunks that are easy to read and reason about. Scrolling through a thousand line long `request_handler()` where everything interacts with everything and variables can be used everywhere is not a beautiful thing to do and a pain to debug. That's why we prefer the separation of routes into their own files.
 
-{/* TODO: write this once SDK v2 is ready
-
 ## Next steps
 
-In the next and final step, you'll see how to deploy your Crawlee project to the cloud. If you used the CLI to bootstrap your project, you already have a **Dockerfile** ready, and the next section will show you how to deploy it to the [Apify platform](../deployment/apify-platform) with ease.
-
-*/}
+In the next and final step, you'll see how to deploy your Crawlee project to the cloud. If you used the CLI to bootstrap your project, you already have a `Dockerfile` ready, and the next section will show you how to deploy it to the [Apify platform](../deployment/apify-platform) with ease.

--- a/docs/introduction/09_running_in_cloud.mdx
+++ b/docs/introduction/09_running_in_cloud.mdx
@@ -10,7 +10,7 @@ import MainExample from '!!raw-loader!./code/09_apify_sdk.py';
 
 ## Apify Platform
 
-Crawlee is developed by [**Apify**](https://apify.com), the web scraping and automation platform. You could say it is the **home of Crawlee projects**. In this section you'll see how to deploy the crawler there with just a few simple steps. You can deploy a **Crawlee** project wherever you want, but using the [**Apify Platform**](https://console.apify.com) will give you the best experience.
+Crawlee is developed by [**Apify**](https://apify.com), the web scraping and automation platform. You could say it is the **home of Crawlee projects**. In this section you'll see how to deploy the crawler there with just a few simple steps. You can deploy a **Crawlee** project wherever you want, but using the [**Apify platform**](https://console.apify.com) will give you the best experience.
 
 {/*In case you want to deploy your Crawlee project to other platforms, check out the [**Deployment**](../deployment) section.*/}
 
@@ -24,24 +24,17 @@ We started this guide by using the Crawlee CLI to bootstrap the project - it off
 
 ## Dependencies
 
-The first step will be installing two new dependencies:
+Before we get started, you'll need to install two new dependencies:
 
-- Apify SDK, a toolkit for working with the Apify Platform. This will allow us to wire the storages (e.g. [`RequestQueue`](https://docs.apify.com/sdk/python/reference/class/RequestQueue) and [`Dataset`](https://docs.apify.com/sdk/python/reference/class/Dataset)) to the Apify cloud products. This will be a dependency of our project.
+- [**Apify SDK**](https://pypi.org/project/apify/), a toolkit for working with the Apify platform. This will allow us to wire the storages (e.g. [`RequestQueue`](https://docs.apify.com/sdk/python/reference/class/RequestQueue) and [`Dataset`](https://docs.apify.com/sdk/python/reference/class/Dataset)) to the Apify cloud products. The Apify SDK, like Crawlee itself, is available as a PyPI package and can be installed with any Python package manager. To install it using [Pip](https://pipx.pypa.io/), run:
 
-    ```bash
-    poetry add apify
-    ```
-
-- Alternatively, if you don't use `poetry` to manage your project, you may just install the SDK with `pip`:
-
-    ```bash
+    ```sh
     pip install apify
     ```
 
+- [**Apify CLI**](https://docs.apify.com/cli/), a command-line tool that will help us with authentication and deployment. It is a [Node.js](https://nodejs.org/) package, and can be installed using any Node.js package manager. In this guide, we will use [NPM](https://www.npmjs.com/). We will install it globally, so you can use it across all your Crawlee and Apify projects. To install it using NPM, run:
 
-- Apify CLI, a command-line tool that will help us with authentication and deployment. This will be a globally installed tool, you will install it only once and use it in all your Crawlee/Apify projects.
-
-    ```bash
+    ```sh
     npm install -g apify-cli
     ```
 
@@ -49,7 +42,7 @@ The first step will be installing two new dependencies:
 
 The next step will be [creating your Apify account](https://console.apify.com/sign-up). Don't worry, we have a **free tier**, so you can try things out before you buy in! Once you have that, it's time to log in with the just-installed [Apify CLI](https://docs.apify.com/cli/). You will need your personal access token, which you can find at https://console.apify.com/account#/integrations.
 
-```bash
+```sh
 apify login
 ```
 
@@ -75,7 +68,7 @@ The [`Actor`](https://docs.apify.com/sdk/python/reference/class/Actor) context m
 
 You will also need to initialize the project for Apify, to do that, use the Apify CLI again:
 
-```bash
+```sh
 apify init
 ```
 
@@ -85,7 +78,7 @@ This will create a folder called `.actor`, and an `actor.json` file inside it - 
 
 And that's all, your project is now ready to be published on the Apify Platform. You can use the Apify CLI once more to do that:
 
-```bash
+```sh
 apify push
 ```
 

--- a/docs/introduction/09_running_in_cloud.mdx
+++ b/docs/introduction/09_running_in_cloud.mdx
@@ -2,13 +2,13 @@
 id: deployment
 title: Running your crawler in the Cloud
 sidebar_label: Running in the Cloud
-description: Deploying Crawlee-python projects to the Apify Platform
+description: Deploying Crawlee-python projects to the Apify platform
 ---
 
 import CodeBlock from '@theme/CodeBlock';
 import MainExample from '!!raw-loader!./code/09_apify_sdk.py';
 
-## Apify Platform
+## Apify platform
 
 Crawlee is developed by [**Apify**](https://apify.com), the web scraping and automation platform. You could say it is the **home of Crawlee projects**. In this section you'll see how to deploy the crawler there with just a few simple steps. You can deploy a **Crawlee** project wherever you want, but using the [**Apify platform**](https://console.apify.com) will give you the best experience.
 
@@ -18,7 +18,7 @@ With a few simple steps, you can convert your Crawlee project into a so-called *
 
 {/*:::info Choosing between Crawlee CLI and Apify CLI for project setup
 
-We started this guide by using the Crawlee CLI to bootstrap the project - it offers the basic Crawlee templates, including a ready-made `Dockerfile`. If you know you will be deploying your project to the Apify Platform, you might want to start with the Apify CLI instead. It also offers several project templates, and those are all set up to be used on the Apify Platform right ahead.
+We started this guide by using the Crawlee CLI to bootstrap the project - it offers the basic Crawlee templates, including a ready-made `Dockerfile`. If you know you will be deploying your project to the Apify platform, you might want to start with the Apify CLI instead. It also offers several project templates, and those are all set up to be used on the Apify platform right ahead.
 
 :::*/}
 
@@ -26,19 +26,19 @@ We started this guide by using the Crawlee CLI to bootstrap the project - it off
 
 Before we get started, you'll need to install two new dependencies:
 
-- [**Apify SDK**](https://pypi.org/project/apify/), a toolkit for working with the Apify platform. This will allow us to wire the storages (e.g. [`RequestQueue`](https://docs.apify.com/sdk/python/reference/class/RequestQueue) and [`Dataset`](https://docs.apify.com/sdk/python/reference/class/Dataset)) to the Apify cloud products. The Apify SDK, like Crawlee itself, is available as a PyPI package and can be installed with any Python package manager. To install it using [Pip](https://pipx.pypa.io/), run:
+- [**Apify SDK**](https://pypi.org/project/apify/), a toolkit for working with the Apify platform. This will allow us to wire the storages (e.g. [`RequestQueue`](https://docs.apify.com/sdk/python/reference/class/RequestQueue) and [`Dataset`](https://docs.apify.com/sdk/python/reference/class/Dataset)) to the Apify cloud products. The Apify SDK, like Crawlee itself, is available as a PyPI package and can be installed with any Python package manager. To install it using [pip](https://pipx.pypa.io/), run:
 
     ```sh
     pip install apify
     ```
 
-- [**Apify CLI**](https://docs.apify.com/cli/), a command-line tool that will help us with authentication and deployment. It is a [Node.js](https://nodejs.org/) package, and can be installed using any Node.js package manager. In this guide, we will use [NPM](https://www.npmjs.com/). We will install it globally, so you can use it across all your Crawlee and Apify projects. To install it using NPM, run:
+- [**Apify CLI**](https://docs.apify.com/cli/), a command-line tool that will help us with authentication and deployment. It is a [Node.js](https://nodejs.org/) package, and can be installed using any Node.js package manager. In this guide, we will use [npm](https://npmjs.com/). We will install it globally, so you can use it across all your Crawlee and Apify projects. To install it using npm, run:
 
     ```sh
     npm install -g apify-cli
     ```
 
-## Logging in to the Apify Platform
+## Logging in to the Apify platform
 
 The next step will be [creating your Apify account](https://console.apify.com/sign-up). Don't worry, we have a **free tier**, so you can try things out before you buy in! Once you have that, it's time to log in with the just-installed [Apify CLI](https://docs.apify.com/cli/). You will need your personal access token, which you can find at https://console.apify.com/account#/integrations.
 
@@ -48,7 +48,7 @@ apify login
 
 ## Adjusting the code
 
-Now that you have your account set up, you will need to adjust the code a tiny bit. We will use the [Apify SDK](https://docs.apify.com/sdk/python/), which will help us to wire the Crawlee storages (like the [`RequestQueue`](https://docs.apify.com/sdk/python/reference/class/RequestQueue)) to their Apify Platform counterparts - otherwise Crawlee would keep things only in memory.
+Now that you have your account set up, you will need to adjust the code a tiny bit. We will use the [Apify SDK](https://docs.apify.com/sdk/python/), which will help us to wire the Crawlee storages (like the [`RequestQueue`](https://docs.apify.com/sdk/python/reference/class/RequestQueue)) to their Apify platform counterparts - otherwise Crawlee would keep things only in memory.
 
 Open your `src/main.py` file, and wrap everyting in your `main` function with the [`Actor`](https://docs.apify.com/sdk/python/reference/class/Actor) context manager. Your code should look like this:
 
@@ -60,7 +60,7 @@ The context manager will configure Crawlee to use the Apify API instead of its d
 
 :::info Understanding `async with Actor` behavior with environment variables
 
-The [`Actor`](https://docs.apify.com/sdk/python/reference/class/Actor) context manager works conditionally based on the environment variables, namely based on the `APIFY_IS_AT_HOME` env var, which is set to `true` on the Apify Platform. This means that your project will remain working the same locally, but will use the Apify API when deployed to the Apify Platform.
+The [`Actor`](https://docs.apify.com/sdk/python/reference/class/Actor) context manager works conditionally based on the environment variables, namely based on the `APIFY_IS_AT_HOME` env var, which is set to `true` on the Apify platform. This means that your project will remain working the same locally, but will use the Apify API when deployed to the Apify platform.
 
 :::
 
@@ -72,17 +72,19 @@ You will also need to initialize the project for Apify, to do that, use the Apif
 apify init
 ```
 
-This will create a folder called `.actor`, and an `actor.json` file inside it - this file contains the configuration relevant to the Apify Platform, namely the Actor name, version, build tag, and few other things. Check out the [relevant documentation](https://docs.apify.com/platform/actors/development/actor-definition/actor-json) to see all the different things you can set there up.
+The CLI will check the project structure and guide you through the setup process. If prompted, follow the instructions and answer the questions to configure the project correctly. For more information follow the [Apify CLI documentation](https://docs.apify.com/cli/docs).
+
+This will create a folder called `.actor`, and an `actor.json` file inside it - this file contains the configuration relevant to the Apify platform, namely the Actor name, version, build tag, and few other things. Check out the [relevant documentation](https://docs.apify.com/platform/actors/development/actor-definition/actor-json) to see all the different things you can set there up.
 
 ## Ship it!
 
-And that's all, your project is now ready to be published on the Apify Platform. You can use the Apify CLI once more to do that:
+And that's all, your project is now ready to be published on the Apify platform. You can use the Apify CLI once more to do that:
 
 ```sh
 apify push
 ```
 
-This command will create an archive from your project, upload it to the Apify Platform and initiate a Docker build. Once finished, you will get a link to your new Actor on the platform.
+This command will create an archive from your project, upload it to the Apify platform and initiate a Docker build. Once finished, you will get a link to your new Actor on the platform.
 
 ## Learning more about web scraping
 

--- a/docs/quick-start/index.mdx
+++ b/docs/quick-start/index.mdx
@@ -44,7 +44,7 @@ Crawlee is available the [`crawlee`](https://pypi.org/project/crawlee/) package 
 You can install Crawlee with all features or choose only the ones you need. For installing it using the [pip](https://pip.pypa.io/en/stable/) package manager, run the following command:
 
 ```sh
-pip install 'crawlee[all]'
+python -m pip install 'crawlee[all]'
 ```
 
 Verify that Crawlee is successfully installed:

--- a/docs/quick-start/index.mdx
+++ b/docs/quick-start/index.mdx
@@ -19,7 +19,7 @@ This short tutorial will help you start scraping with Crawlee in just a minute o
 
 Crawlee offers the following main crawler classes: <ApiLink to="class/BeautifulSoupCrawler">`BeautifulSoupCrawler`</ApiLink>, <ApiLink to="class/ParselCrawler">`ParselCrawler`</ApiLink>, and <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>. All crawlers share the same interface, providing maximum flexibility when switching between them.
 
-:::caution before you start
+:::caution Minimum Python version
 
 Crawlee requires Python 3.9 or later.
 
@@ -39,7 +39,9 @@ The <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink> uses a h
 
 ## Installation
 
-Crawlee is available as [`crawlee`](https://pypi.org/project/crawlee/) PyPI package. The core functionality is included in the base package, with additional features available as optional extras to minimize package size and dependencies. You can install Crawlee with all features or choose only the ones you need. For installing it using the [Pip](https://pip.pypa.io/en/stable/) package manager, run the following command:
+Crawlee is available the [`crawlee`](https://pypi.org/project/crawlee/) package on PyPI. This package includes the core functionality, while additional features are available as optional extras to keep dependencies and package size minimal.
+
+You can install Crawlee with all features or choose only the ones you need. For installing it using the [pip](https://pip.pypa.io/en/stable/) package manager, run the following command:
 
 ```sh
 pip install 'crawlee[all]'

--- a/docs/quick-start/index.mdx
+++ b/docs/quick-start/index.mdx
@@ -19,6 +19,12 @@ This short tutorial will help you start scraping with Crawlee in just a minute o
 
 Crawlee offers the following main crawler classes: <ApiLink to="class/BeautifulSoupCrawler">`BeautifulSoupCrawler`</ApiLink>, <ApiLink to="class/ParselCrawler">`ParselCrawler`</ApiLink>, and <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>. All crawlers share the same interface, providing maximum flexibility when switching between them.
 
+:::caution before you start
+
+Crawlee requires Python 3.9 or later.
+
+:::
+
 ### BeautifulSoupCrawler
 
 The <ApiLink to="class/BeautifulSoupCrawler">`BeautifulSoupCrawler`</ApiLink> is a plain HTTP crawler that parses HTML using the well-known [BeautifulSoup](https://pypi.org/project/beautifulsoup4/) library. It crawls the web using an HTTP client that mimics a browser. This crawler is very fast and efficient but cannot handle JavaScript rendering.
@@ -31,30 +37,24 @@ The <ApiLink to="class/ParselCrawler">`ParselCrawler`</ApiLink> is similar to th
 
 The <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink> uses a headless browser controlled by the [Playwright](https://playwright.dev/) library. It can manage Chromium, Firefox, Webkit, and other browsers. Playwright is the successor to the [Puppeteer](https://pptr.dev/) library and is becoming the de facto standard in headless browser automation. If you need a headless browser, choose Playwright.
 
-:::caution before you start
-
-Crawlee requires Python 3.9 or later.
-
-:::
-
 ## Installation
 
-Crawlee is available as the [`crawlee`](https://pypi.org/project/crawlee/) PyPI package. The core functionality is included in the base package, with additional features available as optional extras to minimize package size and dependencies. To install Crawlee with all features, run the following command:
+Crawlee is available as [`crawlee`](https://pypi.org/project/crawlee/) PyPI package. The core functionality is included in the base package, with additional features available as optional extras to minimize package size and dependencies. You can install Crawlee with all features or choose only the ones you need. For installing it using the [Pip](https://pip.pypa.io/en/stable/) package manager, run the following command:
 
 ```sh
 pip install 'crawlee[all]'
-```
-
-Then, install the Playwright dependencies:
-
-```sh
-playwright install
 ```
 
 Verify that Crawlee is successfully installed:
 
 ```sh
 python -c 'import crawlee; print(crawlee.__version__)'
+```
+
+If you plan to use the <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>, you'll need to install Playwright dependencies, including the browser binaries. To do this, run the following command:
+
+```sh
+playwright install
 ```
 
 For detailed installation instructions see the [Setting up](../introduction/01_setting_up.mdx) documentation page.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ crawlee = "crawlee._cli:cli"
 
 [tool.ruff]
 line-length = 120
+include = ["src/**/*.py", "tests/**/*.py", "docs/**/*.py", "website/**/*.py"]
 extend-exclude = ["project_template"]
 
 [tool.ruff.lint]

--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/README.md
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/README.md
@@ -26,7 +26,7 @@ poetry run python -m {{cookiecutter.__package_name}}
 To install dependencies, your can run the following command:
 
 ```sh
-pip install .
+python -m pip install .
 ```
 
 When the dependencies are installed, you may launch the crawler with:

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -343,7 +343,7 @@ module.exports = {
                     title: 'More',
                     items: [
                         {
-                            label: 'Apify Platform',
+                            label: 'Apify platform',
                             href: 'https://apify.com',
                         },
                         {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -187,7 +187,7 @@ function ActorExample() {
 //                 </CodeBlock>
 //                 <p>
 //                     2️⃣ The next step is to add <code>Actor.init()</code> to the beginning of your main script and <code>Actor.exit()</code> to the end of it.
-//                     This will enable the integration to the Apify Platform, so the <a href="https://apify.com/storage" target="_blank" rel="noreferrer">cloud
+//                     This will enable the integration to the Apify platform, so the <a href="https://apify.com/storage" target="_blank" rel="noreferrer">cloud
 //                     storages</a> (e.g. <code>RequestQueue</code>) will be used. The code should look like this:
 //                 </p>
 //                 <RunnableCodeBlock className="language-typescript" type="playwright">


### PR DESCRIPTION
- I updated the "Setting up" and "Running in cloud" pages to make them more beginner-friendly (hopefully) and also removed mentions of Poetry. Including Poetry was unnecessary and could be confusing. Not to mention in Python there are X other package managers that we could hypotetically mention as well. So I decided to stay only with Pip and Pipx for templates. People using a package manager other than Pip will likely know how to handle the installation on their own.
- This was reported on Slack by @honzajavorek.