### PR TITLE
ci: add APIFY_SIGNING_TOKEN to docs build environment

### DIFF
--- a/.github/workflows/build_and_deploy_docs.yaml
+++ b/.github/workflows/build_and_deploy_docs.yaml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Build Docusaurus docs
         run: make build-docs
+        env:
+          APIFY_SIGNING_TOKEN: ${{ secrets.APIFY_SIGNING_TOKEN }}
 
       - name: Set up GitHub Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
Closes: https://github.com/apify/crawlee-python/issues/1121