### PR TITLE
fix: Remove tmp folder for PlaywrightCrawler in non-headless mode

### DIFF
--- a/src/crawlee/browsers/_playwright_browser.py
+++ b/src/crawlee/browsers/_playwright_browser.py
@@ -68,23 +68,20 @@ class PlaywrightPersistentBrowser(Browser):
             user_data_dir=user_data_dir, **launch_options
         )
 
-        if self._temp_dir:
-            self._context.on('close', self._delete_temp_dir)
-
         return self._context
 
-    async def _delete_temp_dir(self, _: BrowserContext) -> None:
+    async def _delete_temp_dir(self) -> None:
         if self._temp_dir and self._temp_dir.exists():
-            await asyncio.to_thread(shutil.rmtree, self._temp_dir, ignore_errors=True)
+            await asyncio.to_thread(shutil.rmtree, self._temp_dir)
 
     @override
     async def close(self, **kwargs: Any) -> None:
         """Close browser by closing its context."""
         if self._context:
             await self._context.close()
-            await self._delete_temp_dir(self._context)
             self._context = None
         self._is_connected = False
+        await self._delete_temp_dir()
 
     @property
     @override

--- a/src/crawlee/browsers/_playwright_browser.py
+++ b/src/crawlee/browsers/_playwright_browser.py
@@ -68,11 +68,14 @@ class PlaywrightPersistentBrowser(Browser):
             user_data_dir=user_data_dir, **launch_options
         )
 
+        if self._temp_dir:
+            self._context.on('close', self._delete_temp_dir)
+
         return self._context
 
-    async def _delete_temp_dir(self) -> None:
+    async def _delete_temp_dir(self, _: BrowserContext | None) -> None:
         if self._temp_dir and self._temp_dir.exists():
-            await asyncio.to_thread(shutil.rmtree, self._temp_dir)
+            await asyncio.to_thread(shutil.rmtree, self._temp_dir, ignore_errors=True)
 
     @override
     async def close(self, **kwargs: Any) -> None:
@@ -82,7 +85,7 @@ class PlaywrightPersistentBrowser(Browser):
             self._context = None
         self._is_connected = False
         await asyncio.sleep(0.1)
-        await self._delete_temp_dir()
+        await self._delete_temp_dir(self._context)
 
     @property
     @override

--- a/src/crawlee/browsers/_playwright_browser.py
+++ b/src/crawlee/browsers/_playwright_browser.py
@@ -81,7 +81,7 @@ class PlaywrightPersistentBrowser(Browser):
             await self._context.close()
             self._context = None
         self._is_connected = False
-        await asyncio.sleep(0)
+        await asyncio.sleep(0.1)
         await self._delete_temp_dir()
 
     @property

--- a/src/crawlee/browsers/_playwright_browser.py
+++ b/src/crawlee/browsers/_playwright_browser.py
@@ -81,6 +81,7 @@ class PlaywrightPersistentBrowser(Browser):
             await self._context.close()
             self._context = None
         self._is_connected = False
+        await asyncio.sleep(0)
         await self._delete_temp_dir()
 
     @property

--- a/tests/unit/browsers/test_playwright_browser.py
+++ b/tests/unit/browsers/test_playwright_browser.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from playwright.async_api import async_playwright
+
+from crawlee.browsers._playwright_browser import PlaywrightPersistentBrowser
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from playwright.async_api import Playwright
+
+
+@pytest.fixture
+async def playwright() -> AsyncGenerator[Playwright, None]:
+    async with async_playwright() as playwright:
+        yield playwright
+
+
+async def test_init(playwright: Playwright) -> None:
+    browser_type = playwright.chromium
+    persist_browser = PlaywrightPersistentBrowser(browser_type, user_data_dir=None, browser_launch_options={})
+    assert persist_browser._browser_type == browser_type
+    assert persist_browser.browser_type == browser_type
+    assert persist_browser._browser_launch_options == {}
+    assert persist_browser._temp_dir is None
+    assert persist_browser._user_data_dir is None
+    assert persist_browser._is_connected is True
+    assert persist_browser.is_connected() is True
+
+
+async def test_delete_temp_folder_with_close_browser(playwright: Playwright) -> None:
+    persist_browser = PlaywrightPersistentBrowser(
+        playwright.chromium, user_data_dir=None, browser_launch_options={'headless': False}
+    )
+    await persist_browser.new_context()
+    assert isinstance(persist_browser._temp_dir, Path)
+    current_temp_dir = persist_browser._temp_dir
+    assert current_temp_dir.exists()
+    await persist_browser.close()
+    assert not current_temp_dir.exists()

--- a/tests/unit/browsers/test_playwright_browser.py
+++ b/tests/unit/browsers/test_playwright_browser.py
@@ -34,7 +34,7 @@ async def test_init(playwright: Playwright) -> None:
 
 async def test_delete_temp_folder_with_close_browser(playwright: Playwright) -> None:
     persist_browser = PlaywrightPersistentBrowser(
-        playwright.chromium, user_data_dir=None, browser_launch_options={'headless': False}
+        playwright.chromium, user_data_dir=None, browser_launch_options={'headless': True}
     )
     await persist_browser.new_context()
     assert isinstance(persist_browser._temp_dir, Path)

--- a/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
+++ b/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
@@ -218,6 +218,8 @@ async def test_adaptive_crawling(
 
     await crawler.run(test_urls)
 
+    await asyncio.sleep(0)
+
     assert pw_handler_count == test_input.expected_pw_count
     assert pw_hook_count == test_input.expected_pw_count
 

--- a/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
+++ b/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
@@ -218,8 +218,6 @@ async def test_adaptive_crawling(
 
     await crawler.run(test_urls)
 
-    await asyncio.sleep(0)
-
     assert pw_handler_count == test_input.expected_pw_count
     assert pw_hook_count == test_input.expected_pw_count
 


### PR DESCRIPTION
### Description

- Fix a bug removing a temporary folder for non-headless mode. I saved an attempt to remove a folder on the `close` event, for when for some reason the browser crashes and the context is closed by the Playwright mechanisms


