### PR TITLE
fix: Fix templates - poetry-plugin-export version and camoufox template name

### DIFF
--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
@@ -67,5 +67,10 @@ COPY . ./
 # Use compileall to ensure the runnability of the Actor Python code.
 RUN python -m compileall -q .
 
+# % if cookiecutter.crawler_type == 'playwright-camoufox'
+# Fetch camoufox files that are always needed when using camoufox.
+RUN python -m camoufox fetch
+# % endif
+
 # Specify how to launch the source code of your Actor.
 CMD ["python", "-m", "{{ cookiecutter.__package_name }}"]

--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
@@ -3,7 +3,7 @@
 # You can also use any other image from Docker Hub.
 # % if cookiecutter.crawler_type == 'playwright'
 FROM apify/actor-python-playwright:3.13
-# % elif cookiecutter.crawler_type == 'camoufox'
+# % elif cookiecutter.crawler_type == 'playwright-camoufox'
 # Currently camoufox has issues installing on Python 3.13
 FROM apify/actor-python-playwright:3.12
 # % else
@@ -15,7 +15,7 @@ RUN apt install -yq git && rm -rf /var/lib/apt/lists/*
 # % if cookiecutter.package_manager == 'poetry'
 RUN pip install -U pip setuptools \
     && pip install 'poetry<2' \
-    && poetry self add poetry-plugin-export
+    && poetry self add 'poetry-plugin-export<1.9.0'
 
 # Second, copy just poetry.lock and pyproject.toml into the Actor image,
 # since those should be the only files that affects the dependency install in the next step,

--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/_pyproject.toml
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/_pyproject.toml
@@ -1,4 +1,4 @@
-# % if cookiecutter.crawler_type == 'camoufox'
+# % if cookiecutter.crawler_type == 'playwright-camoufox'
 # % set extras = ['playwright']
 # % else
 # % set extras = [cookiecutter.crawler_type]
@@ -18,7 +18,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.9"
-# % if cookiecutter.crawler_type == 'camoufox'
+# % if cookiecutter.crawler_type == 'playwright-camoufox'
 camoufox = {version= ">=0.4.5", extras = ["geoip"]}
 # % endif
 # % if cookiecutter.enable_apify_integration

--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/requirements.txt
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/requirements.txt
@@ -1,4 +1,4 @@
-# % if cookiecutter.crawler_type == 'camoufox'
+# % if cookiecutter.crawler_type == 'playwright-camoufox'
 camoufox
 # % set extras = ['playwright']
 # % else


### PR DESCRIPTION
### Description
Add poetry-plugin-export version constraint <1.9 to make it compatible with already constrained version of poetry <2
(poetry-plugin-export>=1.9 works only with poetry version >=2)

Fix incorrect camoufox cookiecutter template name in several template files 'camoufox'  -> 'playwright-camoufox'


### Issues

- Closes: #951


