### PR TITLE
chore: fix tests and improve tests stability

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,7 +14,7 @@ from crawlee import service_locator
 from crawlee.configuration import Configuration
 from crawlee.proxy_configuration import ProxyInfo
 from crawlee.storage_clients import MemoryStorageClient
-from crawlee.storages import _creation_management
+from crawlee.storages import KeyValueStore, _creation_management
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -176,3 +176,10 @@ def memory_storage_client(tmp_path: Path) -> MemoryStorageClient:
     )
 
     return MemoryStorageClient.from_config(config)
+
+
+@pytest.fixture
+async def key_value_store() -> AsyncGenerator[KeyValueStore, None]:
+    kvs = await KeyValueStore.open()
+    yield kvs
+    await kvs.drop()

--- a/tests/unit/crawlers/_basic/test_basic_crawler.py
+++ b/tests/unit/crawlers/_basic/test_basic_crawler.py
@@ -32,19 +32,12 @@ from crawlee.storage_clients._memory import DatasetClient
 from crawlee.storages import Dataset, KeyValueStore, RequestQueue
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Sequence
+    from collections.abc import Sequence
 
     import respx
     from yarl import URL
 
     from crawlee._types import JsonSerializable
-
-
-@pytest.fixture
-async def key_value_store() -> AsyncGenerator[KeyValueStore, None]:
-    kvs = await KeyValueStore.open()
-    yield kvs
-    await kvs.drop()
 
 
 async def test_processes_requests_from_explicit_queue() -> None:

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -107,7 +107,7 @@ async def test_enqueue_links_with_transform_request_function() -> None:
 
 
 async def test_nonexistent_url_invokes_error_handler() -> None:
-    crawler = PlaywrightCrawler(max_request_retries=4)
+    crawler = PlaywrightCrawler(max_request_retries=4, request_handler=mock.AsyncMock())
 
     error_handler = mock.AsyncMock(return_value=None)
     crawler.error_handler(error_handler)
@@ -115,28 +115,30 @@ async def test_nonexistent_url_invokes_error_handler() -> None:
     failed_handler = mock.AsyncMock(return_value=None)
     crawler.failed_request_handler(failed_handler)
 
-    @crawler.router.default_handler
-    async def request_handler(_context: PlaywrightCrawlingContext) -> None:
-        pass
-
     await crawler.run(['https://this-does-not-exist-22343434.com'])
     assert error_handler.call_count == 3
     assert failed_handler.call_count == 1
 
 
-async def test_redirect_handling(httpbin: URL) -> None:
+async def test_redirect_handling() -> None:
     # Set up a dummy crawler that tracks visited URLs
     crawler = PlaywrightCrawler()
     handled_urls = set[str]()
+
+    @crawler.pre_navigation_hook
+    async def some_hook(context: PlaywrightPreNavCrawlingContext) -> None:
+        # Emulate server response to prevent Playwright from making real requests
+        await context.page.route(
+            '**/redirect', lambda route: route.fulfill(status=301, headers={'Location': 'https://apify.com'})
+        )
+        await context.page.route('https://apify.com/**', lambda route: route.fulfill(status=200))
 
     @crawler.router.default_handler
     async def request_handler(context: PlaywrightCrawlingContext) -> None:
         handled_urls.add(context.request.loaded_url or '')
 
-    # Craft a request that points to httpbin initially, but redirects to apify.com
-    request = Request.from_url(
-        url=str((httpbin / 'redirect-to').update_query(url='https://apify.com')),
-    )
+    # Request with redirects to apify.com
+    request = Request.from_url(url='https://test.com/redirect')
 
     # Ensure that the request uses the SAME_ORIGIN strategy - apify.com will be considered out of scope
     request.crawlee_data.enqueue_strategy = EnqueueStrategy.SAME_ORIGIN
@@ -146,56 +148,70 @@ async def test_redirect_handling(httpbin: URL) -> None:
     assert handled_urls == set()
 
 
-async def test_chromium_headless_headers(httpbin: URL) -> None:
+async def test_chromium_headless_headers() -> None:
     crawler = PlaywrightCrawler(headless=True, browser_type='chromium')
     headers = dict[str, str]()
 
