### PR TITLE
refactor!: update status code handling

### DIFF
--- a/docs/upgrading/upgrading_to_v0x.md
+++ b/docs/upgrading/upgrading_to_v0x.md
@@ -13,6 +13,11 @@ This section summarizes the breaking changes between v0.5.x and v0.6.0.
 
 - Removed `HttpCrawlerOptions` - which contained options from `BasicCrawlerOptions` and unique options `additional_http_error_status_codes` and `ignore_http_error_status_codes`. Both of the unique options were added to `BasicCrawlerOptions` instead.
 
+### HttpClient
+
+- The signature of the `HttpClient` class has been updated. The constructor parameters `additional_http_error_status_codes` and `ignore_http_error_status_codes` have been removed and are now only available in `BasicCrawlerOptions`.
+- The method `_raise_for_error_status_code` has been removed from `HttpClient`. Its logic has been moved to the `BasicCrawler` class.
+
 ### SessionCookies
 
 - Replaces the `dict` used for cookie storage in `Session.cookies` with a new `SessionCookies` class. `SessionCookies` uses `CookieJar`, which enables support for multiple domains.

--- a/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
+++ b/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
@@ -12,7 +12,6 @@ from crawlee._utils.docs import docs_group
 from crawlee._utils.urls import convert_to_absolute_url, is_url_absolute
 from crawlee.crawlers._basic import BasicCrawler, BasicCrawlerOptions, ContextPipeline
 from crawlee.errors import SessionError
-from crawlee.http_clients import HttpxHttpClient
 from crawlee.statistics import StatisticsState
 
 from ._http_crawling_context import HttpCrawlingContext, ParsedHttpCrawlingContext, TParseResult, TSelectResult
@@ -57,16 +56,6 @@ class AbstractHttpCrawler(
     ) -> None:
         self._parser = parser
         self._pre_navigation_hooks: list[Callable[[BasicCrawlingContext], Awaitable[None]]] = []
