### PR TITLE
fix: fix handle error without `args` in `_get_error_message`  for `ErrorTracker`

### DIFF
--- a/src/crawlee/statistics/_error_tracker.py
+++ b/src/crawlee/statistics/_error_tracker.py
@@ -124,9 +124,11 @@ class ErrorTracker:
 
     def _get_error_message(self, error: Exception) -> str:
         if self.show_error_message:
+            error_content = error.args[0] if error.args else error.__context__
+            error_content = str(error_content) if error_content else error.__class__.__name__
             if self.show_full_message:
-                return str(error.args[0])
-            return str(error.args[0]).split('\n')[0]
+                return error_content
+            return error_content.split('\n')[0]
         return ''
 
     @property

--- a/tests/unit/_statistics/test_error_tracker.py
+++ b/tests/unit/_statistics/test_error_tracker.py
@@ -8,11 +8,11 @@ from crawlee.statistics._error_tracker import ErrorTracker
 @pytest.mark.parametrize(
     ('error_tracker', 'expected_unique_errors'),
     [
-        (ErrorTracker(), 4),
-        (ErrorTracker(show_file_and_line_number=False), 3),
-        (ErrorTracker(show_error_name=False), 3),
+        (ErrorTracker(), 5),
+        (ErrorTracker(show_file_and_line_number=False), 4),
+        (ErrorTracker(show_error_name=False), 4),
         (ErrorTracker(show_error_message=False), 3),
-        (ErrorTracker(show_error_name=False, show_file_and_line_number=False), 2),
+        (ErrorTracker(show_error_name=False, show_file_and_line_number=False), 3),
         (ErrorTracker(show_file_and_line_number=False, show_error_message=False), 2),
         (ErrorTracker(show_error_name=False, show_file_and_line_number=False, show_error_message=False), 1),
     ],
@@ -27,6 +27,7 @@ async def test_error_tracker_counts(error_tracker: ErrorTracker, expected_unique
         ValueError(
             'Another value error efg'
         ),  # Same type, but too different message to previous, considered different.
+        ValueError(),  # Same type but don'y have message, considered different.
     ]:
         try:
             raise error  # Errors raised on same line
@@ -38,7 +39,7 @@ async def test_error_tracker_counts(error_tracker: ErrorTracker, expected_unique
     except Exception as e:
         await error_tracker.add(e)
 
-    assert error_tracker.total == 5
+    assert error_tracker.total == 6
     assert error_tracker.unique_error_count == expected_unique_errors
 
 
@@ -98,3 +99,18 @@ async def test_show_full_message(*, show_full_message: bool, expected_message: s
         await error_tracker.add(e)
 
     assert error_tracker.get_most_common_errors()[0][0] == expected_message
+
+
+async def test_error_tracker_with_errors_chain() -> None:
+    """Test error tracker with errors chain."""
+    error_tracker = ErrorTracker(show_error_name=False, show_file_and_line_number=False, show_full_message=True)
+
+    try:
+        raise ZeroDivisionError('Zero division error')  # Errors raised on the same line
+    except Exception as e:
+        try:
+            raise ValueError from e
+        except Exception as e:
+            await error_tracker.add(e)
+
+    assert error_tracker.get_most_common_errors()[0][0] == 'Zero division error'

--- a/tests/unit/_statistics/test_error_tracker.py
+++ b/tests/unit/_statistics/test_error_tracker.py
@@ -27,7 +27,7 @@ async def test_error_tracker_counts(error_tracker: ErrorTracker, expected_unique
         ValueError(
             'Another value error efg'
         ),  # Same type, but too different message to previous, considered different.
-        ValueError(),  # Same type but don'y have message, considered different.
+        ValueError(),  # Same type but don't have message, considered different.
     ]:
         try:
             raise error  # Errors raised on same line


### PR DESCRIPTION
### Description

- Fix getting an error message for errors not having message data in `args`. If the error was raised in a chain, tries to get the previous error message from `__context__`. Otherwise uses the error class name as the message.

### Issues

- Closes: #1179 

### Testing

- Add new tests
