### PR TITLE
chore: Fix flakiness in test and use explicit test id

### DIFF
--- a/tests/unit/_utils/test_html_to_text.py
+++ b/tests/unit/_utils/test_html_to_text.py
@@ -136,7 +136,7 @@ But,
 @pytest.mark.parametrize(
     ('source', 'expected_text'),
     [
-        (_EXAMPLE_HTML, _EXPECTED_TEXT),
+        pytest.param(_EXAMPLE_HTML, _EXPECTED_TEXT, id='Complex html'),
         ('   Plain    text     node    ', 'Plain text node'),
         ('   \nPlain    text     node  \n  ', 'Plain text node'),
         ('<h1>Header 1</h1> <h2>Header 2</h2>', 'Header 1\nHeader 2'),
@@ -163,7 +163,7 @@ But,
         ),
         ('<a>this_word</a>_should_<b></b>be_<span>one</span>', 'this_word_should_be_one'),
         ('<span attributes="should" be="ignored">some <span>text</span></span>', 'some text'),
-        (
+        pytest.param(
             (
                 """<table>
     <tr>
@@ -176,6 +176,7 @@ But,
 </table>"""
             ),
             'Cell A1\tCell A2\tCell A3 \t\nCell B1\tCell B2',
+            id='Table',
         ),
         ('<span>&aacute; &eacute;</span>', 'á é'),
     ],

--- a/tests/unit/crawlers/_basic/test_basic_crawler.py
+++ b/tests/unit/crawlers/_basic/test_basic_crawler.py
@@ -973,8 +973,10 @@ async def test_crawler_manual_stop(httpbin: URL) -> None:
     assert stats.requests_finished == 2
 
 
+@pytest.mark.skipif(sys.version_info[:3] < (3, 11), reason='asyncio.Barrier was introduced in Python 3.11.')
 async def test_crawler_multiple_stops_in_parallel(httpbin: URL) -> None:
     """Test that no new requests are handled after crawler.stop() is called, but ongoing requests can still finish."""
+
     start_urls = [
         str(httpbin / '1'),
         str(httpbin / '2'),
@@ -985,17 +987,17 @@ async def test_crawler_multiple_stops_in_parallel(httpbin: URL) -> None:
     # Set max_concurrency to 2 to ensure two urls are being visited in parallel.
     crawler = BasicCrawler(concurrency_settings=ConcurrencySettings(max_concurrency=2))
 
-    sleep_time_generator = iter([0, 0.1])
+    both_handlers_started = asyncio.Barrier(2)  # type:ignore[attr-defined]  # Test is skipped in older Python versions.
+    only_one_handler_at_a_time = asyncio.Semaphore(1)
 
     @crawler.router.default_handler
     async def handler(context: BasicCrawlingContext) -> None:
-        processed_urls.append(context.request.url)
+        await both_handlers_started.wait()  # Block until both handlers are started.
 
-        # This sleep ensures that first request is processed quickly and triggers stop() almost immediately.
-        # Second request will have some sleep time to make sure it is still being processed after crawler.stop() was
-        # called from the first request and so the crawler is already shutting down.
-        await asyncio.sleep(next(sleep_time_generator))
-        crawler.stop(reason=f'Stop called on {context.request.url}')
+        async with only_one_handler_at_a_time:
+            # Reliably create situation where one handler called `crawler.stop()`, while other handler is still running.
+            crawler.stop(reason=f'Stop called on {context.request.url}')
+            processed_urls.append(context.request.url)
 
     stats = await crawler.run(start_urls)
 


### PR DESCRIPTION
### Description
Replace unreliable `asyncio.sleep` in flaky `test_crawler_multiple_stops_in_parallel` by deterministic `asyncio.Barrier` and `asyncio.Semaphore`
Use explicit test name through `id=` in parametrized `test_html_to_text`  where parameter is several line long string. (To prevent strange test case name in logs.) 

