### PR TITLE
refactor: add enqueue links filter iterator

### DIFF
--- a/src/crawlee/_utils/urls.py
+++ b/src/crawlee/_utils/urls.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from pydantic import AnyHttpUrl, TypeAdapter
 from yarl import URL
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 def is_url_absolute(url: str) -> bool:
@@ -15,6 +20,15 @@ def is_url_absolute(url: str) -> bool:
 def convert_to_absolute_url(base_url: str, relative_url: str) -> str:
     """Convert a relative URL to an absolute URL using a base URL."""
     return str(URL(base_url).join(URL(relative_url)))
+
+
+def to_absolute_url_iterator(base_url: str, urls: Iterator[str]) -> Iterator[str]:
+    """Convert an iterator of relative URLs to absolute URLs using a base URL."""
+    for url in urls:
+        if is_url_absolute(url):
+            yield url
+        else:
+            yield convert_to_absolute_url(base_url, url)
 
 
 _http_url_adapter = TypeAdapter(AnyHttpUrl)

--- a/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
+++ b/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
@@ -172,7 +172,7 @@ class AbstractHttpCrawler(
             else:
                 skipped = iter([])
 
-            for url in self._filter_enqueue_links_iterator(links_iterator, context.request.url, **kwargs):
+            for url in self._enqueue_links_filter_iterator(links_iterator, context.request.url, **kwargs):
                 request_options = RequestOptions(url=url, user_data={**base_user_data}, label=label)
 
                 if transform_request_function:

--- a/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
+++ b/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 import asyncio
 import logging
 from abc import ABC
-from typing import TYPE_CHECKING, Any, Callable, Generic, Union
-from urllib.parse import urlparse
+from typing import TYPE_CHECKING, Any, Callable, Generic
 
+from more_itertools import partition
 from pydantic import ValidationError
 from typing_extensions import TypeVar
 
 from crawlee._request import Request, RequestOptions
 from crawlee._utils.docs import docs_group
-from crawlee._utils.urls import convert_to_absolute_url, is_url_absolute
+from crawlee._utils.urls import to_absolute_url_iterator
 from crawlee.crawlers._basic import BasicCrawler, BasicCrawlerOptions, ContextPipeline
 from crawlee.errors import SessionError
 from crawlee.statistics import StatisticsState
@@ -19,12 +19,12 @@ from crawlee.statistics import StatisticsState
 from ._http_crawling_context import HttpCrawlingContext, ParsedHttpCrawlingContext, TParseResult, TSelectResult
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Awaitable, Sequence
+    from collections.abc import AsyncGenerator, Awaitable, Iterator
 
     from typing_extensions import Unpack
 
     from crawlee import RequestTransformAction
-    from crawlee._types import BasicCrawlingContext, EnqueueLinksFunction, EnqueueLinksKwargs, ExtractLinksFunction
+    from crawlee._types import BasicCrawlingContext, EnqueueLinksKwargs, ExtractLinksFunction
 
     from ._abstract_http_parser import AbstractHttpParser
 
@@ -157,110 +157,51 @@ class AbstractHttpCrawler(
             **kwargs: Unpack[EnqueueLinksKwargs],
         ) -> list[Request]:
             requests = list[Request]()
-            skipped = list[str]()
+
             base_user_data = user_data or {}
 
             robots_txt_file = await self._get_robots_txt_file_for_url(context.request.url)
 
-            strategy = kwargs.get('strategy', 'same-hostname')
-            include_blobs = kwargs.get('include')
-            exclude_blobs = kwargs.get('exclude')
-            limit_requests = kwargs.get('limit')
+            kwargs.setdefault('strategy', 'same-hostname')
 
-            for link in self._parser.find_links(parsed_content, selector=selector):
-                if limit_requests and len(requests) >= limit_requests:
-                    break
+            links_iterator: Iterator[str] = iter(self._parser.find_links(parsed_content, selector=selector))
+            links_iterator = to_absolute_url_iterator(context.request.loaded_url or context.request.url, links_iterator)
 
-                url = link
-                if not is_url_absolute(url):
-                    base_url = context.request.loaded_url or context.request.url
-                    url = convert_to_absolute_url(base_url, url)
+            if robots_txt_file:
+                skipped, links_iterator = partition(lambda url: robots_txt_file.is_allowed(url), links_iterator)
+            else:
+                skipped = iter([])
 
-                if robots_txt_file and not robots_txt_file.is_allowed(url):
-                    skipped.append(url)
+            for url in self._filter_enqueue_links_iterator(links_iterator, context.request.url, **kwargs):
+                request_options = RequestOptions(url=url, user_data={**base_user_data}, label=label)
+
+                if transform_request_function:
+                    transform_request_options = transform_request_function(request_options)
+                    if transform_request_options == 'skip':
+                        continue
+                    if transform_request_options != 'unchanged':
+                        request_options = transform_request_options
+
+                try:
+                    request = Request.from_url(**request_options)
+                except ValidationError as exc:
+                    context.log.debug(
+                        f'Skipping URL "{url}" due to invalid format: {exc}. '
+                        'This may be caused by a malformed URL or unsupported URL scheme. '
+                        'Please ensure the URL is correct and retry.'
+                    )
                     continue
 
-                if self._check_enqueue_strategy(
-                    strategy,
-                    target_url=urlparse(url),
-                    origin_url=urlparse(context.request.url),
-                ) and self._check_url_patterns(url, include_blobs, exclude_blobs):
-                    request_options = RequestOptions(url=url, user_data={**base_user_data}, label=label)
+                requests.append(request)
 
-                    if transform_request_function:
-                        transform_request_options = transform_request_function(request_options)
-                        if transform_request_options == 'skip':
-                            continue
-                        if transform_request_options != 'unchanged':
-                            request_options = transform_request_options
+            skipped_tasks = [
+                asyncio.create_task(self._handle_skipped_request(request, 'robots_txt')) for request in skipped
+            ]
+            await asyncio.gather(*skipped_tasks)
 
-                    try:
-                        request = Request.from_url(**request_options)
-                    except ValidationError as exc:
-                        context.log.debug(
-                            f'Skipping URL "{url}" due to invalid format: {exc}. '
-                            'This may be caused by a malformed URL or unsupported URL scheme. '
-                            'Please ensure the URL is correct and retry.'
-                        )
-                        continue
-
-                    requests.append(request)
-
-            if skipped:
-                skipped_tasks = [
-                    asyncio.create_task(self._handle_skipped_request(request, 'robots_txt')) for request in skipped
-                ]
-                await asyncio.gather(*skipped_tasks)
             return requests
 
         return extract_links
-
-    def _create_enqueue_links_function(
-        self, context: HttpCrawlingContext, extract_links: ExtractLinksFunction
-    ) -> EnqueueLinksFunction:
-        """Create a callback function for extracting links from parsed content and enqueuing them to the crawl.
-
-        Args:
-            context: The current crawling context.
-            extract_links: Function used to extract links from the page.
-
-        Returns:
-            Awaitable that is used for extracting links from parsed content and enqueuing them to the crawl.
-        """
-
-        async def enqueue_links(
-            *,
-            selector: str | None = None,
-            label: str | None = None,
-            user_data: dict[str, Any] | None = None,
-            transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction]
-            | None = None,
-            requests: Sequence[str | Request] | None = None,
-            **kwargs: Unpack[EnqueueLinksKwargs],
-        ) -> None:
-            kwargs.setdefault('strategy', 'same-hostname')
-
-            if requests:
-                if any((selector, label, user_data, transform_request_function)):
-                    raise ValueError(
-                        'You cannot provide `selector`, `label`, `user_data` or '
-                        '`transform_request_function` arguments when `requests` is provided.'
-                    )
-                # Add directly passed requests.
-                await context.add_requests(requests or list[Union[str, Request]](), **kwargs)
-            else:
-                # Add requests from extracted links.
-                await context.add_requests(
-                    await extract_links(
-                        selector=selector or 'a',
-                        label=label,
-                        user_data=user_data,
-                        transform_request_function=transform_request_function,
-                    ),
-                    **kwargs,
-                )
-
-        return enqueue_links
 
     async def _make_http_request(self, context: BasicCrawlingContext) -> AsyncGenerator[HttpCrawlingContext, None]:
         """Make http request and create context enhanced by HTTP response.

--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -935,7 +935,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
 
         return enqueue_links
 
-    def _filter_enqueue_links_iterator(
+    def _enqueue_links_filter_iterator(
         self, request_iterator: Iterator[TRequestIterator], origin_url: str, **kwargs: Unpack[EnqueueLinksKwargs]
     ) -> Iterator[TRequestIterator]:
         limit = kwargs.get('limit')
@@ -1199,7 +1199,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
 
             enqueue_links_kwargs: EnqueueLinksKwargs = {k: v for k, v in add_requests_call.items() if k != 'requests'}  # type: ignore[assignment]
 
-            filter_requests_iterator = self._filter_enqueue_links_iterator(
+            filter_requests_iterator = self._enqueue_links_filter_iterator(
                 requests_iterator, context.request.url, **enqueue_links_kwargs
             )
 

--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -938,6 +938,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
     def _enqueue_links_filter_iterator(
         self, request_iterator: Iterator[TRequestIterator], origin_url: str, **kwargs: Unpack[EnqueueLinksKwargs]
     ) -> Iterator[TRequestIterator]:
+        """Filter requests based on the enqueue strategy and URL patterns."""
         limit = kwargs.get('limit')
         parsed_origin_url = urlparse(origin_url)
 

--- a/src/crawlee/crawlers/_playwright/_playwright_crawler.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_crawler.py
@@ -364,7 +364,7 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext, StatisticsState]
             else:
                 skipped = iter([])
 
-            for url in self._filter_enqueue_links_iterator(links_iterator, context.request.url, **kwargs):
+            for url in self._enqueue_links_filter_iterator(links_iterator, context.request.url, **kwargs):
                 request_option = RequestOptions({'url': url, 'user_data': {**base_user_data}, 'label': label})
 
                 if transform_request_function:

--- a/src/crawlee/crawlers/_playwright/_playwright_crawler.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_crawler.py
@@ -356,7 +356,6 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext, StatisticsState]
             links_iterator: Iterator[str] = iter(
                 [url for element in elements if (url := await element.get_attribute('href')) is not None]
             )
-
             links_iterator = to_absolute_url_iterator(context.request.loaded_url or context.request.url, links_iterator)
 
             if robots_txt_file:
@@ -386,11 +385,10 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext, StatisticsState]
 
                 requests.append(request)
 
-            if skipped:
-                skipped_tasks = [
-                    asyncio.create_task(self._handle_skipped_request(request, 'robots_txt')) for request in skipped
-                ]
-                await asyncio.gather(*skipped_tasks)
+            skipped_tasks = [
+                asyncio.create_task(self._handle_skipped_request(request, 'robots_txt')) for request in skipped
+            ]
+            await asyncio.gather(*skipped_tasks)
 
             return requests
 

--- a/src/crawlee/crawlers/_playwright/_playwright_crawler.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_crawler.py
@@ -4,9 +4,9 @@ import asyncio
 import logging
 import warnings
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Generic, Literal, Union
-from urllib.parse import urlparse
+from typing import TYPE_CHECKING, Any, Callable, Generic, Literal
 
+from more_itertools import partition
 from pydantic import ValidationError
 from typing_extensions import NotRequired, TypedDict, TypeVar
 
@@ -15,7 +15,7 @@ from crawlee._request import Request, RequestOptions
 from crawlee._utils.blocked import RETRY_CSS_SELECTORS
 from crawlee._utils.docs import docs_group
 from crawlee._utils.robots import RobotsTxtFile
-from crawlee._utils.urls import convert_to_absolute_url, is_url_absolute
+from crawlee._utils.urls import to_absolute_url_iterator
 from crawlee.browsers import BrowserPool
 from crawlee.crawlers._basic import BasicCrawler, BasicCrawlerOptions, ContextPipeline
 from crawlee.errors import SessionError
@@ -33,7 +33,7 @@ TCrawlingContext = TypeVar('TCrawlingContext', bound=PlaywrightCrawlingContext)
 TStatisticsState = TypeVar('TStatisticsState', bound=StatisticsState, default=StatisticsState)
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Awaitable, Mapping, Sequence
+    from collections.abc import AsyncGenerator, Awaitable, Iterator, Mapping
     from pathlib import Path
 
     from playwright.async_api import Page, Route
@@ -43,7 +43,6 @@ if TYPE_CHECKING:
     from crawlee import RequestTransformAction
     from crawlee._types import (
         BasicCrawlingContext,
-        EnqueueLinksFunction,
         EnqueueLinksKwargs,
         ExtractLinksFunction,
         HttpHeaders,
@@ -346,60 +345,46 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext, StatisticsState]
             The `PlaywrightCrawler` implementation of the `ExtractLinksFunction` function.
             """
             requests = list[Request]()
