### PR TITLE
chore: fix DeprecationWarning in CLI

### DIFF
--- a/src/crawlee/_cli.py
+++ b/src/crawlee/_cli.py
@@ -38,7 +38,6 @@ def callback(
         typer.Option(
             '-V',
             '--version',
-            is_flag=True,
             help='Print Crawlee version',
         ),
     ] = False,


### PR DESCRIPTION
```
DeprecationWarning: The 'is_flag' and 'flag_value' parameters are not supported by Typer and will be removed entirely in a future release.
```

The default `False` value automatically makes the option a flag.