### PR TITLE
refactor: allow extra attributes for storages

### DIFF
--- a/src/crawlee/storage_clients/models.py
+++ b/src/crawlee/storage_clients/models.py
@@ -23,7 +23,7 @@ class StorageMetadata(BaseModel):
     It contains common fields shared across all specific storage types.
     """
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, extra='allow')
 
     id: Annotated[str, Field(alias='id')]
     name: Annotated[str | None, Field(alias='name', default='')]

--- a/tests/unit/storages/test_dataset.py
+++ b/tests/unit/storages/test_dataset.py
@@ -145,6 +145,7 @@ async def test_from_storage_object() -> None:
         accessed_at=datetime.now(timezone.utc),
         created_at=datetime.now(timezone.utc),
         modified_at=datetime.now(timezone.utc),
+        extra_attribute='extra',
     )
 
     dataset = Dataset.from_storage_object(storage_client, storage_object)
@@ -152,3 +153,4 @@ async def test_from_storage_object() -> None:
     assert dataset.id == storage_object.id
     assert dataset.name == storage_object.name
     assert dataset.storage_object == storage_object
+    assert storage_object.model_extra.get('extra_attribute') == 'extra'  # type: ignore[union-attr]

--- a/tests/unit/storages/test_key_value_store.py
+++ b/tests/unit/storages/test_key_value_store.py
@@ -218,6 +218,7 @@ async def test_from_storage_object() -> None:
         accessed_at=datetime.now(timezone.utc),
         created_at=datetime.now(timezone.utc),
         modified_at=datetime.now(timezone.utc),
+        extra_attribute='extra',
     )
 
     key_value_store = KeyValueStore.from_storage_object(storage_client, storage_object)
@@ -225,3 +226,4 @@ async def test_from_storage_object() -> None:
     assert key_value_store.id == storage_object.id
     assert key_value_store.name == storage_object.name
     assert key_value_store.storage_object == storage_object
+    assert storage_object.model_extra.get('extra_attribute') == 'extra'  # type: ignore[union-attr]

--- a/tests/unit/storages/test_request_queue.py
+++ b/tests/unit/storages/test_request_queue.py
@@ -277,6 +277,7 @@ async def test_from_storage_object() -> None:
         accessed_at=datetime.now(timezone.utc),
         created_at=datetime.now(timezone.utc),
         modified_at=datetime.now(timezone.utc),
+        extra_attribute='extra',
     )
 
     request_queue = RequestQueue.from_storage_object(storage_client, storage_object)
@@ -284,3 +285,4 @@ async def test_from_storage_object() -> None:
     assert request_queue.id == storage_object.id
     assert request_queue.name == storage_object.name
     assert request_queue.storage_object == storage_object
+    assert storage_object.model_extra.get('extra_attribute') == 'extra'  # type: ignore[union-attr]

--- a/uv.lock
+++ b/uv.lock
@@ -578,7 +578,7 @@ toml = [
 
 [[package]]
 name = "crawlee"
-version = "0.6.1"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "browserforge" },


### PR DESCRIPTION
### Description

This PR follows up on https://github.com/apify/crawlee-python/pull/993. While aligning changes with the Apify SDK, I noticed that Pydantic models only select explicitly defined fields. However, we also need access to `urlSigningSecretKey`, so I’ve updated the `StorageMetadata` config **to allow extra fields.**

### Testing

Added tests for all storage types (datasets, key-value stores, and request queues) to ensure extra attributes are correctly handled.

### Checklist

- [x] CI passed
