### PR TITLE
chore: Add e2e tests for playwright templates and pip based templates

### DIFF
--- a/.github/workflows/templates_e2e_tests.yaml
+++ b/.github/workflows/templates_e2e_tests.yaml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        http-client: [ "httpx", "curl_impersonate" ]
+        http-client: [ "httpx", "curl_impersonate"]
         crawler-type: [ "parsel", "beautifulsoup", "playwright", "playwright_camoufox"]
-        package-manager: [ "uv", "poetry" ]
+        package-manager: ["pip", "uv", "poetry"]
 
     runs-on: "ubuntu-latest"
     env:

--- a/.github/workflows/templates_e2e_tests.yaml
+++ b/.github/workflows/templates_e2e_tests.yaml
@@ -12,6 +12,11 @@ jobs:
     name: End-to-end tests
     strategy:
       fail-fast: false
+      max-parallel: 2
+      matrix:
+        http-client: [ "httpx", "curl_impersonate" ]
+        crawler-type: [ "parsel", "beautifulsoup", "playwright", "playwright_camoufox"]
+        package-manager: [ "uv", "poetry" ]
 
     runs-on: "ubuntu-latest"
     env:
@@ -44,10 +49,11 @@ jobs:
         with:
           python-version: ${{ env.python-version }}
 
+      # Sync the project, but no need to install the browsers into the test runner environment.
       - name: Install Python dependencies
-        run: make install-dev
+        run: make install-sync
 
       - name: Run templates end-to-end tests