-        kwargs.setdefault('additional_http_error_status_codes', ())
-        kwargs.setdefault('ignore_http_error_status_codes', ())
-
-        kwargs.setdefault(
-            'http_client',
-            HttpxHttpClient(
-                additional_http_error_status_codes=kwargs['additional_http_error_status_codes'],
-                ignore_http_error_status_codes=kwargs['ignore_http_error_status_codes'],
-            ),
-        )
 
         if '_context_pipeline' not in kwargs:
             raise ValueError(
@@ -111,8 +100,9 @@ class AbstractHttpCrawler(
             ContextPipeline()
             .compose(self._execute_pre_navigation_hooks)
             .compose(self._make_http_request)
+            .compose(self._handle_status_code_response)
             .compose(self._parse_http_response)
-            .compose(self._handle_blocked_request)
+            .compose(self._handle_blocked_request_by_content)
         )
 
     async def _execute_pre_navigation_hooks(
@@ -216,10 +206,32 @@ class AbstractHttpCrawler(
 
         yield HttpCrawlingContext.from_basic_crawling_context(context=context, http_response=result.http_response)
 
-    async def _handle_blocked_request(
+    async def _handle_status_code_response(
+        self, context: HttpCrawlingContext
+    ) -> AsyncGenerator[HttpCrawlingContext, None]:
+        """Validate the HTTP status code and raise appropriate exceptions if needed.
+
+        Args:
+            context: The current crawling context containing the HTTP response.
+
+        Raises:
+            SessionError: If the status code indicates the session is blocked.
+            HttpStatusCodeError: If the status code represents a server error or is explicitly configured as an error.
+            HttpClientStatusCodeError: If the status code represents a client error.
+
+        Yields:
+            The original crawling context if no errors are detected.
+        """
+        status_code = context.http_response.status_code
+        if self._retry_on_blocked:
+            self._raise_for_session_blocked_status_code(context.session, status_code)
+        self._raise_for_error_status_code(status_code)
+        yield context
+
+    async def _handle_blocked_request_by_content(
         self, context: ParsedHttpCrawlingContext[TParseResult]
     ) -> AsyncGenerator[ParsedHttpCrawlingContext[TParseResult], None]:
-        """Try to detect if the request is blocked based on the HTTP status code or the parsed response content.
+        """Try to detect if the request is blocked based on the parsed response content.
 
         Args:
             context: The current crawling context.
@@ -228,14 +240,10 @@ class AbstractHttpCrawler(
             SessionError: If the request is considered blocked.
 
         Yields:
-            The original crawling context if no errors are detected.
+            The original crawling context if no blocking is detected.
         """
-        if self._retry_on_blocked:
-            status_code = context.http_response.status_code
-            if self._is_session_blocked_status_code(context.session, status_code):
-                raise SessionError(f'Assuming the session is blocked based on HTTP status code {status_code}')
-            if blocked_info := self._parser.is_blocked(context.parsed_content):
-                raise SessionError(blocked_info.reason)
+        if self._retry_on_blocked and (blocked_info := self._parser.is_blocked(context.parsed_content)):
+            raise SessionError(blocked_info.reason)
         yield context
 
     def pre_navigation_hook(self, hook: Callable[[BasicCrawlingContext], Awaitable[None]]) -> None:

--- a/src/crawlee/crawlers/_playwright/_playwright_crawler.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_crawler.py
@@ -152,7 +152,11 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext, StatisticsState]
 
         # Compose the context pipeline with the Playwright-specific context enhancer.
         kwargs['_context_pipeline'] = (
-            ContextPipeline().compose(self._open_page).compose(self._navigate).compose(self._handle_blocked_request)
+            ContextPipeline()
+            .compose(self._open_page)
+            .compose(self._navigate)
+            .compose(self._handle_status_code_response)
+            .compose(self._handle_blocked_request_by_content)
         )
         kwargs['_additional_context_managers'] = [self._browser_pool]
         kwargs.setdefault('_logger', logging.getLogger(__name__))
@@ -293,11 +297,33 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext, StatisticsState]
                 block_requests=partial(block_requests, page=context.page),
             )
 
-    async def _handle_blocked_request(
+    async def _handle_status_code_response(
+        self, context: PlaywrightCrawlingContext
+    ) -> AsyncGenerator[PlaywrightCrawlingContext, None]:
+        """Validate the HTTP status code and raise appropriate exceptions if needed.
+
+        Args:
+            context: The current crawling context containing the response.
+
+        Raises:
+            SessionError: If the status code indicates the session is blocked.
+            HttpStatusCodeError: If the status code represents a server error or is explicitly configured as an error.
+            HttpClientStatusCodeError: If the status code represents a client error.
+
+        Yields:
+            The original crawling context if no errors are detected.
+        """
+        status_code = context.response.status
+        if self._retry_on_blocked:
+            self._raise_for_session_blocked_status_code(context.session, status_code)
+        self._raise_for_error_status_code(status_code)
+        yield context
+
+    async def _handle_blocked_request_by_content(
         self,
         context: PlaywrightCrawlingContext,
     ) -> AsyncGenerator[PlaywrightCrawlingContext, None]:
-        """Try to detect if the request is blocked based on the HTTP status code or the response content.
+        """Try to detect if the request is blocked based on the response content.
 
         Args:
             context: The current crawling context.
@@ -309,12 +335,6 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext, StatisticsState]
             The original crawling context if no errors are detected.
         """
         if self._retry_on_blocked:
-            status_code = context.response.status
-
-            # Check if the session is blocked based on the HTTP status code.
-            if self._is_session_blocked_status_code(context.session, status_code):
-                raise SessionError(f'Assuming the session is blocked based on HTTP status code {status_code}')
-
             matched_selectors = [
                 selector for selector in RETRY_CSS_SELECTORS if (await context.page.query_selector(selector))
             ]

--- a/src/crawlee/http_clients/_curl_impersonate.py
+++ b/src/crawlee/http_clients/_curl_impersonate.py
@@ -19,7 +19,6 @@ from crawlee.errors import ProxyError
 from crawlee.http_clients import HttpClient, HttpCrawlingResult, HttpResponse
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
     from http.cookiejar import Cookie
 
     from curl_cffi import Curl
@@ -111,22 +110,16 @@ class CurlImpersonateHttpClient(HttpClient):
         self,
         *,
         persist_cookies_per_session: bool = True,
-        additional_http_error_status_codes: Iterable[int] = (),
-        ignore_http_error_status_codes: Iterable[int] = (),
         **async_session_kwargs: Any,
     ) -> None:
         """A default constructor.
 
         Args:
             persist_cookies_per_session: Whether to persist cookies per HTTP session.
-            additional_http_error_status_codes: Additional HTTP status codes to treat as errors.
-            ignore_http_error_status_codes: HTTP status codes to ignore as errors.
             async_session_kwargs: Additional keyword arguments for `curl_cffi.requests.AsyncSession`.
         """
         super().__init__(
             persist_cookies_per_session=persist_cookies_per_session,
-            additional_http_error_status_codes=additional_http_error_status_codes,
-            ignore_http_error_status_codes=ignore_http_error_status_codes,
         )
         self._async_session_kwargs = async_session_kwargs
 
@@ -158,12 +151,6 @@ class CurlImpersonateHttpClient(HttpClient):
 
         if statistics:
             statistics.register_status_code(response.status_code)
-
-        self._raise_for_error_status_code(
-            response.status_code,
-            self._additional_http_error_status_codes,
-            self._ignore_http_error_status_codes,
-        )
 
         if self._persist_cookies_per_session and session and response.curl:
             response_cookies = self._get_cookies(response.curl)
@@ -204,12 +191,6 @@ class CurlImpersonateHttpClient(HttpClient):
             if self._is_proxy_error(exc):
                 raise ProxyError from exc
             raise
-
-        self._raise_for_error_status_code(
-            response.status_code,
-            self._additional_http_error_status_codes,
-            self._ignore_http_error_status_codes,
-        )
 
         if self._persist_cookies_per_session and session and response.curl:
             response_cookies = self._get_cookies(response.curl)

--- a/src/crawlee/http_clients/_httpx.py
+++ b/src/crawlee/http_clients/_httpx.py
@@ -15,7 +15,6 @@ from crawlee.http_clients import HttpClient, HttpCrawlingResult, HttpResponse
 from crawlee.sessions import Session
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
     from ssl import SSLContext
 
     from crawlee import Request
@@ -96,8 +95,6 @@ class HttpxHttpClient(HttpClient):
         self,
         *,
         persist_cookies_per_session: bool = True,
-        additional_http_error_status_codes: Iterable[int] = (),
-        ignore_http_error_status_codes: Iterable[int] = (),
         http1: bool = True,
         http2: bool = True,
         verify: str | bool | SSLContext = True,
@@ -108,8 +105,6 @@ class HttpxHttpClient(HttpClient):
 
         Args:
             persist_cookies_per_session: Whether to persist cookies per HTTP session.
-            additional_http_error_status_codes: Additional HTTP status codes to treat as errors.
-            ignore_http_error_status_codes: HTTP status codes to ignore as errors.
             http1: Whether to enable HTTP/1.1 support.
             http2: Whether to enable HTTP/2 support.
             verify: SSL certificates used to verify the identity of requested hosts.
@@ -118,8 +113,6 @@ class HttpxHttpClient(HttpClient):
         """
         super().__init__(
             persist_cookies_per_session=persist_cookies_per_session,
-            additional_http_error_status_codes=additional_http_error_status_codes,
-            ignore_http_error_status_codes=ignore_http_error_status_codes,
         )
         self._http1 = http1
         self._http2 = http2
@@ -172,12 +165,6 @@ class HttpxHttpClient(HttpClient):
         if statistics:
             statistics.register_status_code(response.status_code)
 
-        self._raise_for_error_status_code(
-            response.status_code,
-            self._additional_http_error_status_codes,
-            self._ignore_http_error_status_codes,
-        )
-
         request.loaded_url = str(response.url)
 
         return HttpCrawlingResult(
@@ -215,12 +202,6 @@ class HttpxHttpClient(HttpClient):
             if self._is_proxy_error(exc):
                 raise ProxyError from exc
             raise
-
-        self._raise_for_error_status_code(
-            response.status_code,
-            self._additional_http_error_status_codes,
-            self._ignore_http_error_status_codes,
-        )
 
         return _HttpxResponse(response)
 

--- a/src/crawlee/sessions/_session.py
+++ b/src/crawlee/sessions/_session.py
@@ -199,21 +199,16 @@ class Session:
         self,
         *,
         status_code: int,
-        additional_blocked_status_codes: set[int] | None = None,
         ignore_http_error_status_codes: set[int] | None = None,
     ) -> bool:
         """Evaluate whether a session should be retired based on the received HTTP status code.
 
         Args:
             status_code: The HTTP status code received from a server response.
-            additional_blocked_status_codes: Optional additional status codes that should trigger session retirement.
             ignore_http_error_status_codes: Optional status codes to allow suppression of
             codes from `blocked_status_codes`.
 
         Returns:
             True if the session should be retired, False otherwise.
         """
-        if additional_blocked_status_codes and status_code in additional_blocked_status_codes:
-            return True
-
         return status_code in (self._blocked_status_codes - (ignore_http_error_status_codes or set()))

--- a/tests/unit/crawlers/_http/test_http_crawler.py
+++ b/tests/unit/crawlers/_http/test_http_crawler.py
@@ -82,6 +82,7 @@ async def server() -> AsyncGenerator[respx.MockRouter, None]:
             </html>""",
         )
 
+        # Endpoint with Session Blocked status code
         mock.get('/403', name='403_endpoint').return_value = Response(
             403,
             text="""<html>
@@ -91,6 +92,17 @@ async def server() -> AsyncGenerator[respx.MockRouter, None]:
             </html>""",
         )
 
+        # Endpoint with Client Error status code
+        mock.get('/402', name='402_endpoint').return_value = Response(
+            402,
+            text="""<html>
+                <head>
+                    <title>Not found</title>
+                </head>
+            </html>""",
+        )
+
+        # Endpoint with Server Error status code
         mock.get('/500', name='500_endpoint').return_value = Response(
             500,
             text="""<html>
@@ -155,11 +167,11 @@ async def test_handles_redirects(
         # error without retry for all 4xx statuses
         pytest.param([], [], 1, id='default_behavior'),
         # make retry for codes in `additional_http_error_status_codes` list
-        pytest.param([403], [], 3, id='additional_status_codes'),
+        pytest.param([402], [], 3, id='additional_status_codes'),
         # take as successful status codes from the `ignore_http_error_status_codes` list
-        pytest.param([], [403], 0, id='ignore_error_status_codes'),
+        pytest.param([], [402], 0, id='ignore_error_status_codes'),
         # check precedence for `additional_http_error_status_codes`
-        pytest.param([403], [403], 3, id='additional_and_ignore'),
+        pytest.param([402], [402], 3, id='additional_and_ignore'),
     ],
 )
 async def test_handles_client_errors(
@@ -176,10 +188,54 @@ async def test_handles_client_errors(
         max_request_retries=3,
     )
 
+    await crawler.add_requests(['https://test.io/402'])
+    await crawler.run()
+
+    assert crawler.statistics.error_tracker.total == expected_number_error
+
+    # Request handler should not be called for error status codes.
+    if expected_number_error:
+        mock_request_handler.assert_not_called()
+    else:
+        mock_request_handler.assert_called()
+
+    assert server['402_endpoint'].called
+
+
+@pytest.mark.parametrize(
+    ('ignore_http_error_status_codes', 'use_session_pool', 'expected_session_rotate', 'expected_number_error'),
+    [
+        # change session and retry for no block 4xx statuses
+        pytest.param([], True, 4, 1, id='default_behavior'),
+        # error without retry for all 4xx statuses
+        pytest.param([], False, 0, 1, id='default_behavior_without_session_pool'),
+        # take as successful status codes from the `ignore_http_error_status_codes` list with Sessoion Pool
+        pytest.param([403], True, 0, 0, id='ignore_error_status_codes'),
+        # take as successful status codes from the `ignore_http_error_status_codes` list without Sessoion Pool
+        pytest.param([403], False, 0, 0, id='ignore_error_status_codes_without_session_pool'),
+    ],
+)
+async def test_handles_session_block_errors(
+    ignore_http_error_status_codes: list[int],
+    use_session_pool: bool,  # noqa: FBT001
+    expected_session_rotate: int,
+    expected_number_error: int,
+    mock_request_handler: AsyncMock,
+    server: respx.MockRouter,
+) -> None:
+    crawler = HttpCrawler(
+        request_handler=mock_request_handler,
+        ignore_http_error_status_codes=ignore_http_error_status_codes,
+        max_request_retries=3,
+        max_session_rotations=5,
+        use_session_pool=use_session_pool,
+    )
+
     await crawler.add_requests(['https://test.io/403'])
     await crawler.run()
 
     assert crawler.statistics.error_tracker.total == expected_number_error
+    assert crawler.statistics.error_tracker_retry.total == expected_session_rotate
 
     # Request handler should not be called for error status codes.
     if expected_number_error:
@@ -208,7 +264,7 @@ async def test_handles_server_error(
     ],
 )
 async def test_stores_cookies(http_client_class: type[HttpClient], httpbin: URL) -> None:
-    http_client = http_client_class(ignore_http_error_status_codes=[401])
+    http_client = http_client_class()
     visit = Mock()
     track_session_usage = Mock()
 
@@ -262,19 +318,21 @@ async def test_do_not_retry_on_client_errors(crawler: HttpCrawler, server: respx
 
 async def test_http_status_statistics(crawler: HttpCrawler, server: respx.MockRouter) -> None:
     await crawler.add_requests([f'https://test.io/500?id={i}' for i in range(10)])
+    await crawler.add_requests([f'https://test.io/402?id={i}' for i in range(10)])
     await crawler.add_requests([f'https://test.io/403?id={i}' for i in range(10)])
     await crawler.add_requests([f'https://test.io/html?id={i}' for i in range(10)])
 
     await crawler.run()
-
     assert crawler.statistics.state.requests_with_status_code == {
         '200': 10,
-        '403': 10,  # client errors are not retried by default
+        '403': 100,  # block errors change session and retry
+        '402': 10,  # client errors are not retried by default
         '500': 30,  # server errors are retried by default
     }
 
     assert len(server['html_endpoint'].calls) == 10
-    assert len(server['403_endpoint'].calls) == 10
+    assert len(server['403_endpoint'].calls) == 100
+    assert len(server['402_endpoint'].calls) == 10
     assert len(server['500_endpoint'].calls) == 30
 
 

--- a/tests/unit/crawlers/_http/test_http_crawler.py
+++ b/tests/unit/crawlers/_http/test_http_crawler.py
@@ -216,8 +216,9 @@ async def test_handles_client_errors(
     ],
 )
 async def test_handles_session_block_errors(
+    *,
     ignore_http_error_status_codes: list[int],
-    use_session_pool: bool,  # noqa: FBT001
+    use_session_pool: bool,
     expected_session_rotate: int,
     expected_number_error: int,
     mock_request_handler: AsyncMock,


### PR DESCRIPTION
### Description


* `additional_http_error_status_codes` and `ignore_http_error_status_codes` have been removed from the constructor parameters for HTTP clients
* The method `_raise_for_error_status_code` has been removed from `HttpClient` and its logic has been moved to `BasicCrawler`
* Prioritized checking of status codes that indicate `Session` blocking. Codes (401, 403, 429) trigger `retire` for the `Session` and retry, while other 4XX codes are handled as client errors (errors without retries).
* `additional_http_error_status_codes` is no longer used when checking status codes that indicate `Session` blocking. According to current documentation, these codes should trigger a retry, not `retire` for the `Session` and retry. Blocking status codes can be modified in `SessionPool` through `create_session_settings`.
* Standardized error handling for status codes in both `PlaywrightCrawler` and `HttpCrawler`

### Issues

- Closes: #998
- Closes: #830

### Testing

* Tests for client error status codes now use code 402.
* A separate test has been added for 403 since in this case the number of retries is affected by the 'max_session_rotations' parameter.
