### PR TITLE
fix: fix convert relative link to absolute in `enqueue_links` for response with redirect

### DIFF
--- a/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
+++ b/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
@@ -152,7 +152,8 @@ class AbstractHttpCrawler(Generic[TCrawlingContext, TParseResult], BasicCrawler[
             for link in self._parser.find_links(parsed_content, selector=selector):
                 url = link
                 if not is_url_absolute(url):
-                    url = convert_to_absolute_url(context.request.url, url)
+                    base_url = context.request.loaded_url or context.request.url
+                    url = convert_to_absolute_url(base_url, url)
 
                 request_options = RequestOptions(url=url, user_data={**base_user_data}, label=label)
 

--- a/src/crawlee/crawlers/_playwright/_playwright_crawler.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_crawler.py
@@ -210,7 +210,8 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext]):
                         url = url.strip()
 
                         if not is_url_absolute(url):
-                            url = convert_to_absolute_url(context.request.url, url)
+                            base_url = context.request.loaded_url or context.request.url
+                            url = convert_to_absolute_url(base_url, url)
 
                         request_option = RequestOptions({'url': url, 'user_data': {**base_user_data}, 'label': label})
 

--- a/tests/unit/crawlers/_parsel/test_parsel_crawler.py
+++ b/tests/unit/crawlers/_parsel/test_parsel_crawler.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 @pytest.fixture
 async def server() -> AsyncGenerator[respx.MockRouter, None]:
     with respx.mock(base_url='https://test.io', assert_all_called=False) as mock:
+        mock.get('https://www.test.io/').return_value = Response(302, headers={'Location': 'https://test.io/'})
+
         mock.get('/', name='index_endpoint').return_value = Response(
             200,
             text="""<html>
@@ -134,14 +136,14 @@ async def test_enqueue_links(server: respx.MockRouter) -> None:
         visit(url)
         await context.enqueue_links()
 
-    await crawler.run(['https://test.io/'])
+    await crawler.run(['https://www.test.io/'])
 
     assert server['index_endpoint'].called
     assert server['secondary_index_endpoint'].called
 
     visited = {call[0][0] for call in visit.call_args_list}
     assert visited == {
-        'https://test.io/',
+        'https://www.test.io/',
         'https://test.io/asdf',
         'https://test.io/hjkl',
         'https://test.io/qwer',

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -48,24 +48,6 @@ async def test_basic_request(httpbin: URL) -> None:
 
 
 async def test_enqueue_links() -> None:
-    requests = ['https://crawlee.dev/docs/examples']
-    crawler = PlaywrightCrawler()
-    visit = mock.Mock()
-
-    @crawler.router.default_handler
-    async def request_handler(context: PlaywrightCrawlingContext) -> None:
-        visit(context.request.url)
-        await context.enqueue_links(include=[Glob('https://crawlee.dev/docs/examples/**')])
-
-    await crawler.run(requests)
-
-    visited: set[str] = {call[0][0] for call in visit.call_args_list}
-
-    assert len(visited) >= 10
-    assert all(url.startswith('https://crawlee.dev/docs/examples') for url in visited)
-
-
-async def test_enqueue_links_with_redirect() -> None:
     # www.crawlee.dev create a redirect to crawlee.dev
     requests = ['https://www.crawlee.dev/docs/examples']
     crawler = PlaywrightCrawler(max_requests_per_crawl=11)


### PR DESCRIPTION
### Description

-  fix `enqueue_links` for response with redirect. 

### Issues

- Closes: #955
