### PR TITLE
fix: Add `browserforge` to mandatory dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ keywords = [
     "scraping",
 ]
 dependencies = [
+    "browserforge>=1.2.3",
     "cachetools>=5.5.0",
     "colorama>=0.4.0",
     "docutils>=0.21.0",
@@ -55,7 +56,6 @@ dependencies = [
 # https://github.com/apify/crawlee-python/issues/995
 all = [
     "beautifulsoup4[lxml]>=4.12.0",
-    "browserforge>=1.2.3",
     "cookiecutter>=2.6.0",
     "curl-cffi>=0.9.0",
     "html5lib>=1.0",
@@ -77,7 +77,7 @@ beautifulsoup = ["beautifulsoup4[lxml]>=4.12.0", "html5lib>=1.0"]
 cli = ["cookiecutter>=2.6.0", "inquirer>=3.3.0", "typer>=0.12.0"]
 curl-impersonate = ["curl-cffi>=0.9.0"]
 parsel = ["parsel>=1.10.0"]
-playwright = ["browserforge>=1.2.3", "playwright>=1.27.0"]
+playwright = ["playwright>=1.27.0"]
 
 [project.scripts]
 crawlee = "crawlee._cli:cli"

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -130,7 +131,7 @@ name = "blessed"
 version = "1.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jinxed", marker = "platform_system == 'Windows'" },
+    { name = "jinxed", marker = "sys_platform == 'win32'" },
     { name = "six" },
     { name = "wcwidth" },
 ]
@@ -465,7 +466,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -580,6 +581,7 @@ name = "crawlee"
 version = "0.6.0"
 source = { editable = "." }
 dependencies = [
+    { name = "browserforge" },
     { name = "cachetools" },
     { name = "colorama" },
     { name = "docutils" },
@@ -606,7 +608,6 @@ adaptive-crawler = [
 ]
 all = [
     { name = "beautifulsoup4", extra = ["lxml"] },
-    { name = "browserforge" },
     { name = "cookiecutter" },
     { name = "curl-cffi" },
     { name = "html5lib" },
@@ -634,7 +635,6 @@ parsel = [
     { name = "parsel" },
 ]
 playwright = [
-    { name = "browserforge" },
     { name = "playwright" },
 ]
 
@@ -668,8 +668,7 @@ dev = [
 requires-dist = [
     { name = "beautifulsoup4", extras = ["lxml"], marker = "extra == 'all'", specifier = ">=4.12.0" },
     { name = "beautifulsoup4", extras = ["lxml"], marker = "extra == 'beautifulsoup'", specifier = ">=4.12.0" },
-    { name = "browserforge", marker = "extra == 'all'", specifier = ">=1.2.3" },
-    { name = "browserforge", marker = "extra == 'playwright'", specifier = ">=1.2.3" },
+    { name = "browserforge", specifier = ">=1.2.3" },
     { name = "cachetools", specifier = ">=5.5.0" },
     { name = "colorama", specifier = ">=0.4.0" },
     { name = "cookiecutter", marker = "extra == 'all'", specifier = ">=2.6.0" },
@@ -707,6 +706,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.1.0" },
     { name = "yarl", specifier = ">=1.18.0" },
 ]
+provides-extras = ["all", "adaptive-crawler", "beautifulsoup", "cli", "curl-impersonate", "parsel", "playwright"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1113,7 +1113,7 @@ name = "importlib-metadata"
 version = "8.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/08/c1395a292bb23fd03bdf572a1357c5a733d3eecbab877641ceacab23db6e/importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580", size = 55767 }
 wheels = [
@@ -1283,7 +1283,7 @@ name = "jinxed"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ansicon", marker = "platform_system == 'Windows'" },
+    { name = "ansicon", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/d0/59b2b80e7a52d255f9e0ad040d2e826342d05580c4b1d7d7747cfb8db731/jinxed-1.3.0.tar.gz", hash = "sha256:1593124b18a41b7a3da3b078471442e51dbad3d77b4d4f2b0c26ab6f7d660dbf", size = 80981 }
 wheels = [


### PR DESCRIPTION
### Description

`Browserforge` is now used for header generation not only for `PlaywrightCrawler`, but also for http clients and so it needs to be mandatory dependency.