-            skipped = list[str]()
-            base_user_data = user_data or {}
 
-            elements = await context.page.query_selector_all(selector)
+            base_user_data = user_data or {}
 
             robots_txt_file = await self._get_robots_txt_file_for_url(context.request.url)
 
-            strategy = kwargs.get('strategy', 'same-hostname')
-            include_blobs = kwargs.get('include')
-            exclude_blobs = kwargs.get('exclude')
-            limit_requests = kwargs.get('limit')
+            kwargs.setdefault('strategy', 'same-hostname')
 
-            for element in elements:
-                if limit_requests and len(requests) >= limit_requests:
-                    break
+            elements = await context.page.query_selector_all(selector)
+            links_iterator: Iterator[str] = iter(
+                [url for element in elements if (url := await element.get_attribute('href')) is not None]
+            )
 
-                url = await element.get_attribute('href')
+            links_iterator = to_absolute_url_iterator(context.request.loaded_url or context.request.url, links_iterator)
 
-                if url:
-                    url = url.strip()
+            if robots_txt_file:
+                skipped, links_iterator = partition(lambda url: robots_txt_file.is_allowed(url), links_iterator)
+            else:
+                skipped = iter([])
 
-                    if not is_url_absolute(url):
-                        base_url = context.request.loaded_url or context.request.url
-                        url = convert_to_absolute_url(base_url, url)
+            for url in self._filter_enqueue_links_iterator(links_iterator, context.request.url, **kwargs):
+                request_option = RequestOptions({'url': url, 'user_data': {**base_user_data}, 'label': label})
 
