### PR TITLE
fix: Allow config change on `PlaywrightCrawler`

### DIFF
--- a/src/crawlee/crawlers/_playwright/_playwright_crawler.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_crawler.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, Literal, Union
 from pydantic import ValidationError
 from typing_extensions import NotRequired, TypedDict, TypeVar
 
+from crawlee import service_locator
 from crawlee._request import Request, RequestOptions
 from crawlee._utils.blocked import RETRY_CSS_SELECTORS
 from crawlee._utils.docs import docs_group
@@ -120,6 +121,10 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext, StatisticsState]
                 This option should not be used if `browser_pool` is provided.
             kwargs: Additional keyword arguments to pass to the underlying `BasicCrawler`.
         """
+        configuration = kwargs.pop('configuration', None)
+        if configuration is not None:
+            service_locator.set_configuration(configuration)
+
         if browser_pool:
             # Raise an exception if browser_pool is provided together with other browser-related arguments.
             if any(

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock
 import pytest
 
 from crawlee import ConcurrencySettings, HttpHeaders, Request, RequestTransformAction, SkippedReason
+from crawlee.configuration import Configuration
 from crawlee.crawlers import PlaywrightCrawler
 from crawlee.fingerprint_suite import (
     DefaultFingerprintGenerator,
@@ -689,3 +690,9 @@ async def test_send_request_with_client(server_url: URL) -> None:
     assert check_data['send_request']['user-agent'] == 'My User-Agent'
 
     assert check_data['default'] != check_data['send_request']
+
+
+async def test_overwrite_configuration() -> None:
+    """Check that the configuration is allowed to be passed to the Playwrightcrawler."""
+    configuration = Configuration(default_dataset_id='my_dataset_id')
+    PlaywrightCrawler(configuration=configuration)

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -11,7 +11,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from crawlee import ConcurrencySettings, HttpHeaders, Request, RequestTransformAction, SkippedReason
+from crawlee import ConcurrencySettings, HttpHeaders, Request, RequestTransformAction, SkippedReason, service_locator
 from crawlee.configuration import Configuration
 from crawlee.crawlers import PlaywrightCrawler
 from crawlee.fingerprint_suite import (
@@ -696,3 +696,5 @@ async def test_overwrite_configuration() -> None:
     """Check that the configuration is allowed to be passed to the Playwrightcrawler."""
     configuration = Configuration(default_dataset_id='my_dataset_id')
     PlaywrightCrawler(configuration=configuration)
+    used_configuration = service_locator.get_configuration()
+    assert used_configuration is configuration


### PR DESCRIPTION
### Description

It is not possible to apply `Configuration` to the Playwright crawler (see issue). This is a proposal for a solution.

### Issues

- Closes: #1185 

### Testing

Added a test that failed before the fix, but works now.

### Checklist

- [x] CI passed
