### PR TITLE
refactor: set storage_object on open of storages

### DIFF
--- a/src/crawlee/storages/_base.py
+++ b/src/crawlee/storages/_base.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from crawlee.configuration import Configuration
     from crawlee.storage_clients._base import StorageClient
+    from crawlee.storage_clients.models import _StorageMetadata
 
 
 class Storage(ABC):
@@ -20,6 +21,11 @@ class Storage(ABC):
     @abstractmethod
     def name(self) -> str | None:
         """Get the storage name."""
+
+    @property
+    @abstractmethod
+    def storage_object(self) -> _StorageMetadata:
+        """Get the full storage info object."""
 
     @classmethod
     @abstractmethod

--- a/src/crawlee/storages/_creation_management.py
+++ b/src/crawlee/storages/_creation_management.py
@@ -169,7 +169,9 @@ async def open_storage(
             resource_collection_client = _get_resource_collection_client(storage_class, storage_client)
             storage_info = await resource_collection_client.get_or_create(name=name)
 
-        storage = storage_class(id=storage_info.id, name=storage_info.name, storage_client=storage_client)
+        storage = storage_class(
+            id=storage_info.id, name=storage_info.name, storage_client=storage_client, storage_object=storage_info
+        )
 
         # Cache the storage by ID and name
         _add_to_cache_by_id(storage.id, storage)

--- a/src/crawlee/storages/_dataset.py
+++ b/src/crawlee/storages/_dataset.py
@@ -12,7 +12,7 @@ from crawlee import service_locator
 from crawlee._utils.byte_size import ByteSize
 from crawlee._utils.docs import docs_group
 from crawlee._utils.file import json_dumps
-from crawlee.storage_clients.models import DatasetMetadata
+from crawlee.storage_clients.models import DatasetMetadata, _StorageMetadata
 
 from ._base import Storage
 from ._key_value_store import KeyValueStore
@@ -194,9 +194,12 @@ class Dataset(Storage):
     _EFFECTIVE_LIMIT_SIZE = _MAX_PAYLOAD_SIZE - (_MAX_PAYLOAD_SIZE * _SAFETY_BUFFER_PERCENT)
     """Calculated payload limit considering safety buffer."""
 
-    def __init__(self, id: str, name: str | None, storage_client: StorageClient) -> None:
+    def __init__(
+        self, id: str, name: str | None, storage_client: StorageClient, storage_object: _StorageMetadata
+    ) -> None:
         self._id = id
         self._name = name
+        self._storage_object = storage_object
 
         # Get resource clients from the storage client.
         self._resource_client = storage_client.dataset(self._id)
@@ -211,6 +214,11 @@ class Dataset(Storage):
     @override
     def name(self) -> str | None:
         return self._name
+
+    @property
+    @override
+    def storage_object(self) -> _StorageMetadata:
+        return self._storage_object
 
     @override
     @classmethod

--- a/src/crawlee/storages/_key_value_store.py
+++ b/src/crawlee/storages/_key_value_store.py
@@ -9,7 +9,7 @@ from typing_extensions import override
 from crawlee import service_locator
 from crawlee._utils.docs import docs_group
 from crawlee.events._types import Event, EventPersistStateData
-from crawlee.storage_clients.models import KeyValueStoreKeyInfo, KeyValueStoreMetadata
+from crawlee.storage_clients.models import KeyValueStoreKeyInfo, KeyValueStoreMetadata, _StorageMetadata
 
 from ._base import Storage
 
@@ -62,9 +62,12 @@ class KeyValueStore(Storage):
     _general_cache: ClassVar[dict[str, dict[str, dict[str, JsonSerializable]]]] = {}
     _persist_state_event_started = False
 
-    def __init__(self, id: str, name: str | None, storage_client: StorageClient) -> None:
+    def __init__(
+        self, id: str, name: str | None, storage_client: StorageClient, storage_object: _StorageMetadata
+    ) -> None:
         self._id = id
         self._name = name
+        self._storage_object = storage_object
 
         # Get resource clients from storage client
         self._resource_client = storage_client.key_value_store(self._id)
@@ -79,6 +82,11 @@ class KeyValueStore(Storage):
     @override
     def name(self) -> str | None:
         return self._name
+
+    @property
+    @override
+    def storage_object(self) -> _StorageMetadata:
+        return self._storage_object
 
     async def get_info(self) -> KeyValueStoreMetadata | None:
         """Get an object containing general information about the key value store."""

--- a/src/crawlee/storages/_request_queue.py
+++ b/src/crawlee/storages/_request_queue.py
@@ -17,7 +17,7 @@ from crawlee._utils.requests import unique_key_to_request_id
 from crawlee._utils.wait import wait_for_all_tasks_for_finish
 from crawlee.events import Event
 from crawlee.request_loaders import RequestManager
-from crawlee.storage_clients.models import ProcessedRequest, RequestQueueMetadata
+from crawlee.storage_clients.models import ProcessedRequest, RequestQueueMetadata, _StorageMetadata
 
 from ._base import Storage
 
@@ -106,12 +106,15 @@ class RequestQueue(Storage, RequestManager):
     _STORAGE_CONSISTENCY_DELAY = timedelta(seconds=3)
     """Expected delay for storage to achieve consistency, guiding the timing of subsequent read operations."""
 
-    def __init__(self, id: str, name: str | None, storage_client: StorageClient) -> None:
+    def __init__(
+        self, id: str, name: str | None, storage_client: StorageClient, storage_object: _StorageMetadata
+    ) -> None:
         config = service_locator.get_configuration()
         event_manager = service_locator.get_event_manager()
 
         self._id = id
         self._name = name
+        self._storage_object = storage_object
 
         # Get resource clients from storage client
         self._resource_client = storage_client.request_queue(self._id)
@@ -146,6 +149,11 @@ class RequestQueue(Storage, RequestManager):
     @override
     def name(self) -> str | None:
         return self._name
+
+    @property
+    @override
+    def storage_object(self) -> _StorageMetadata:
+        return self._storage_object
 
     @override
     @classmethod

--- a/tests/unit/storages/test_key_value_store.py
+++ b/tests/unit/storages/test_key_value_store.py
@@ -51,6 +51,13 @@ async def test_open() -> None:
         await KeyValueStore.open(id='dummy-name')
 
 
+async def test_open_save_storage_object() -> None:
+    default_key_value_store = await KeyValueStore.open()
+
+    assert default_key_value_store.storage_object is not None
+    assert default_key_value_store.storage_object.id == default_key_value_store.id
+
+
 async def test_consistency_accross_two_clients() -> None:
     kvs = await KeyValueStore.open(name='my-kvs')
     await kvs.set_value('key', 'value')


### PR DESCRIPTION
### Description

Currently, when opening a KV store, dataset or request queue we only store the id and name from the get() response.

This PR updates the logic to store the entire storage_object, allowing access to additional attributes without requiring extra requests.

More context in [slack](https://apify.slack.com/archives/CD0SF6KD4/p1738936334553189)

P.S. Python Crawlee storage constructors are a bit different than JS storage consturctors, that's why I've added storage_object to all of the classes - KV store, dataset & request queue

[Similar PR in Crawlee JS](https://github.com/apify/crawlee/pull/2837)

### Testing

I've added one test, which checks that KV store class has storage_object after open.