-        run: make e2e-templates-tests
+        run: make e2e-templates-tests args="-m ${{ matrix.http-client }} and ${{ matrix.crawler-type }} and ${{ matrix.package-manager }}"
         env:
           APIFY_TEST_USER_API_TOKEN: ${{ secrets.APIFY_TEST_USER_API_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,11 @@ E2E_TESTS_CONCURRENCY = 1
 clean:
 	rm -rf .mypy_cache .pytest_cache .ruff_cache build dist htmlcov .coverage
 
-install-dev:
+install-sync:
 	uv sync --all-extras
+
+install-dev:
+	make install-sync
 	uv run pre-commit install
 	uv run playwright install
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-.PHONY: clean install-dev build publish-to-pypi lint type-check unit-tests unit-tests-cov \
-	integration-tests format check-code build-api-reference run-docs
+.PHONY: clean install-sync install-dev build publish-to-pypi lint type-check unit-tests unit-tests-cov \
+	e2e-templates-tests format check-code build-api-reference run-docs
+
+
 
 # This is default for local testing, but GitHub workflows override it to a higher value in CI
 E2E_TESTS_CONCURRENCY = 1
@@ -32,8 +34,8 @@ unit-tests:
 unit-tests-cov:
 	uv run pytest --numprocesses=auto --verbose --cov=src/crawlee --cov-report=html tests/unit
 
-e2e-templates-tests:
-	uv run pytest --numprocesses=$(E2E_TESTS_CONCURRENCY) --verbose tests/e2e/project_template
+e2e-templates-tests $(args):
+	uv run pytest --numprocesses=$(E2E_TESTS_CONCURRENCY) --verbose tests/e2e/project_template "$(args)"
 
 format:
 	uv run ruff check --fix

--- a/src/crawlee/project_template/templates/main_beautifulsoup.py
+++ b/src/crawlee/project_template/templates/main_beautifulsoup.py
@@ -7,6 +7,6 @@ from crawlee.crawlers import BeautifulSoupCrawler
 # % block instantiation
 crawler = BeautifulSoupCrawler(
     request_handler=router,
-    max_requests_per_crawl=50,
+    max_requests_per_crawl=10,
     {{ self.http_client_instantiation() }})
 # % endblock

--- a/src/crawlee/project_template/templates/main_parsel.py
+++ b/src/crawlee/project_template/templates/main_parsel.py
@@ -7,6 +7,6 @@ from crawlee.crawlers import ParselCrawler
 # % block instantiation
 crawler = ParselCrawler(
     request_handler=router,
-    max_requests_per_crawl=50,
+    max_requests_per_crawl=10,
     {{ self.http_client_instantiation() }})
 # % endblock

--- a/src/crawlee/project_template/templates/main_playwright.py
+++ b/src/crawlee/project_template/templates/main_playwright.py
@@ -8,6 +8,6 @@ from crawlee.crawlers import PlaywrightCrawler
 crawler = PlaywrightCrawler(
     request_handler=router,
     headless=True,
-    max_requests_per_crawl=50,
+    max_requests_per_crawl=10,
     {{ self.http_client_instantiation() }})
 # % endblock

--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
@@ -72,8 +72,8 @@ RUN echo "Python version:" \
  && cat requirements.txt | \
  # Replace playwright version so that it matches whatever is pre-installed in the image (the `hash` checks if playwright is installed)
     sed "s/^playwright==\(.*\)/playwright==$(hash playwright 2>/dev/null && (playwright --version | cut -d ' ' -f 2) || echo '\1')/" | \
- # Install everything using pip (ignore dependency checks - the lockfile is correct, period)
-    pip install -r /dev/stdin --no-dependencies \
+ # Install everything using pip
+    pip install -r /dev/stdin \
  && echo "All installed Python packages:" \
  && pip freeze
 # % elif cookiecutter.package_manager == 'manual'

--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/requirements.txt
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/requirements.txt
@@ -1,5 +1,5 @@
 # % if cookiecutter.crawler_type == 'playwright-camoufox'
-camoufox
+camoufox[geoip]>=0.4.5
 # % set extras = ['playwright']
 # % else
 # % set extras = [cookiecutter.crawler_type]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -18,6 +18,7 @@ def pytest_configure(config: Config) -> None:
         'beautifulsoup',
         'uv',
         'poetry',
+        'pip',
     ]:
         config.addinivalue_line('markers', f'{marker}: Integration test parameter marker.')
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -2,9 +2,24 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from _pytest.config import Config
 from filelock import FileLock
 
 _CRAWLEE_ROOT_PATH = Path(__file__).parent.parent.parent.resolve()
+
+
+def pytest_configure(config: Config) -> None:
+    for marker in [
+        'httpx',
+        'curl_impersonate',
+        'playwright',
+        'playwright_camoufox',
+        'parsel',
+        'beautifulsoup',
+        'uv',
+        'poetry',
+    ]:
+        config.addinivalue_line('markers', f'{marker}: Integration test parameter marker.')
 
 
 @pytest.fixture(scope='session')

--- a/tests/e2e/project_template/test_static_crawlers_templates.py
+++ b/tests/e2e/project_template/test_static_crawlers_templates.py
@@ -2,6 +2,7 @@ import os
 import re
 import subprocess
 from pathlib import Path
+from typing import Literal
 
 import pytest
 from apify_client import ApifyClientAsync
@@ -9,7 +10,7 @@ from cookiecutter.main import cookiecutter
 
 from crawlee._cli import default_start_url, template_directory
 from crawlee._utils.crypto import crypto_random_object_id
-from tests.e2e.project_template.utils import patch_crawlee_version_in_pyproject_toml_based_project
+from tests.e2e.project_template.utils import patch_crawlee_version_in_project
 
 # To run these tests locally, make sure you have apify-cli installed and available in the path.
 # https://docs.apify.com/cli/docs/installation
@@ -32,10 +33,19 @@ from tests.e2e.project_template.utils import patch_crawlee_version_in_pyproject_
     ],
 )
 @pytest.mark.parametrize(
-    'package_manager', [pytest.param('uv', marks=pytest.mark.uv), pytest.param('poetry', marks=pytest.mark.poetry)]
+    'package_manager',
+    [
+        pytest.param('pip', marks=pytest.mark.pip),
+        pytest.param('uv', marks=pytest.mark.uv),
+        pytest.param('poetry', marks=pytest.mark.poetry),
+    ],
 )
 async def test_static_crawler_actor_at_apify(
-    tmp_path: Path, crawlee_wheel_path: Path, package_manager: str, crawler_type: str, http_client: str
+    tmp_path: Path,
+    crawlee_wheel_path: Path,
+    package_manager: Literal['pip', 'uv', 'poetry'],
+    crawler_type: str,
+    http_client: str,
 ) -> None:
     # Generate new actor name
     actor_name = f'crawlee-python-template-e2e-test-{crypto_random_object_id(8).lower()}'
@@ -56,8 +66,8 @@ async def test_static_crawler_actor_at_apify(
         output_dir=tmp_path,
     )
 
-    patch_crawlee_version_in_pyproject_toml_based_project(
-        project_path=tmp_path / actor_name, wheel_path=crawlee_wheel_path
+    patch_crawlee_version_in_project(
+        project_path=tmp_path / actor_name, wheel_path=crawlee_wheel_path, package_manager=package_manager
     )
 
     # Build actor using sequence of cli commands as the user would


### PR DESCRIPTION
### Description
- Add e2e tests for playwright templates
- Add e2e tests for pip-based templates
- Fix template issue with pip template that has additional dependencies
- Separate all e2e tests in CI to run in it's own runner to allow selective re-triggers (e2e tests work on real network and it will always have some flakiness due to that)
- Reduce `max_requests_per_crawl` to 10 in all templates to be aligned with doc examples and to make the tests faster.

### Issues

- Closes: #1109

