### PR TITLE
fix: Use `perf_counter_ns` for request duration tracking

### DIFF
--- a/src/crawlee/statistics/_statistics.py
+++ b/src/crawlee/statistics/_statistics.py
@@ -43,7 +43,7 @@ class RequestProcessingRecord:
         if self._last_run_at_ns is None:
             raise RuntimeError('Invalid state')
 
-        self.duration = timedelta(microseconds=(time.perf_counter_ns() - self._last_run_at_ns) / 1000)
+        self.duration = timedelta(microseconds=math.ceil((time.perf_counter_ns() - self._last_run_at_ns) / 1000))
         return self.duration
 
     @property

--- a/src/crawlee/statistics/_statistics.py
+++ b/src/crawlee/statistics/_statistics.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import math
+import time
 from datetime import datetime, timedelta, timezone
 from logging import Logger, getLogger
 from typing import TYPE_CHECKING, Generic, Literal
@@ -27,22 +28,22 @@ class RequestProcessingRecord:
     """Tracks information about the processing of a request."""
 
     def __init__(self) -> None:
-        self._last_run_at: datetime | None = None
+        self._last_run_at_ns: int | None = None
         self._runs = 0
         self.duration: timedelta | None = None
 
     def run(self) -> int:
         """Mark the job as started."""
-        self._last_run_at = datetime.now(timezone.utc)
+        self._last_run_at_ns = time.perf_counter_ns()
         self._runs += 1
         return self._runs
 
     def finish(self) -> timedelta:
         """Mark the job as finished."""
-        if self._last_run_at is None:
+        if self._last_run_at_ns is None:
             raise RuntimeError('Invalid state')
 
-        self.duration = datetime.now(timezone.utc) - self._last_run_at
+        self.duration = timedelta(microseconds=(time.perf_counter_ns() - self._last_run_at_ns) / 1000)
         return self.duration
 
     @property

--- a/tests/unit/_statistics/test_request_processing_record.py
+++ b/tests/unit/_statistics/test_request_processing_record.py
@@ -1,0 +1,17 @@
+from datetime import timedelta
+
+from crawlee.statistics._statistics import RequestProcessingRecord
+
+
+def test_tracking_time_resolution() -> None:
+    """Test that `RequestProcessingRecord` tracks time with sufficient resolution
+
+    This is generally not an issue on Linux, but on Windows some packages in older Python versions might be using system
+    timers with not so granular resolution - some sources estimate 15ms. This test will start failing on Windows
+    if unsuitable source of time measurement is selected due to two successive time measurements possibly using same
+    timing sample."""
+    record = RequestProcessingRecord()
+    record.run()
+    record.finish()
+    assert record.duration
+    assert record.duration > timedelta(seconds=0)

--- a/tests/unit/_statistics/test_request_processing_record.py
+++ b/tests/unit/_statistics/test_request_processing_record.py
@@ -4,7 +4,7 @@ from crawlee.statistics._statistics import RequestProcessingRecord
 
 
 def test_tracking_time_resolution() -> None:
-    """Test that `RequestProcessingRecord` tracks time with sufficient resolution
+    """Test that `RequestProcessingRecord` tracks time with sufficient resolution.
 
     This is generally not an issue on Linux, but on Windows some packages in older Python versions might be using system
     timers with not so granular resolution - some sources estimate 15ms. This test will start failing on Windows


### PR DESCRIPTION
### Description

Replace `datetime.now` by `time.perf_counter_ns` in time difference calculations for request duration tracking to avoid possible issues  connected to measured time resolution.
This fixes the flakiness of `test_final_statistics` that was happening on Windows and Python versions < 3.13.

### Issues

- Closes: #1256

### Testing

Newly added test was stress tested 500x times on old implementation to see the test sensitivity. On the source code before this PR the new test failed for Windows and Python versions 3.9,3.10,3.11,3.12 all 500 times. It did not fail even once for Linux or Windows  + Python 3.13. 