+    @crawler.pre_navigation_hook
+    async def some_hook(context: PlaywrightPreNavCrawlingContext) -> None:
+        # Emulate server response to prevent Playwright from making real requests
+        await context.page.route(
+            '**/*', lambda route: route.fulfill(status=200, body=json.dumps(route.request.headers))
+        )
+
     @crawler.router.default_handler
     async def request_handler(context: PlaywrightCrawlingContext) -> None:
         response = await context.response.text()
-        response_headers = dict(json.loads(response)).get('headers', {})
+        response_headers = json.loads(response)
 
         for key, val in response_headers.items():
             headers[key] = val
 
-    await crawler.run([str(httpbin / 'get')])
+    await crawler.run(['https://test.com'])
 
-    assert 'User-Agent' in headers
-    assert 'Sec-Ch-Ua' in headers
-    assert 'Sec-Ch-Ua-Mobile' in headers
-    assert 'Sec-Ch-Ua-Platform' in headers
+    assert 'user-agent' in headers
+    assert 'sec-ch-ua' in headers
+    assert 'sec-ch-ua-mobile' in headers
+    assert 'sec-ch-ua-platform' in headers
 
-    assert 'headless' not in headers['Sec-Ch-Ua'].lower()
-    assert 'headless' not in headers['User-Agent'].lower()
+    assert 'headless' not in headers['sec-ch-ua'].lower()
+    assert 'headless' not in headers['user-agent'].lower()
 
-    assert headers['Sec-Ch-Ua'] == PW_CHROMIUM_HEADLESS_DEFAULT_SEC_CH_UA
-    assert headers['Sec-Ch-Ua-Mobile'] == PW_CHROMIUM_HEADLESS_DEFAULT_SEC_CH_UA_MOBILE
-    assert headers['Sec-Ch-Ua-Platform'] == PW_CHROMIUM_HEADLESS_DEFAULT_SEC_CH_UA_PLATFORM
-    assert headers['User-Agent'] == PW_CHROMIUM_HEADLESS_DEFAULT_USER_AGENT
+    assert headers['sec-ch-ua'] == PW_CHROMIUM_HEADLESS_DEFAULT_SEC_CH_UA
+    assert headers['sec-ch-ua-mobile'] == PW_CHROMIUM_HEADLESS_DEFAULT_SEC_CH_UA_MOBILE
+    assert headers['sec-ch-ua-platform'] == PW_CHROMIUM_HEADLESS_DEFAULT_SEC_CH_UA_PLATFORM
+    assert headers['user-agent'] == PW_CHROMIUM_HEADLESS_DEFAULT_USER_AGENT
 
 
-async def test_firefox_headless_headers(httpbin: URL) -> None:
+async def test_firefox_headless_headers() -> None:
     crawler = PlaywrightCrawler(headless=True, browser_type='firefox')
     headers = dict[str, str]()
 
+    @crawler.pre_navigation_hook
+    async def some_hook(context: PlaywrightPreNavCrawlingContext) -> None:
+        # Emulate server response to prevent Playwright from making real requests
+        await context.page.route(
+            '**/*', lambda route: route.fulfill(status=200, body=json.dumps(route.request.headers))
+        )
+
     @crawler.router.default_handler
     async def request_handler(context: PlaywrightCrawlingContext) -> None:
         response = await context.response.text()
-        response_headers = dict(json.loads(response)).get('headers', {})
+        response_headers = json.loads(response)
 
         for key, val in response_headers.items():
             headers[key] = val
 
-    await crawler.run([str(httpbin / 'get')])
+    await crawler.run(['https://test.com'])
 
-    assert 'User-Agent' in headers
-    assert 'Sec-Ch-Ua' not in headers
-    assert 'Sec-Ch-Ua-Mobile' not in headers
-    assert 'Sec-Ch-Ua-Platform' not in headers
+    assert 'user-agent' in headers
+    assert 'sec-ch-ua' not in headers
+    assert 'sec-ch-ua-mobile' not in headers
+    assert 'sec-ch-ua-platform' not in headers
 
-    assert 'headless' not in headers['User-Agent'].lower()
+    assert 'headless' not in headers['user-agent'].lower()
 
-    assert headers['User-Agent'] == PW_FIREFOX_HEADLESS_DEFAULT_USER_AGENT
+    assert headers['user-agent'] == PW_FIREFOX_HEADLESS_DEFAULT_USER_AGENT
 
 
 async def test_custom_headers(httpbin: URL) -> None:
