### PR TITLE
ci: Trigger docs build even after docs commits

### DIFF
--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -17,7 +17,6 @@ concurrency:
 
 jobs:
   release_metadata:
-    if: "!startsWith(github.event.head_commit.message, 'ci') && startsWith(github.repository, 'apify/')"
     name: Prepare release metadata
     runs-on: ubuntu-latest
     outputs:
@@ -63,7 +62,7 @@ jobs:
     secrets: inherit
 
   publish_to_pypi:
-    if: "!startsWith(github.event.head_commit.message, 'docs')"
+    if: "!startsWith(github.event.head_commit.message, 'ci') && !startsWith(github.event.head_commit.message, 'docs')"
     name: Publish to PyPI
     needs: [release_metadata, update_changelog]
     runs-on: ubuntu-latest

--- a/.github/workflows/pre_release.yaml
+++ b/.github/workflows/pre_release.yaml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   release_metadata:
-    if: "!startsWith(github.event.head_commit.message, 'docs') && !startsWith(github.event.head_commit.message, 'ci') && startsWith(github.repository, 'apify/')"
+    if: "!startsWith(github.event.head_commit.message, 'ci') && startsWith(github.repository, 'apify/')"
     name: Prepare release metadata
     runs-on: ubuntu-latest
     outputs:
@@ -63,6 +63,7 @@ jobs:
     secrets: inherit
 
   publish_to_pypi:
+    if: "!startsWith(github.event.head_commit.message, 'docs')"
     name: Publish to PyPI
     needs: [release_metadata, update_changelog]
     runs-on: ubuntu-latest


### PR DESCRIPTION
The current version skips the `build_and_deploy_docs` step (all steps, to be more precise) in the `pre_release` workflow for `docs:` commits, which is not correct.

This PR changes that so that we only avoid pushing to PyPI for `docs:` commits.
