### PR TITLE
chore: Update `test_enqueue_links` to use test server 

### DIFF
--- a/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
+++ b/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
@@ -279,7 +279,12 @@ class AbstractHttpCrawler(
         """
         status_code = context.http_response.status_code
         if self._retry_on_blocked:
-            self._raise_for_session_blocked_status_code(context.session, status_code)
+            try:
+                self._raise_for_session_blocked_status_code(context.session, status_code)
+            except SessionError:
+                context.log.warning(context.http_response.status_code)
+                context.log.warning(context.http_response.headers)
+                raise
         self._raise_for_error_status_code(status_code)
         yield context
 

--- a/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
+++ b/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
@@ -279,12 +279,7 @@ class AbstractHttpCrawler(
         """
         status_code = context.http_response.status_code
         if self._retry_on_blocked:
-            try:
-                self._raise_for_session_blocked_status_code(context.session, status_code)
-            except SessionError:
-                context.log.warning(context.http_response.status_code)
-                context.log.warning(context.http_response.headers)
-                raise
+            self._raise_for_session_blocked_status_code(context.session, status_code)
         self._raise_for_error_status_code(status_code)
         yield context
 

--- a/tests/unit/crawlers/_parsel/test_parsel_crawler.py
+++ b/tests/unit/crawlers/_parsel/test_parsel_crawler.py
@@ -65,7 +65,6 @@ async def test_enqueue_links(redirect_server_url: URL, server_url: URL, http_cli
 
 async def test_enqueue_links_with_incompatible_kwargs_raises_error(server_url: URL) -> None:
     """Call `enqueue_links` with arguments that can't be used together."""
-    requests = ['https://www.test.io/']
     crawler = ParselCrawler(max_request_retries=1)
     exceptions = []
 
@@ -76,7 +75,7 @@ async def test_enqueue_links_with_incompatible_kwargs_raises_error(server_url: U
         except Exception as e:
             exceptions.append(e)
 
-    await crawler.run(requests)
+    await crawler.run([str(server_url)])
 
     assert len(exceptions) == 1
     assert type(exceptions[0]) is ValueError

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -84,9 +84,8 @@ async def test_enqueue_links(redirect_server_url: URL, server_url: URL) -> None:
     }
 
 
-async def test_enqueue_links_with_incompatible_kwargs_raises_error() -> None:
+async def test_enqueue_links_with_incompatible_kwargs_raises_error(server_url: URL) -> None:
     """Call `enqueue_links` with arguments that can't be used together."""
-    requests = ['https://www.something.com']
     crawler = PlaywrightCrawler(max_request_retries=1)
     exceptions = []
 
@@ -101,7 +100,7 @@ async def test_enqueue_links_with_incompatible_kwargs_raises_error() -> None:
         except Exception as e:
             exceptions.append(e)
 
-    await crawler.run(requests)
+    await crawler.run([str(server_url)])
 
     assert len(exceptions) == 1
     assert type(exceptions[0]) is ValueError


### PR DESCRIPTION
### Description
Update `test_enqueue_links` to use test server.
(The test was still using real page instead of test server and the test started being blocked by `Cloudflare` when running in CI)

