### PR TITLE
refactor!: move `cli` dependencies to optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ pipx --help
 Then, run the CLI and choose from the available templates:
 
 ```sh
-pipx run crawlee create my-crawler
+pipx run crawlee[cli] create my-crawler
 ```
 
 If you already have `crawlee` installed, you can spin it up by running:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ pipx --help
 Then, run the CLI and choose from the available templates:
 
 ```sh
-pipx run crawlee[cli] create my-crawler
+pipx run 'crawlee[cli]' create my-crawler
 ```
 
 If you already have `crawlee` installed, you can spin it up by running:

--- a/docs/introduction/01_setting_up.mdx
+++ b/docs/introduction/01_setting_up.mdx
@@ -116,7 +116,7 @@ If Pipx is not installed, follow the official [installation guide](https://pipx.
 Then, run the Crawlee CLI using Pipx and choose from the available templates:
 
 ```sh
-pipx run crawlee[cli] create my_crawler
+pipx run 'crawlee[cli]' create my-crawler
 ```
 
 ### Using Crawlee CLI directly

--- a/docs/introduction/01_setting_up.mdx
+++ b/docs/introduction/01_setting_up.mdx
@@ -116,7 +116,7 @@ If Pipx is not installed, follow the official [installation guide](https://pipx.
 Then, run the Crawlee CLI using Pipx and choose from the available templates:
 
 ```sh
-pipx run crawlee create my_crawler
+pipx run crawlee[cli] create my_crawler
 ```
 
 ### Using Crawlee CLI directly

--- a/docs/upgrading/upgrading_to_v0x.md
+++ b/docs/upgrading/upgrading_to_v0x.md
@@ -17,6 +17,10 @@ This section summarizes the breaking changes between v0.5.x and v0.6.0.
 
 The `Configuration` fields `chrome_executable_path`, `xvfb`, and `verbose_log` have been removed. The `chrome_executable_path` and `xvfb` fields were unused, while `verbose_log` can be replaced by setting `log_level` to `DEBUG`.
 
+### CLI dependencies
+
+CLI dependencies have been moved to optional dependencies. If you need the CLI, install `crawlee[cli]`
+
 ### Abstract base classes
 
 We decided to move away from [Hungarian notation](https://en.wikipedia.org/wiki/Hungarian_notation) and remove all the `Base` prefixes from the abstract classes. It includes the following public classes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ curl-impersonate = ["curl-cffi>=0.9.0"]
 parsel = ["parsel>=1.10.0"]
 playwright = ["browserforge>=1.2.3", "playwright>=1.27.0"]
 
+[project.scripts]
+crawlee = "crawlee._cli:cli"
+
 [project.urls]
 "Homepage" = "https://crawlee.dev/python"
 "Apify homepage" = "https://apify.com"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,9 @@ keywords = [
 dependencies = [
     "cachetools>=5.5.0",
     "colorama>=0.4.0",
-    "cookiecutter>=2.6.0",
     "docutils>=0.21.0",
     "eval-type-backport>=0.2.0",
     "httpx[brotli,http2,zstd]>=0.27.0",
-    "inquirer>=3.3.0",
     "more-itertools>=10.2.0",
     "psutil>=6.0.0",
     "pydantic-settings>=2.2.0,<2.7.0",
@@ -48,7 +46,6 @@ dependencies = [
     "rich>=13.9.0",
     "sortedcollections>=2.1.0",
     "tldextract>=5.1.0",
-    "typer>=0.12.0",
     "typing-extensions>=4.1.0",
     "yarl>=1.18.0",
 ]
@@ -77,6 +74,7 @@ beautifulsoup = ["beautifulsoup4[lxml]>=4.12.0", "html5lib>=1.0"]
 curl-impersonate = ["curl-cffi>=0.9.0"]
 parsel = ["parsel>=1.10.0"]
 playwright = ["browserforge>=1.2.3", "playwright>=1.27.0"]
+cli = ["cookiecutter>=2.6.0", "inquirer>=3.3.0", "typer>=0.12.0"]
 
 [project.scripts]
 crawlee = "crawlee._cli:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,13 +56,16 @@ dependencies = [
 all = [
     "beautifulsoup4[lxml]>=4.12.0",
     "browserforge>=1.2.3",
+    "cookiecutter>=2.6.0",
     "curl-cffi>=0.9.0",
     "html5lib>=1.0",
+    "inquirer>=3.3.0",
     "jaro-winkler>=2.0.3",
     "parsel>=1.10.0",
     "playwright>=1.27.0",
     "scikit-learn==1.5.2; python_version == '3.9'",
     "scikit-learn>=1.6.0; python_version >= '3.10'",
+    'typer>=0.12.0'
 ]
 adaptive-crawler = [
     "jaro-winkler>=2.0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,10 +74,10 @@ adaptive-crawler = [
     "scikit-learn>=1.6.0; python_version >= '3.10'",
 ]
 beautifulsoup = ["beautifulsoup4[lxml]>=4.12.0", "html5lib>=1.0"]
+cli = ["cookiecutter>=2.6.0", "inquirer>=3.3.0", "typer>=0.12.0"]
 curl-impersonate = ["curl-cffi>=0.9.0"]
 parsel = ["parsel>=1.10.0"]
 playwright = ["browserforge>=1.2.3", "playwright>=1.27.0"]
-cli = ["cookiecutter>=2.6.0", "inquirer>=3.3.0", "typer>=0.12.0"]
 
 [project.scripts]
 crawlee = "crawlee._cli:cli"

--- a/src/crawlee/_cli.py
+++ b/src/crawlee/_cli.py
@@ -13,7 +13,7 @@ try:
     from inquirer.render.console import ConsoleRender  # type: ignore[import-untyped]
     from rich.progress import Progress, SpinnerColumn, TextColumn
 except ModuleNotFoundError as exc:
-    raise UserWarning("Looks like you're running just 'crawlee', try using 'crawlee[cli]'") from exc
+    raise ImportError("Looks like you're running just 'crawlee', try using 'crawlee[cli]'") from exc
 
 cli = typer.Typer(no_args_is_help=True)
 

--- a/src/crawlee/_cli.py
+++ b/src/crawlee/_cli.py
@@ -13,7 +13,10 @@ try:
     from inquirer.render.console import ConsoleRender  # type: ignore[import-untyped]
     from rich.progress import Progress, SpinnerColumn, TextColumn
 except ModuleNotFoundError as exc:
-    raise ImportError("Looks like you're running just 'crawlee', try using 'crawlee[cli]'") from exc
+    raise ImportError(
+        "Missing required dependencies for the Crawlee CLI. It looks like you're running 'crawlee'"
+        "without the CLI extra. Try using 'crawlee[cli]' instead.'"
+    ) from exc
 
 cli = typer.Typer(no_args_is_help=True)
 

--- a/src/crawlee/_cli.py
+++ b/src/crawlee/_cli.py
@@ -14,8 +14,8 @@ try:
     from rich.progress import Progress, SpinnerColumn, TextColumn
 except ModuleNotFoundError as exc:
     raise ImportError(
-        "Missing required dependencies for the Crawlee CLI. It looks like you're running 'crawlee'"
-        "without the CLI extra. Try using 'crawlee[cli]' instead.'"
+        "Missing required dependencies for the Crawlee CLI. It looks like you're running 'crawlee' "
+        "without the CLI extra. Try using 'crawlee[cli]' instead."
     ) from exc
 
 cli = typer.Typer(no_args_is_help=True)

--- a/src/crawlee/_cli.py
+++ b/src/crawlee/_cli.py
@@ -6,11 +6,14 @@ import json
 from pathlib import Path
 from typing import Annotated, Optional, cast
 
-import inquirer  # type: ignore[import-untyped]
-import typer
-from cookiecutter.main import cookiecutter  # type: ignore[import-untyped]
-from inquirer.render.console import ConsoleRender  # type: ignore[import-untyped]
-from rich.progress import Progress, SpinnerColumn, TextColumn
+try:
+    import inquirer  # type: ignore[import-untyped]
+    import typer
+    from cookiecutter.main import cookiecutter  # type: ignore[import-untyped]
+    from inquirer.render.console import ConsoleRender  # type: ignore[import-untyped]
+    from rich.progress import Progress, SpinnerColumn, TextColumn
+except ModuleNotFoundError as exc:
+    raise UserWarning("Looks like you're running just 'crawlee', try using 'crawlee[cli]'") from exc
 
 cli = typer.Typer(no_args_is_help=True)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -131,7 +130,7 @@ name = "blessed"
 version = "1.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jinxed", marker = "sys_platform == 'win32'" },
+    { name = "jinxed", marker = "platform_system == 'Windows'" },
     { name = "six" },
     { name = "wcwidth" },
 ]
@@ -466,7 +465,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -608,13 +607,16 @@ adaptive-crawler = [
 all = [
     { name = "beautifulsoup4", extra = ["lxml"] },
     { name = "browserforge" },
+    { name = "cookiecutter" },
     { name = "curl-cffi" },
     { name = "html5lib" },
+    { name = "inquirer" },
     { name = "jaro-winkler" },
     { name = "parsel" },
     { name = "playwright" },
     { name = "scikit-learn", version = "1.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "scikit-learn", version = "1.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typer" },
 ]
 beautifulsoup = [
     { name = "beautifulsoup4", extra = ["lxml"] },
@@ -670,6 +672,7 @@ requires-dist = [
     { name = "browserforge", marker = "extra == 'playwright'", specifier = ">=1.2.3" },
     { name = "cachetools", specifier = ">=5.5.0" },
     { name = "colorama", specifier = ">=0.4.0" },
+    { name = "cookiecutter", marker = "extra == 'all'", specifier = ">=2.6.0" },
     { name = "cookiecutter", marker = "extra == 'cli'", specifier = ">=2.6.0" },
     { name = "curl-cffi", marker = "extra == 'all'", specifier = ">=0.9.0" },
     { name = "curl-cffi", marker = "extra == 'curl-impersonate'", specifier = ">=0.9.0" },
@@ -678,6 +681,7 @@ requires-dist = [
     { name = "html5lib", marker = "extra == 'all'", specifier = ">=1.0" },
     { name = "html5lib", marker = "extra == 'beautifulsoup'", specifier = ">=1.0" },
     { name = "httpx", extras = ["brotli", "http2", "zstd"], specifier = ">=0.27.0" },
+    { name = "inquirer", marker = "extra == 'all'", specifier = ">=3.3.0" },
     { name = "inquirer", marker = "extra == 'cli'", specifier = ">=3.3.0" },
     { name = "jaro-winkler", marker = "extra == 'adaptive-crawler'", specifier = ">=2.0.3" },
     { name = "jaro-winkler", marker = "extra == 'all'", specifier = ">=2.0.3" },
@@ -698,11 +702,11 @@ requires-dist = [
     { name = "scikit-learn", marker = "python_full_version >= '3.10' and extra == 'all'", specifier = ">=1.6.0" },
     { name = "sortedcollections", specifier = ">=2.1.0" },
     { name = "tldextract", specifier = ">=5.1.0" },
+    { name = "typer", marker = "extra == 'all'", specifier = ">=0.12.0" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12.0" },
     { name = "typing-extensions", specifier = ">=4.1.0" },
     { name = "yarl", specifier = ">=1.18.0" },
 ]
-provides-extras = ["all", "adaptive-crawler", "beautifulsoup", "curl-impersonate", "parsel", "playwright", "cli"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1242,7 +1246,7 @@ name = "jinxed"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ansicon", marker = "sys_platform == 'win32'" },
+    { name = "ansicon", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/d0/59b2b80e7a52d255f9e0ad040d2e826342d05580c4b1d7d7747cfb8db731/jinxed-1.3.0.tar.gz", hash = "sha256:1593124b18a41b7a3da3b078471442e51dbad3d77b4d4f2b0c26ab6f7d660dbf", size = 80981 }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -583,11 +583,9 @@ source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
     { name = "colorama" },
-    { name = "cookiecutter" },
     { name = "docutils" },
     { name = "eval-type-backport" },
     { name = "httpx", extra = ["brotli", "http2", "zstd"] },
-    { name = "inquirer" },
     { name = "more-itertools" },
     { name = "psutil" },
     { name = "pydantic" },
@@ -596,7 +594,6 @@ dependencies = [
     { name = "rich" },
     { name = "sortedcollections" },
     { name = "tldextract" },
-    { name = "typer" },
     { name = "typing-extensions" },
     { name = "yarl" },
 ]
@@ -622,6 +619,11 @@ all = [
 beautifulsoup = [
     { name = "beautifulsoup4", extra = ["lxml"] },
     { name = "html5lib" },
+]
+cli = [
+    { name = "cookiecutter" },
+    { name = "inquirer" },
+    { name = "typer" },
 ]
 curl-impersonate = [
     { name = "curl-cffi" },
@@ -668,7 +670,7 @@ requires-dist = [
     { name = "browserforge", marker = "extra == 'playwright'", specifier = ">=1.2.3" },
     { name = "cachetools", specifier = ">=5.5.0" },
     { name = "colorama", specifier = ">=0.4.0" },
-    { name = "cookiecutter", specifier = ">=2.6.0" },
+    { name = "cookiecutter", marker = "extra == 'cli'", specifier = ">=2.6.0" },
     { name = "curl-cffi", marker = "extra == 'all'", specifier = ">=0.9.0" },
     { name = "curl-cffi", marker = "extra == 'curl-impersonate'", specifier = ">=0.9.0" },
     { name = "docutils", specifier = ">=0.21.0" },
@@ -676,7 +678,7 @@ requires-dist = [
     { name = "html5lib", marker = "extra == 'all'", specifier = ">=1.0" },
     { name = "html5lib", marker = "extra == 'beautifulsoup'", specifier = ">=1.0" },
     { name = "httpx", extras = ["brotli", "http2", "zstd"], specifier = ">=0.27.0" },
-    { name = "inquirer", specifier = ">=3.3.0" },
+    { name = "inquirer", marker = "extra == 'cli'", specifier = ">=3.3.0" },
     { name = "jaro-winkler", marker = "extra == 'adaptive-crawler'", specifier = ">=2.0.3" },
     { name = "jaro-winkler", marker = "extra == 'all'", specifier = ">=2.0.3" },
     { name = "more-itertools", specifier = ">=10.2.0" },
@@ -696,11 +698,11 @@ requires-dist = [
     { name = "scikit-learn", marker = "python_full_version >= '3.10' and extra == 'all'", specifier = ">=1.6.0" },
     { name = "sortedcollections", specifier = ">=2.1.0" },
     { name = "tldextract", specifier = ">=5.1.0" },
-    { name = "typer", specifier = ">=0.12.0" },
+    { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12.0" },
     { name = "typing-extensions", specifier = ">=4.1.0" },
     { name = "yarl", specifier = ">=1.18.0" },
 ]
-provides-extras = ["all", "adaptive-crawler", "beautifulsoup", "curl-impersonate", "parsel", "playwright"]
+provides-extras = ["all", "adaptive-crawler", "beautifulsoup", "curl-impersonate", "parsel", "playwright", "cli"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -56,7 +56,7 @@ function Hero() {
                     </div>
                     <div className={styles.codeBlock}>
                         <CodeBlock className="language-bash">
-                            pipx run crawlee[cli] create my-crawler
+                            pipx run 'crawlee[cli]' create my-crawler
                         </CodeBlock>
                     </div>
                 </div>
@@ -116,7 +116,7 @@ function ActorExample() {
                     The fastest way to try Crawlee out is to use the <b>Crawlee CLI</b> and choose one of the provided templates. The CLI will prepare a new project for you, and add boilerplate code for you to play with.
                 </p>
                 <CodeBlock className="language-bash">
-                    pipx run crawlee[cli] create my-crawler
+                    pipx run 'crawlee[cli]' create my-crawler
                 </CodeBlock>
                 <p>
                     If you prefer to integrate Crawlee <b>into your own project</b>, you can follow the example below. Crawlee is available on  <a href="https://pypi.org/project/crawlee/">PyPI</a>, so you can install it using <code>pip</code>. Since it uses <code>PlaywrightCrawler</code>, you will also need to install <code>crawlee</code> package with <code>playwright</code> extra. It is not not included with Crawlee by default to keep the installation size minimal.

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -56,7 +56,7 @@ function Hero() {
                     </div>
                     <div className={styles.codeBlock}>
                         <CodeBlock className="language-bash">
-                            pipx run crawlee create my-crawler
+                            pipx run crawlee[cli] create my-crawler
                         </CodeBlock>
                     </div>
                 </div>
@@ -116,7 +116,7 @@ function ActorExample() {
                     The fastest way to try Crawlee out is to use the <b>Crawlee CLI</b> and choose one of the provided templates. The CLI will prepare a new project for you, and add boilerplate code for you to play with.
                 </p>
                 <CodeBlock className="language-bash">
-                    pipx run crawlee create my-crawler
+                    pipx run crawlee[cli] create my-crawler
                 </CodeBlock>
                 <p>
                     If you prefer to integrate Crawlee <b>into your own project</b>, you can follow the example below. Crawlee is available on  <a href="https://pypi.org/project/crawlee/">PyPI</a>, so you can install it using <code>pip</code>. Since it uses <code>PlaywrightCrawler</code>, you will also need to install <code>crawlee</code> package with <code>playwright</code> extra. It is not not included with Crawlee by default to keep the installation size minimal.


### PR DESCRIPTION
### Description

- Restore entrypoint `crawlee` for `cli`
- Move cli dependencies to optional dependencies

### Issues

- Closes: #1010
- Closes: #703

### Testing

- Tested on a locally created wheel and local index

for pipx
```bash
pipx run --pip-args="--index-url http://localhost:8080" crawlee[cli] create
```

For uvx.
```bash
uvx --index-url http://localhost:8080 crawlee[cli] create
```
