### PR TITLE
docs: update symbol group ordering

### DIFF
--- a/src/crawlee/_utils/docs.py
+++ b/src/crawlee/_utils/docs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, Literal, TypeVar
 
-# The order of the rendered API groups is defined in the docusaurus-plugin-typedoc-api.
+# The order of the rendered API groups is defined in the website/docusaurus.config.js file.
 GroupName = Literal[
     'Autoscaling',
     'Browser management',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -4,16 +4,24 @@ const path = require('path');
 const { externalLinkProcessor } = require('./tools/utils/externalLink');
 
 const GROUP_ORDER = [
-    'Classes',
-    'Abstract classes',
-    'Data structures',
+    'Autoscaling',
+    'Browser management',
+    'Configuration',
+    'Crawlers',
+    'Crawling contexts',
     'Errors',
+    'Event data',
+    'Event managers',
     'Functions',
-    'Constructors',
-    'Methods',
-    'Properties',
-    'Constants',
-    'Enumeration Members',
+    'HTTP clients',
+    'HTTP parsers',
+    'Request loaders',
+    'Session management',
+    'Statistics',
+    'Storage clients',
+    'Storage data',
+    'Storages',
+    'Other',
 ];
 
 const groupSort = (g1, g2) => {


### PR DESCRIPTION
<img width="1661" height="1009" alt="image" src="https://github.com/user-attachments/assets/7e8d21c3-c4c1-4372-83b8-554b53d884cc" />

Follow-up for #1309 (see [relevant comment](https://github.com/apify/crawlee-python/pull/1309#discussion_r2215488717))