### PR TITLE
chore: switch to the common self-hosted HTTPBin instance

### DIFF
--- a/.github/workflows/run_code_checks.yaml
+++ b/.github/workflows/run_code_checks.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Unit tests
     uses: apify/workflows/.github/workflows/python_unit_tests.yaml@main
     secrets:
-      httpbin_url: ${{ secrets.APIFY_HTTPBIN_TOKEN && format('https://janbuchar--httpbin.apify.actor?token={0}', secrets.APIFY_HTTPBIN_TOKEN) || 'https://httpbin.org'}}
+      httpbin_url: ${{ secrets.APIFY_HTTPBIN_TOKEN && format('https://httpbin.apify.actor?token={0}', secrets.APIFY_HTTPBIN_TOKEN) || 'https://httpbin.org'}}
 
   docs_check:
     name: Docs check


### PR DESCRIPTION
Switches the `crawlee-python` unit tests to use the common service account for running the HTTPBin instance (and not the personal Apify account).

Uses the org-wide `APIFY_HTTPBIN_TOKEN` secret. It's possible that the personal acc token will shadow the org-wide secret - let's see how it works in the PR checks