### PR TITLE
fix: Fix logger name for http based loggers

### DIFF
--- a/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
+++ b/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
@@ -74,7 +74,7 @@ class AbstractHttpCrawler(
                 'AbstractHttpCrawler._create_static_content_crawler_pipeline() method to initialize it.'
             )
 
-        kwargs.setdefault('_logger', logging.getLogger(__name__))
+        kwargs.setdefault('_logger', logging.getLogger(self.__class__.__name__))
         super().__init__(**kwargs)
 
     @classmethod

--- a/tests/unit/crawlers/_beautifulsoup/test_beautifulsoup_crawler.py
+++ b/tests/unit/crawlers/_beautifulsoup/test_beautifulsoup_crawler.py
@@ -206,3 +206,7 @@ async def test_handle_blocked_request(server: respx.MockRouter) -> None:
     stats = await crawler.run(['https://test.io/fdyr'])
     assert server['incapsula_endpoint'].called
     assert stats.requests_failed == 1
+
+
+def test_default_logger() -> None:
+    assert BeautifulSoupCrawler().log.name == 'BeautifulSoupCrawler'

--- a/tests/unit/crawlers/_http/test_http_crawler.py
+++ b/tests/unit/crawlers/_http/test_http_crawler.py
@@ -547,3 +547,7 @@ async def test_isolation_cookies_httpx(server: respx.MockRouter) -> None:
     # This way we can be sure that no cookies are being leaked through the http client
     assert sessions_cookies[clean_session_id] == {}
     assert response_cookies[clean_session_id] == ''
+
+
+def test_default_logger() -> None:
+    assert HttpCrawler().log.name == 'HttpCrawler'

--- a/tests/unit/crawlers/_parsel/test_parsel_crawler.py
+++ b/tests/unit/crawlers/_parsel/test_parsel_crawler.py
@@ -312,3 +312,7 @@ async def test_xml(server: respx.MockRouter) -> None:
     assert handler.called
 
     assert handler.call_args[0][0] == ['<hello>world</hello>']
+
+
+def test_default_logger() -> None:
+    assert ParselCrawler().log.name == 'ParselCrawler'


### PR DESCRIPTION
### Description
Set logger name for http based loggers to class name.

### Issues

- Closes: #1021


