### PR TITLE
feat: Handle unprocessed requests in `add_requests_batched`

### DIFF
--- a/src/crawlee/storages/_request_queue.py
+++ b/src/crawlee/storages/_request_queue.py
@@ -237,21 +237,15 @@ class RequestQueue(Storage, RequestManager):
         transformed_requests = self._transform_requests(requests)
         wait_time_secs = wait_time_between_batches.total_seconds()
 
-        async def _process_batch(batch: Sequence[Request]) -> None:
-            request_count = len(batch)
-            response = await self._resource_client.batch_add_requests(batch)
-            self._assumed_total_count += request_count
-            logger.debug(f'Added {request_count} requests to the queue, response: {response}')
-
         # Wait for the first batch to be added
         first_batch = transformed_requests[:batch_size]
         if first_batch:
-            await _process_batch(first_batch)
+            await self._process_batch(first_batch)
 
         async def _process_remaining_batches() -> None:
             for i in range(batch_size, len(transformed_requests), batch_size):
                 batch = transformed_requests[i : i + batch_size]
-                await _process_batch(batch)
+                await self._process_batch(batch)
                 if i + batch_size < len(transformed_requests):
                     await asyncio.sleep(wait_time_secs)
 
@@ -269,6 +263,27 @@ class RequestQueue(Storage, RequestManager):
                 logger=logger,
                 timeout=wait_for_all_requests_to_be_added_timeout,
             )
+
+    async def _process_batch(self, batch: Sequence[Request], attempt: int = 1) -> None:
+        max_attempts = 5
+        response = await self._resource_client.batch_add_requests(batch)
+
+        if response.unprocessed_requests:
+            logger.debug(f'Following requests were not processed: {response.unprocessed_requests}.')
+            if attempt > max_attempts:
+                logger.warning(
+                    f'Following requests were not processed even after {max_attempts} attempts:\n'
+                    f'{response.unprocessed_requests}'
+                )
+            else:
+                logger.debug(f'Retry to add requests.')
+                unprocessed_requests_unique_keys = {request.unique_key for request in response.unprocessed_requests}
+                retry_batch = [request for request in batch if request.unique_key in unprocessed_requests_unique_keys]
+                await self._process_batch(retry_batch, attempt+1)
+
+        request_count = len(batch) - len(response.unprocessed_requests)
+        self._assumed_total_count += request_count
+        logger.debug(f'Added {request_count} requests to the queue. Processed requests: {response.processed_requests}')
 
     async def get_request(self, request_id: str) -> Request | None:
         """Retrieve a request from the queue.

--- a/src/crawlee/storages/_request_queue.py
+++ b/src/crawlee/storages/_request_queue.py
@@ -276,14 +276,17 @@ class RequestQueue(Storage, RequestManager):
                     f'{response.unprocessed_requests}'
                 )
             else:
-                logger.debug(f'Retry to add requests.')
+                logger.debug('Retry to add requests.')
                 unprocessed_requests_unique_keys = {request.unique_key for request in response.unprocessed_requests}
                 retry_batch = [request for request in batch if request.unique_key in unprocessed_requests_unique_keys]
-                await self._process_batch(retry_batch, attempt+1)
+                await self._process_batch(retry_batch, attempt + 1)
 
         request_count = len(batch) - len(response.unprocessed_requests)
         self._assumed_total_count += request_count
-        logger.debug(f'Added {request_count} requests to the queue. Processed requests: {response.processed_requests}')
+        if request_count:
+            logger.debug(
+                f'Added {request_count} requests to the queue. Processed requests: {response.processed_requests}'
+            )
 
     async def get_request(self, request_id: str) -> Request | None:
         """Retrieve a request from the queue.

--- a/tests/unit/storages/test_request_queue.py
+++ b/tests/unit/storages/test_request_queue.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from itertools import count
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
@@ -349,7 +349,9 @@ async def test_add_batched_requests_with_retry(request_queue: RequestQueue) -> N
     request_queue = RequestQueue(id='default', name='some_name', storage_client=mocked_storage_client)
 
     # Add the requests to the RQ in batches
-    await request_queue.add_requests_batched(requests, wait_for_all_requests_to_be_added=True)
+    await request_queue.add_requests_batched(
+        requests, wait_for_all_requests_to_be_added=True, wait_time_between_batches=timedelta(0)
+    )
 
     # Ensure the batch was processed correctly
     assert await request_queue.get_total_count() == expected_added_requests

--- a/tests/unit/storages/test_request_queue.py
+++ b/tests/unit/storages/test_request_queue.py
@@ -336,7 +336,7 @@ async def test_add_batched_requests_with_retry(request_queue: RequestQueue) -> N
             """
             call_count = next(batch_add_requests_call_counter)
             if call_count == 1:
-                # Process all but last three        @staticmethod
+                # Process all but last three
                 return await self._batch_add_requests_without_last_n(requests, n=3)
             # Process all but last
             return await self._batch_add_requests_without_last_n(requests, n=1)


### PR DESCRIPTION
### Description
Adds retry to unprocessed requests in call `add_requests_batched`.
Retry calls recursively `_process_batch`, which initially works on full request batch and then on batches of unprocessed requests until retry limit is reached or all requests are processed. Each retry is done after linearly increasing delay with each attempt.

Unprocessed requests are not counted in `request_queue.get_total_count`
Add test.

### Issues

- Closes: [Handle unprocessed requests in batch_add_requests](https://github.com/apify/apify-sdk-python/issues/456)
