### PR TITLE
fix: call `failed_request_handler` for `SessionError` when session rotation count exceeds maximum

### DIFF
--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -1164,8 +1164,6 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
                 await request_manager.reclaim_request(request)
                 await self._statistics.error_tracker_retry.add(error=session_error, context=context)
             else:
-                self._logger.exception('Request failed and reached maximum retries', exc_info=session_error)
-
                 await wait_for(
                     lambda: request_manager.mark_request_as_handled(context.request),
                     timeout=self._internal_timeout,
@@ -1175,8 +1173,8 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
                     max_retries=3,
                 )
 
+                await self._handle_failed_request(context, session_error)
                 self._statistics.record_request_processing_failure(statistics_id)
-                await self._statistics.error_tracker.add(error=session_error, context=context)
 
         except ContextPipelineInterruptedError as interrupted_error:
             self._logger.debug('The context pipeline was interrupted', exc_info=interrupted_error)

--- a/tests/unit/crawlers/_basic/test_basic_crawler.py
+++ b/tests/unit/crawlers/_basic/test_basic_crawler.py
@@ -1291,3 +1291,22 @@ async def test_handle_error_bound_session_to_request() -> None:
     await crawler.run(requests)
 
     assert error_handler_mock.call_count == 1
+
+
+async def test_handles_session_error_in_failed_request_handler() -> None:
+    crawler = BasicCrawler(max_session_rotations=1)
+    handler_requests = set()
+
+    @crawler.router.default_handler
+    async def handler(context: BasicCrawlingContext) -> None:
+        raise SessionError('blocked')
+
+    @crawler.failed_request_handler
+    async def failed_request_handler(context: BasicCrawlingContext, error: Exception) -> None:
+        handler_requests.add(context.request.url)
+
+    requests = ['http://a.com/', 'http://b.com/', 'http://c.com/']
+
+    await crawler.run(requests)
+
+    assert set(requests) == handler_requests

--- a/uv.lock
+++ b/uv.lock
@@ -600,7 +600,7 @@ toml = [
 
 [[package]]
 name = "crawlee"
-version = "0.6.6"
+version = "0.6.7"
 source = { editable = "." }
 dependencies = [
     { name = "apify-fingerprint-datapoints" },
@@ -1149,7 +1149,7 @@ name = "importlib-metadata"
 version = "8.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.11'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/08/c1395a292bb23fd03bdf572a1357c5a733d3eecbab877641ceacab23db6e/importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580", size = 55767 }
 wheels = [


### PR DESCRIPTION
### Description

- Call `failed_request_handler` for `SessionError` when session rotation count exceeds maximum


