### PR TITLE
fix: Fix the order in which cookies are saved to the `SessionCookies` and the handler is executed for `PlaywrightCrawler`

### DIFF
--- a/src/crawlee/crawlers/_playwright/_playwright_crawler.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_crawler.py
@@ -232,10 +232,6 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext, StatisticsState]
             # Set the loaded URL to the actual URL after redirection.
             context.request.loaded_url = context.page.url
 
-            if context.session:
-                pw_cookies = await self._get_cookies(context.page)
-                context.session.cookies.set_cookies_from_playwright_format(pw_cookies)
-
             extract_links = self._create_extract_links_function(context)
 
             error = yield PlaywrightCrawlingContext(
@@ -255,6 +251,10 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext, StatisticsState]
                 enqueue_links=self._create_enqueue_links_function(context, extract_links),
                 block_requests=partial(block_requests, page=context.page),
             )
+
+            if context.session:
+                pw_cookies = await self._get_cookies(context.page)
+                context.session.cookies.set_cookies_from_playwright_format(pw_cookies)
 
             # Collect data in case of errors, before the page object is closed.
             if error:

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -381,6 +381,7 @@ async def test_save_cookies_after_handler_processing(server_url: URL) -> None:
 
         @crawler.router.default_handler
         async def request_handler(context: PlaywrightCrawlingContext) -> None:
+            # Simulate cookies installed from an external source in the browser
             await context.page.context.add_cookies([{'name': 'check', 'value': 'test', 'url': str(server_url)}])
 
             if context.session:


### PR DESCRIPTION
### Description

- For `PlaywrightCrawler`, cookies should only be saved to the session store when the handler is fully executed. This is because the browser may continue to set cookies while the handler is being executed

### Testing

- Add a test simulating the installation of a cookie in the browser during the `default_handler` execution process
- Update the `test_isolation_cookies` test

