### PR TITLE
feat: Add crawlee-cli option to skip project installation

### DIFF
--- a/src/crawlee/_cli.py
+++ b/src/crawlee/_cli.py
@@ -29,6 +29,7 @@ crawler_choices = cookiecutter_json['crawler_type']
 http_client_choices = cookiecutter_json['http_client']
 package_manager_choices = cookiecutter_json['package_manager']
 default_start_url = cookiecutter_json['start_url']
+default_enable_apify_integration = cookiecutter_json['enable_apify_integration']
 default_install_project = cookiecutter_json['install_project']
 
 
@@ -160,7 +161,7 @@ def create(
     install_project: bool | None = typer.Option(
         None,
         '--install/--no-install',
-        show_default=True,
+        show_default=False,
         help='Should the project be installed now? If not given, you will be prompted.',
     ),
 ) -> None:
@@ -187,11 +188,13 @@ def create(
 
         # Ask about Apify integration if not explicitly configured
         if enable_apify_integration is None:
-            enable_apify_integration = _prompt_bool('Should Apify integration be set up for you?', default=False)
+            enable_apify_integration = _prompt_bool(
+                'Should Apify integration be set up for you?', default=default_enable_apify_integration
+            )
 
         # Ask about installing the project
         if install_project is None:
-            install_project = _prompt_bool('Should the project be installed now?', default=True)
+            install_project = _prompt_bool('Should the project be installed now?', default=default_install_project)
 
         if all(
             [

--- a/src/crawlee/project_template/cookiecutter.json
+++ b/src/crawlee/project_template/cookiecutter.json
@@ -4,8 +4,9 @@
     "crawler_type": ["beautifulsoup", "parsel", "playwright", "playwright-camoufox"],
     "__crawler_type": "{{ cookiecutter.crawler_type|lower|replace('-', '_') }}",
     "http_client": ["httpx", "curl-impersonate"],
-    "package_manager": ["poetry", "pip", "uv", "manual"],
+    "package_manager": ["poetry", "pip", "uv"],
     "enable_apify_integration": false,
+    "install_project": true,
     "start_url": "https://crawlee.dev",
     "_jinja2_env_vars": {
         "line_statement_prefix": "# %"

--- a/src/crawlee/project_template/hooks/post_gen_project.py
+++ b/src/crawlee/project_template/hooks/post_gen_project.py
@@ -5,6 +5,7 @@ from pathlib import Path
 # % if cookiecutter.package_manager in ['poetry', 'uv']
 Path('requirements.txt').unlink()
 
+# % if cookiecutter.install_project == True
 # % if cookiecutter.package_manager == 'poetry'
 subprocess.check_call(['poetry', 'install'])
 # % elif cookiecutter.package_manager == 'uv'
@@ -15,6 +16,7 @@ subprocess.check_call(['uv', 'sync'])
 manager = "{{ cookiecutter.package_manager }}"
 subprocess.check_call([manager, 'run', 'playwright', 'install'])
 # % endif
+# % endif
 
 
 # % elif cookiecutter.package_manager == 'pip'
@@ -24,6 +26,7 @@ import venv  # noqa: E402
 venv_root = Path('.venv')
 venv.main([str(venv_root)])
 
+# % if cookiecutter.install_project == True
 if platform.system() == 'Windows':  # noqa: SIM108
     path = venv_root / 'Scripts'
 else:
@@ -37,5 +40,6 @@ Path('requirements.txt').write_text(
 
 # % if cookiecutter.crawler_type == 'playwright'
 subprocess.check_call([str(path / 'playwright'), 'install'])
+# % endif
 # % endif
 # % endif

--- a/tests/e2e/project_template/test_static_crawlers_templates.py
+++ b/tests/e2e/project_template/test_static_crawlers_templates.py
@@ -61,8 +61,8 @@ async def test_static_crawler_actor_at_apify(
             'http_client': http_client,
             'enable_apify_integration': True,
             'start_url': default_start_url,
+            'install_project': False,
         },
-        accept_hooks=False,  # Do not install the newly created environment.
         output_dir=tmp_path,
     )
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -30,6 +30,7 @@ def test_create_interactive(mock_cookiecutter: Mock, monkeypatch: pytest.MonkeyP
             readchar.key.ENTER,
             readchar.key.ENTER,
             readchar.key.ENTER,
+            readchar.key.ENTER,
         ]
     )
     monkeypatch.setattr(target=readchar, name='readkey', value=lambda: next(mock_input))
@@ -47,6 +48,7 @@ def test_create_interactive(mock_cookiecutter: Mock, monkeypatch: pytest.MonkeyP
             'http_client': 'httpx',
             'enable_apify_integration': False,
             'start_url': 'https://crawlee.dev',
+            'install_project': True,
         },
     )
 
@@ -57,6 +59,7 @@ def test_create_interactive_non_default_template(mock_cookiecutter: Mock, monkey
             *'my_project',
             readchar.key.ENTER,
             readchar.key.DOWN,
+            readchar.key.ENTER,
             readchar.key.ENTER,
             readchar.key.ENTER,
             readchar.key.ENTER,
@@ -79,6 +82,7 @@ def test_create_interactive_non_default_template(mock_cookiecutter: Mock, monkey
             'http_client': 'httpx',
             'enable_apify_integration': False,
             'start_url': 'https://crawlee.dev',
+            'install_project': True,
         },
     )
 
@@ -98,6 +102,7 @@ def test_create_non_interactive(mock_cookiecutter: Mock) -> None:
             '--start-url',
             'https://yr.no',
             '--no-apify',
+            '--no-install',
         ],
     )
 
@@ -111,6 +116,7 @@ def test_create_non_interactive(mock_cookiecutter: Mock) -> None:
             'http_client': 'curl-impersonate',
             'start_url': 'https://yr.no',
             'enable_apify_integration': False,
+            'install_project': False,
         },
     )
 
@@ -144,6 +150,7 @@ def test_create_existing_folder(
             '--start-url',
             'https://yr.no',
             '--no-apify',
+            '--install',
         ],
     )
     assert 'existing_project already exists' in result.output
@@ -158,6 +165,7 @@ def test_create_existing_folder(
             'http_client': 'curl-impersonate',
             'start_url': 'https://yr.no',
             'enable_apify_integration': False,
+            'install_project': True,
         },
     )
 
@@ -170,6 +178,7 @@ def test_create_existing_folder_interactive(
             *'existing_project',
             readchar.key.ENTER,
             *'my_project',
+            readchar.key.ENTER,
             readchar.key.ENTER,
             readchar.key.ENTER,
             readchar.key.ENTER,
@@ -196,6 +205,7 @@ def test_create_existing_folder_interactive(
             'http_client': 'httpx',
             'start_url': 'https://crawlee.dev',
             'enable_apify_integration': False,
+            'install_project': True,
         },
     )
 
@@ -210,6 +220,7 @@ def test_create_existing_folder_interactive_multiple_attempts(
             *'existing_project_2',
             readchar.key.ENTER,
             *'my_project',
+            readchar.key.ENTER,
             readchar.key.ENTER,
             readchar.key.ENTER,
             readchar.key.ENTER,
@@ -237,5 +248,6 @@ def test_create_existing_folder_interactive_multiple_attempts(
             'http_client': 'httpx',
             'start_url': 'https://crawlee.dev',
             'enable_apify_integration': False,
+            'install_project': True,
         },
     )


### PR DESCRIPTION
### Description

- Add `crawlee-cli` option to skip project installation -  skips Python packages installation and Playwright installation.
- Remove `manual` value from package_manager `crawlee-cli` option

### Issues

- Closes: #1122


