### PR TITLE
fix: Fix default migration storage

### DIFF
--- a/src/crawlee/sessions/_models.py
+++ b/src/crawlee/sessions/_models.py
@@ -30,7 +30,7 @@ class SessionPoolModel(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     persistence_enabled: Annotated[bool, Field(alias='persistenceEnabled')]
-    persist_state_kvs_name: Annotated[str, Field(alias='persistStateKvsName')]
+    persist_state_kvs_name: Annotated[str | None, Field(alias='persistStateKvsName')]
     persist_state_key: Annotated[str, Field(alias='persistStateKey')]
     max_pool_size: Annotated[int, Field(alias='maxPoolSize')]
     session_count: Annotated[int, Field(alias='sessionCount')]

--- a/src/crawlee/sessions/_session_pool.py
+++ b/src/crawlee/sessions/_session_pool.py
@@ -41,7 +41,7 @@ class SessionPool:
         create_session_function: CreateSessionFunctionType | None = None,
         event_manager: EventManager | None = None,
         persistence_enabled: bool = False,
-        persist_state_kvs_name: str = 'default',
+        persist_state_kvs_name: str | None = None,
         persist_state_key: str = 'CRAWLEE_SESSION_POOL_STATE',
     ) -> None:
         """A default constructor.

--- a/src/crawlee/statistics/_statistics.py
+++ b/src/crawlee/statistics/_statistics.py
@@ -69,7 +69,7 @@ class Statistics(Generic[TStatisticsState]):
         self,
         *,
         persistence_enabled: bool = False,
-        persist_state_kvs_name: str = 'default',
+        persist_state_kvs_name: str | None = None,
         persist_state_key: str | None = None,
         key_value_store: KeyValueStore | None = None,
         log_message: str = 'Statistics',
@@ -123,7 +123,7 @@ class Statistics(Generic[TStatisticsState]):
     def with_default_state(
         *,
         persistence_enabled: bool = False,
-        persist_state_kvs_name: str = 'default',
+        persist_state_kvs_name: str | None = None,
         persist_state_key: str | None = None,
         key_value_store: KeyValueStore | None = None,
         log_message: str = 'Statistics',


### PR DESCRIPTION
### Description
Fix the "default" storage used for the migration.
It should not be named "default", it should have `None` name to create default storage.

### Issues

- Closes: #991

