### PR TITLE
chore: Add `sortedcontainers` to the project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "pyee>=9.0.0",
     "rich>=13.9.0",
     "sortedcollections>=2.1.0",
+    "sortedcontainers>=2.4.0",
     "tldextract>=5.1.0",
     "typing-extensions>=4.1.0",
     "yarl>=1.18.0",

--- a/uv.lock
+++ b/uv.lock
@@ -587,7 +587,7 @@ toml = [
 
 [[package]]
 name = "crawlee"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "apify-fingerprint-datapoints" },
@@ -603,6 +603,7 @@ dependencies = [
     { name = "pyee" },
     { name = "rich" },
     { name = "sortedcollections" },
+    { name = "sortedcontainers" },
     { name = "tldextract" },
     { name = "typing-extensions" },
     { name = "yarl" },
@@ -709,6 +710,7 @@ requires-dist = [
     { name = "scikit-learn", marker = "python_full_version >= '3.10' and extra == 'adaptive-crawler'", specifier = ">=1.6.0" },
     { name = "scikit-learn", marker = "python_full_version >= '3.10' and extra == 'all'", specifier = ">=1.6.0" },
     { name = "sortedcollections", specifier = ">=2.1.0" },
+    { name = "sortedcontainers", specifier = ">=2.4.0" },
     { name = "tldextract", specifier = ">=5.1.0" },
     { name = "typer", marker = "extra == 'all'", specifier = ">=0.12.0" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12.0" },


### PR DESCRIPTION
Explicitly add `sortedcontainers` to the project dependencies.
It is already being used in code, but so far it was not explicitly mentioned due to `sortedcollections` already being in project dependencies.
`sortedcontainers` is dependency of `sortedcollections` and thus it was kind of implictly present in the project.