@@ -218,19 +234,18 @@ async def test_custom_headers(httpbin: URL) -> None:
     assert response_headers.get('My-Test-Header') == request_headers['My-Test-Header']
 
 
-async def test_pre_navigation_hook(httpbin: URL) -> None:
-    crawler = PlaywrightCrawler()
-    mock_hook = mock.AsyncMock(return_value=None)
+async def test_pre_navigation_hook() -> None:
+    crawler = PlaywrightCrawler(request_handler=mock.AsyncMock())
+    visit = mock.Mock()
 
-    crawler.pre_navigation_hook(mock_hook)
+    @crawler.pre_navigation_hook
+    async def some_hook(context: PlaywrightPreNavCrawlingContext) -> None:
+        visit()
+        await context.page.route('**/*', lambda route: route.fulfill(status=200))
 
-    @crawler.router.default_handler
-    async def request_handler(_context: PlaywrightCrawlingContext) -> None:
-        pass
+    await crawler.run(['https://test.com', 'https://test.io'])
 
-    await crawler.run(['https://example.com', str(httpbin)])
-
-    assert mock_hook.call_count == 2
+    assert visit.call_count == 2
 
 
 async def test_proxy_set() -> None:
@@ -265,22 +280,30 @@ async def test_proxy_set() -> None:
         pytest.param(True, id='with use_incognito_pages'),
     ],
 )
-async def test_isolation_cookies(*, use_incognito_pages: bool, httpbin: URL) -> None:
+async def test_isolation_cookies(*, use_incognito_pages: bool) -> None:
     sessions_ids: list[str] = []
     sessions_cookies: dict[str, dict[str, str]] = {}
     response_cookies: dict[str, dict[str, str]] = {}
 
     crawler = PlaywrightCrawler(
-        session_pool=SessionPool(
-            max_pool_size=1,
-            create_session_settings={
-                'max_error_score': 50,
-            },
-        ),
+        session_pool=SessionPool(max_pool_size=1),
         use_incognito_pages=use_incognito_pages,
         concurrency_settings=ConcurrencySettings(max_concurrency=1),
-        max_request_retries=10,
     )
+
+    @crawler.pre_navigation_hook
+    async def some_hook(context: PlaywrightPreNavCrawlingContext) -> None:
+        # Emulate server response to prevent Playwright from making real requests
+        await context.page.route(
+            '**/cookies_set', lambda route: route.fulfill(status=200, headers={'Set-Cookie': 'a=1; Path=/'})
+        )
+
+        await context.page.route(
+            '**/cookies_get',
+            lambda route: route.fulfill(
+                status=200, body=json.dumps({'cookies': route.request.headers.get('cookie', '')})
+            ),
+        )
 
     @crawler.router.default_handler
     async def handler(context: PlaywrightCrawlingContext) -> None:
@@ -302,10 +325,10 @@ async def test_isolation_cookies(*, use_incognito_pages: bool, httpbin: URL) -> 
     await crawler.run(
         [
             # The first request sets the cookie in the session
-            str(httpbin.with_path('/cookies/set').extend_query(a=1)),
+            'https://test.com/cookies_set',
             # With the second request, we check the cookies in the session and set retire
-            Request.from_url(str(httpbin.with_path('/cookies')), unique_key='1', user_data={'retire_session': True}),
-            Request.from_url(str(httpbin.with_path('/cookies')), unique_key='2'),
+            Request.from_url('https://test.com/cookies_get', unique_key='1', user_data={'retire_session': True}),
+            Request.from_url('https://test.com/cookies_get', unique_key='2'),
         ]
     )
 
@@ -322,20 +345,24 @@ async def test_isolation_cookies(*, use_incognito_pages: bool, httpbin: URL) -> 
     # When using `use_incognito_pages` there should be full cookie isolation
     if use_incognito_pages:
         # The initiated cookies must match in both the response and the session store
-        assert sessions_cookies[cookie_session_id] == response_cookies[cookie_session_id] == {'a': '1'}
+        assert sessions_cookies[cookie_session_id] == {'a': '1'}
+        assert response_cookies[cookie_session_id] == 'a=1'
 
         # For a clean session, the cookie should not be in the sesstion store or in the response
         # This way we can be sure that no cookies are being leaked through the http client
-        assert sessions_cookies[clean_session_id] == response_cookies[clean_session_id] == {}
+        assert sessions_cookies[clean_session_id] == {}
+        assert response_cookies[clean_session_id] == ''
     # Without `use_incognito_pages` we will have access to the session cookie,
     # but there will be a cookie leak via PlaywrightContext
     else:
         # The initiated cookies must match in both the response and the session store