-                    if robots_txt_file and not robots_txt_file.is_allowed(url):
-                        skipped.append(url)
+                if transform_request_function:
+                    transform_request_option = transform_request_function(request_option)
+                    if transform_request_option == 'skip':
                         continue
+                    if transform_request_option != 'unchanged':
+                        request_option = transform_request_option
 
-                    if self._check_enqueue_strategy(
-                        strategy,
-                        target_url=urlparse(url),
-                        origin_url=urlparse(context.request.url),
-                    ) and self._check_url_patterns(url, include_blobs, exclude_blobs):
-                        request_option = RequestOptions({'url': url, 'user_data': {**base_user_data}, 'label': label})
+                try:
+                    request = Request.from_url(**request_option)
+                except ValidationError as exc:
+                    context.log.debug(
+                        f'Skipping URL "{url}" due to invalid format: {exc}. '
+                        'This may be caused by a malformed URL or unsupported URL scheme. '
+                        'Please ensure the URL is correct and retry.'
+                    )
+                    continue
 
-                        if transform_request_function:
-                            transform_request_option = transform_request_function(request_option)
-                            if transform_request_option == 'skip':
-                                continue
-                            if transform_request_option != 'unchanged':
-                                request_option = transform_request_option
-
-                        try:
-                            request = Request.from_url(**request_option)
-                        except ValidationError as exc:
-                            context.log.debug(
-                                f'Skipping URL "{url}" due to invalid format: {exc}. '
-                                'This may be caused by a malformed URL or unsupported URL scheme. '
-                                'Please ensure the URL is correct and retry.'
-                            )
-                            continue
-
-                        requests.append(request)
+                requests.append(request)
 
             if skipped:
                 skipped_tasks = [
@@ -410,47 +395,6 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext, StatisticsState]
             return requests
 
         return extract_links
