### PR TITLE
fix: fix session managment with retire

### DIFF
--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -1029,7 +1029,7 @@ class BasicCrawler(Generic[TCrawlingContext]):
 
             request.state = RequestState.DONE
 
-            if context.session:
+            if context.session and context.session.is_usable:
                 context.session.mark_good()
 
             self._statistics.record_request_processing_finish(statistics_id)


### PR DESCRIPTION
### Description

- Fix cases where a session was not excluded from the pool after calling `session.retire()` inside a successful `request_handler`.