### PR TITLE
chore: fix `GuessedAtParserWarning` in BeautifulSoup

### DIFF
--- a/src/crawlee/crawlers/_beautifulsoup/_utils.py
+++ b/src/crawlee/crawlers/_beautifulsoup/_utils.py
@@ -27,7 +27,7 @@ def html_to_text(source: str | Tag) -> str:
         Newline separated plain text without tags.
     """
     if isinstance(source, str):
-        soup = BeautifulSoup(source)
+        soup = BeautifulSoup(source, features='lxml')
     elif isinstance(source, BeautifulSoup):
         soup = source
     else:

--- a/tests/unit/_utils/test_html_to_text.py
+++ b/tests/unit/_utils/test_html_to_text.py
@@ -196,4 +196,4 @@ def test_html_to_text_parsel() -> None:
 
 
 def test_html_to_text_beautifulsoup() -> None:
-    assert html_to_text_beautifulsoup(BeautifulSoup(_EXAMPLE_HTML)) == _EXPECTED_TEXT
+    assert html_to_text_beautifulsoup(BeautifulSoup(_EXAMPLE_HTML, features='lxml')) == _EXPECTED_TEXT

--- a/uv.lock
+++ b/uv.lock
@@ -771,7 +771,7 @@ dev = [
     { name = "pytest-asyncio", specifier = "~=1.0.0" },
     { name = "pytest-cov", specifier = "~=6.1.0" },
     { name = "pytest-only", specifier = "~=2.1.0" },
-    { name = "pytest-timeout", specifier = "~=2.4.0" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = "~=3.7.0" },
     { name = "ruff", specifier = "~=0.11.0" },
     { name = "setuptools" },

--- a/uv.lock
+++ b/uv.lock
@@ -771,7 +771,7 @@ dev = [
     { name = "pytest-asyncio", specifier = "~=1.0.0" },
     { name = "pytest-cov", specifier = "~=6.1.0" },
     { name = "pytest-only", specifier = "~=2.1.0" },
-    { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "pytest-timeout", specifier = "~=2.4.0" },
     { name = "pytest-xdist", specifier = "~=3.7.0" },
     { name = "ruff", specifier = "~=0.11.0" },
     { name = "setuptools" },


### PR DESCRIPTION
```
GuessedAtParserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("lxml"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.
```

Use `lxml` explicitly. If this becomes an issue for someone, we can expose the parser option.