### PR TITLE
feat: add periodic status logging and `status_message_callback` parameter for customization

### DIFF
--- a/src/crawlee/_log_config.py
+++ b/src/crawlee/_log_config.py
@@ -4,7 +4,7 @@ import json
 import logging
 import sys
 import textwrap
-from typing import Any
+from typing import Any, Literal
 
 from colorama import Fore, Style, just_fix_windows_console
 from typing_extensions import assert_never
@@ -34,22 +34,27 @@ _LOG_LEVEL_SHORT_ALIAS = {
 _LOG_MESSAGE_INDENT = ' ' * 6
 
 
+def string_to_log_level(level: Literal['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']) -> int:
+    """Convert a string representation of a log level to an integer log level."""
+    if level == 'DEBUG':
+        return logging.DEBUG
+    if level == 'INFO':
+        return logging.INFO
+    if level == 'WARNING':
+        return logging.WARNING
+    if level == 'ERROR':
+        return logging.ERROR
+    if level == 'CRITICAL':
+        return logging.CRITICAL
+
+    assert_never(level)
+
+
 def get_configured_log_level() -> int:
     config = service_locator.get_configuration()
 
     if 'log_level' in config.model_fields_set:
-        if config.log_level == 'DEBUG':
-            return logging.DEBUG
-        if config.log_level == 'INFO':
-            return logging.INFO
-        if config.log_level == 'WARNING':
-            return logging.WARNING
-        if config.log_level == 'ERROR':
-            return logging.ERROR
-        if config.log_level == 'CRITICAL':
-            return logging.CRITICAL
-
-        assert_never(config.log_level)
+        return string_to_log_level(config.log_level)
 
     if sys.flags.dev_mode:
         return logging.DEBUG

--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -1459,7 +1459,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
         if self._status_message_callback:
             self._status_message_callback(current_state, self._previous_crawler_state, message)
         else:
-            self.set_status_message(message)
+            self.set_status_message(message, level='INFO')
 
         event_manager.emit(event=Event.CRAWLER_STATUS, event_data=EventCrawlerStatusData(message=message))
 

--- a/src/crawlee/events/__init__.py
+++ b/src/crawlee/events/__init__.py
@@ -3,6 +3,7 @@ from ._local_event_manager import LocalEventManager
 from ._types import (
     Event,
     EventAbortingData,
+    EventCrawlerStatusData,
     EventData,
     EventExitData,
     EventListener,
@@ -14,6 +15,7 @@ from ._types import (
 __all__ = [
     'Event',
     'EventAbortingData',
+    'EventCrawlerStatusData',
     'EventData',
     'EventExitData',
     'EventListener',

--- a/src/crawlee/events/_event_manager.py
+++ b/src/crawlee/events/_event_manager.py
@@ -19,6 +19,7 @@ from crawlee._utils.wait import wait_for_all_tasks_for_finish
 from crawlee.events._types import (
     Event,
     EventAbortingData,
+    EventCrawlerStatusData,
     EventExitData,
     EventListener,
     EventMigratingData,
@@ -147,6 +148,8 @@ class EventManager:
     @overload
     def on(self, *, event: Literal[Event.EXIT], listener: EventListener[EventExitData]) -> None: ...
     @overload
+    def on(self, *, event: Literal[Event.CRAWLER_STATUS], listener: EventListener[EventCrawlerStatusData]) -> None: ...
+    @overload
     def on(self, *, event: Event, listener: EventListener[None]) -> None: ...
 
     def on(self, *, event: Event, listener: EventListener[Any]) -> None:
@@ -221,6 +224,8 @@ class EventManager:
     def emit(self, *, event: Literal[Event.ABORTING], event_data: EventAbortingData) -> None: ...
     @overload
     def emit(self, *, event: Literal[Event.EXIT], event_data: EventExitData) -> None: ...
+    @overload
+    def emit(self, *, event: Literal[Event.CRAWLER_STATUS], event_data: EventCrawlerStatusData) -> None: ...
     @overload
     def emit(self, *, event: Event, event_data: Any) -> None: ...
 

--- a/src/crawlee/events/_types.py
+++ b/src/crawlee/events/_types.py
@@ -31,6 +31,9 @@ class Event(str, Enum):
     PAGE_CREATED = 'pageCreated'
     PAGE_CLOSED = 'pageClosed'
 
+    # State events
+    CRAWLER_STATUS = 'crawlerStatus'
+
 
 @docs_group('Event payloads')
 class EventPersistStateData(BaseModel):

--- a/src/crawlee/events/_types.py
+++ b/src/crawlee/events/_types.py
@@ -82,7 +82,23 @@ class EventExitData(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
-EventData = Union[EventPersistStateData, EventSystemInfoData, EventMigratingData, EventAbortingData, EventExitData]
+@docs_group('Event payloads')
+class EventCrawlerStatusData(BaseModel):
+    """Data for the crawler status event."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    message: str
+
+
+EventData = Union[
+    EventPersistStateData,
+    EventSystemInfoData,
+    EventMigratingData,
+    EventAbortingData,
+    EventExitData,
+    EventCrawlerStatusData,
+]
 """A helper type for all possible event payloads"""
 
 WrappedListener = Callable[..., Coroutine[Any, Any, None]]


### PR DESCRIPTION
### Description

- Add periodic logging of the current crawler status
- Add `status_message_logging_interval` parameter to configure the logging interval
- Add `status_message_callback` parameter to allow custom status message handling
- Add a new `CRAWLER_STATUS` `Event` that emits status messages through `EventManager`

### Issues

- Closes: #96 
