### PR TITLE
chore: update project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
@@ -80,13 +81,14 @@ playwright = ["playwright>=1.27.0"]
 crawlee = "crawlee._cli:cli"
 
 [project.urls]
-homepage = "https://crawlee.dev/python"
-source = "https://github.com/apify/crawlee-python"
-changelog = "https://crawlee.dev/python/docs/changelog"
-releasenotes = "https://crawlee.dev/python/docs/upgrading"
-documentation = "https://crawlee.dev/python/docs"
-issues = "https://github.com/apify/crawlee-python/issues"
-"Apify homepage" = "https://apify.com"
+"Apify Homepage" = "https://apify.com"
+"Changelog" = "https://crawlee.dev/python/docs/changelog"
+"Discord" = "https://discord.com/invite/jyEM2PRvMU"
+"Documentation" = "https://crawlee.dev/python/docs"
+"Homepage" = "https://crawlee.dev/python"
+"Issue Tracker" = "https://github.com/apify/crawlee-python/issues"
+"Release Notes" = "https://crawlee.dev/python/docs/upgrading"
+"Source Code" = "https://github.com/apify/crawlee-python"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Basically reverting https://github.com/apify/crawlee-python/pull/1285 and adding "Discord" and "Release Notes" fields. For some reason the [well-known labels](https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels) are not being rendered on the PyPI (see https://pypi.org/project/crawlee/0.6.12b13/ or attachment).

![image](https://github.com/user-attachments/assets/04bd3d5e-ee78-4712-b622-7e76e8f27e25)
