### PR TITLE
fix: set `WindowsSelectorEventLoopPolicy` only for curl-impersonate template without `playwright`

### DIFF
--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/{{cookiecutter.__package_name}}/__main__.py
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/{{cookiecutter.__package_name}}/__main__.py
@@ -1,15 +1,27 @@
 import asyncio
-# % if cookiecutter.http_client == 'curl-impersonate' and 'playwright' not in cookiecutter.crawler_type
+# % if cookiecutter.http_client == 'curl-impersonate'
 import platform
+# % if 'playwright' in cookiecutter.crawler_type
+import warnings
+# % endif
 # % endif
 {{ '' }}
 from .main import main
 
 if __name__ == '__main__':
-    # % if cookiecutter.http_client == 'curl-impersonate' and 'playwright' not in cookiecutter.crawler_type
+    # % if cookiecutter.http_client == 'curl-impersonate'
     if platform.system() == 'Windows':
         # This mitigates a warning raised by curl-cffi.
+        # % if 'playwright' in cookiecutter.crawler_type
+        warnings.warn(
+            message=('curl-cffi suggests using WindowsSelectorEventLoopPolicy, but this conflicts with Playwright. '
+                     'Ignore the curl-cffi warning.'),
+            category=UserWarning,
+            stacklevel=2,
+        )
+        # % else
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        # % endif
     # % endif
 {{ '' }}
     asyncio.run(main())

--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/{{cookiecutter.__package_name}}/__main__.py
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/{{cookiecutter.__package_name}}/__main__.py
@@ -1,12 +1,15 @@
 import asyncio
+# % if cookiecutter.http_client == 'curl-impersonate' and 'playwright' not in cookiecutter.crawler_type
 import platform
-
+# % endif
+{{ '' }}
 from .main import main
 
-
 if __name__ == '__main__':
+    # % if cookiecutter.http_client == 'curl-impersonate' and 'playwright' not in cookiecutter.crawler_type
     if platform.system() == 'Windows':
-        # This mitigates a warning raised by curl-cffi. If you do not need to use curl-impersonate, you may remove this.
+        # This mitigates a warning raised by curl-cffi.
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
+    # % endif
+{{ '' }}
     asyncio.run(main())


### PR DESCRIPTION
### Description

- Sets `WindowsSelectorEventLoopPolicy` only for templates that use curl-impersonate, provided that playwright is not used. Since curl-impersonate does not support `ProactorEventLoop` used in Windows.

For all other cases, `ProactorEventLoop` is recommended for Windows.

### Issues

- Closes: #1204 