-
-    def _create_enqueue_links_function(
-        self, context: PlaywrightPreNavCrawlingContext, extract_links: ExtractLinksFunction
-    ) -> EnqueueLinksFunction:
-        async def enqueue_links(
-            *,
-            selector: str | None = None,
-            label: str | None = None,
-            user_data: dict | None = None,
-            transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction]
-            | None = None,
-            requests: Sequence[str | Request] | None = None,
-            **kwargs: Unpack[EnqueueLinksKwargs],
-        ) -> None:
-            """Extract and enqueue links from the current page.
-
-            The `PlaywrightCrawler` implementation of the `EnqueueLinksFunction` function.
-            """
-            kwargs.setdefault('strategy', 'same-hostname')
-
-            if requests:
-                if any((selector, label, user_data, transform_request_function)):
-                    raise ValueError(
-                        'You cannot provide `selector`, `label`, `user_data` or `transform_request_function` '
-                        'arguments when `requests` is provided.'
-                    )
-                # Add directly passed requests.
-                await context.add_requests(requests or list[Union[str, Request]](), **kwargs)
-            else:
-                # Add requests from extracted links.
-                await context.add_requests(
-                    await extract_links(
-                        selector=selector or 'a',
-                        label=label,
-                        user_data=user_data,
-                        transform_request_function=transform_request_function,
-                    ),
-                    **kwargs,
-                )
-
-        return enqueue_links
 
     async def _handle_status_code_response(
         self, context: PlaywrightCrawlingContext


### PR DESCRIPTION
### Description

- The goal of the refactoring is to create a new helper function to check `EnqueueLinksKwargs`, for use elsewhere in the code. The new function works as an iterator, to better fit the application as a filter.
- Also updated related functions that currently have `EnqueueLinksKwargs` check logic: `extract_links` and `_commit_request_handler_result`.
