### PR TITLE
chore: fix `PytestConfigWarning` by adding `pytest-timeout`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,8 +94,8 @@ crawlee = "crawlee._cli:cli"
 
 [dependency-groups]
 dev = [
-    "apify_client",  # For e2e tests.
-    "build~=1.2.2",  # For e2e tests.
+    "apify_client", # For e2e tests.
+    "build~=1.2.2", # For e2e tests.
     "mypy~=1.16.0",
     "pre-commit~=4.2.0",
     "proxy-py~=2.4.0",
@@ -103,10 +103,11 @@ dev = [
     "pytest-asyncio~=1.0.0",
     "pytest-cov~=6.1.0",
     "pytest-only~=2.1.0",
+    "pytest-timeout~=2.4.0",
     "pytest-xdist~=3.7.0",
     "pytest~=8.4.0",
     "ruff~=0.11.0",
-    "setuptools",  # setuptools are used by pytest, but not explicitly required
+    "setuptools", # setuptools are used by pytest, but not explicitly required
     "sortedcontainers-stubs~=2.4.0",
     "types-beautifulsoup4~=4.12.0.20240229",
     "types-cachetools~=6.0.0.20250525",

--- a/uv.lock
+++ b/uv.lock
@@ -699,6 +699,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-only" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "setuptools" },
@@ -770,6 +771,7 @@ dev = [
     { name = "pytest-asyncio", specifier = "~=1.0.0" },
     { name = "pytest-cov", specifier = "~=6.1.0" },
     { name = "pytest-only", specifier = "~=2.1.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = "~=3.7.0" },
     { name = "ruff", specifier = "~=0.11.0" },
     { name = "setuptools" },
@@ -2267,6 +2269,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1f/2f/937d554943477a540aa2aae2b4c47ad41c2f089f47691288938c67e94143/pytest_only-2.1.2.tar.gz", hash = "sha256:e341acc083e3bb66debc660b7d5d71ae3b31da5edc2a737280d7304221ab0c29", size = 4863, upload-time = "2024-05-27T17:04:18.626Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/95/3cf1a035048ee224a5dc701a3f41a5ec8684b030d217517bdf7da2f545aa/pytest_only-2.1.2-py3-none-any.whl", hash = "sha256:04dffe2aed64a741145ce5ad25b5df3ae4212e01ff885a8821fd2318eb509e91", size = 6456, upload-time = "2024-05-27T17:04:16.936Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
```
PytestConfigWarning: Unknown config option: timeout
```

We use pytest timeout in pytest config, let's add the `pytest-timeout` plugin.