-        assert sessions_cookies[cookie_session_id] == response_cookies[cookie_session_id] == {'a': '1'}
+        assert sessions_cookies[cookie_session_id] == {'a': '1'}
+        assert response_cookies[cookie_session_id] == 'a=1'
 
         # PlaywrightContext makes cookies shared by all sessions that work with it.
         # So in this case a clean session contains the same cookies
-        assert sessions_cookies[clean_session_id] == response_cookies[clean_session_id] == {'a': '1'}
+        assert sessions_cookies[clean_session_id] == {'a': '1'}
+        assert response_cookies[clean_session_id] == 'a=1'
 
 
 async def test_custom_fingerprint_uses_generator_options(httpbin: URL) -> None:
@@ -353,17 +380,10 @@ async def test_custom_fingerprint_uses_generator_options(httpbin: URL) -> None:
 
     crawler = PlaywrightCrawler(headless=True, fingerprint_generator=fingerprint_generator)
 
-    response_headers = dict[str, str]()
     fingerprints = dict[str, Any]()
 
     @crawler.router.default_handler
     async def request_handler(context: PlaywrightCrawlingContext) -> None:
-        response = await context.response.text()
-        context_response_headers = dict(json.loads(response)).get('headers', {})
-
-        for key, val in context_response_headers.items():
-            response_headers[key] = val
-
         for relevant_key in (
             'window.navigator.userAgent',
             'window.navigator.userAgentData',
@@ -380,22 +400,29 @@ async def test_custom_fingerprint_uses_generator_options(httpbin: URL) -> None:
     assert min_height <= int(fingerprints['window.screen.height']) <= max_height
 
 
-async def test_custom_fingerprint_matches_header_user_agent(httpbin: URL) -> None:
+async def test_custom_fingerprint_matches_header_user_agent() -> None:
     """Test that generated fingerprint and header have matching user agent."""
 
     crawler = PlaywrightCrawler(headless=True, fingerprint_generator=DefaultFingerprintGenerator())
     response_headers = dict[str, str]()
     fingerprints = dict[str, str]()
 
+    @crawler.pre_navigation_hook
+    async def some_hook(context: PlaywrightPreNavCrawlingContext) -> None:
+        # Emulate server response to prevent Playwright from making real requests
+        await context.page.route(
+            '**/*', lambda route: route.fulfill(status=200, body=json.dumps(route.request.headers))
+        )
+
     @crawler.router.default_handler
     async def request_handler(context: PlaywrightCrawlingContext) -> None:
         response = await context.response.text()
-        context_response_headers = dict(json.loads(response)).get('headers', {})
+        context_response_headers = dict(json.loads(response))
 
-        response_headers['User-Agent'] = context_response_headers['User-Agent']
+        response_headers['User-Agent'] = context_response_headers['user-agent']
         fingerprints['window.navigator.userAgent'] = await context.page.evaluate('()=>window.navigator.userAgent')
 
-    await crawler.run([Request.from_url(str(httpbin / 'get'))])
+    await crawler.run(['https://test.com'])
 
     assert response_headers['User-Agent'] == fingerprints['window.navigator.userAgent']
 

--- a/tests/unit/storages/test_key_value_store.py
+++ b/tests/unit/storages/test_key_value_store.py
@@ -19,13 +19,6 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-async def key_value_store() -> AsyncGenerator[KeyValueStore, None]:
-    kvs = await KeyValueStore.open()
-    yield kvs
-    await kvs.drop()
-
-
-@pytest.fixture
 async def mock_event_manager() -> AsyncGenerator[EventManager, None]:
     async with EventManager(persist_state_interval=timedelta(milliseconds=50)) as event_manager:
         with patch('crawlee.service_locator.get_event_manager', return_value=event_manager):


### PR DESCRIPTION
### Description

- Fix `kvs` isolation in the `use_state` test for `AdaptivePlaywrightCrawler` 
- Separate isolation cookie tests for `httpx` and `curl`. Having `httpx` use `respx` instead of `httpbin` will increase the stability of the test.
- Update some `PlaywrightCrawler` tests to use `route` instead of `httpbin`. This will speed up execution time and improve stability. It will also probably be useful for #929 in future