### PR TITLE
fix: Fix retry count to not count the original request

### DIFF
--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -855,7 +855,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
         if max_request_retries is None:
             max_request_retries = self._max_request_retries
 
-        return (context.request.retry_count + 1) < max_request_retries
+        return context.request.retry_count < max_request_retries
 
     async def _check_url_after_redirects(self, context: TCrawlingContext) -> AsyncGenerator[TCrawlingContext, None]:
         """Ensure that the `loaded_url` still matches the enqueue strategy after redirects.

--- a/tests/unit/crawlers/_http/test_http_crawler.py
+++ b/tests/unit/crawlers/_http/test_http_crawler.py
@@ -104,7 +104,7 @@ async def test_handles_client_errors(
         request_handler=mock_request_handler,
         additional_http_error_status_codes=additional_http_error_status_codes,
         ignore_http_error_status_codes=ignore_http_error_status_codes,
-        max_request_retries=3,
+        max_request_retries=2,
     )
 
     await crawler.add_requests([str(server_url / 'status/402')])
@@ -230,7 +230,7 @@ async def test_http_status_statistics(crawler: HttpCrawler, server_url: URL) -> 
         '200': 10,
         '403': 100,  # block errors change session and retry
         '402': 10,  # client errors are not retried by default
-        '500': 30,  # server errors are retried by default
+        '500': 40,  # server errors are retried by default
     }
 
 
@@ -568,7 +568,7 @@ async def test_error_snapshot_through_statistics(server_url: URL) -> None:
         kvs_content[key_info.key] = await kvs.get_value(key_info.key)
 
     # One error, three time retried.
-    assert crawler.statistics.error_tracker.total == 3
+    assert crawler.statistics.error_tracker.total == 4
     assert crawler.statistics.error_tracker.unique_error_count == 1
     assert len(kvs_content) == 1
     assert key_info.key.endswith('.html')

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -150,7 +150,7 @@ async def test_enqueue_links_with_transform_request_function(server_url: URL) ->
 
 
 async def test_nonexistent_url_invokes_error_handler() -> None:
-    crawler = PlaywrightCrawler(max_request_retries=4, request_handler=mock.AsyncMock())
+    crawler = PlaywrightCrawler(max_request_retries=3, request_handler=mock.AsyncMock())
 
     error_handler = mock.AsyncMock(return_value=None)
     crawler.error_handler(error_handler)
@@ -617,7 +617,7 @@ async def test_error_snapshot_through_statistics(server_url: URL) -> None:
             assert kvs_content[key_info.key] == HELLO_WORLD.decode('utf-8')
 
     # Three errors twice retried errors, but only 2 unique -> 4 (2 x (html and jpg)) artifacts expected.
-    assert crawler.statistics.error_tracker.total == 3 * max_retries
+    assert crawler.statistics.error_tracker.total == 3 * (max_retries + 1)
     assert crawler.statistics.error_tracker.unique_error_count == 2
     assert len(list(kvs_content.keys())) == 4
 


### PR DESCRIPTION
### Description
The argument  `max_request_retries` of  `BasicCrawler` previously included also the initial request in retries. Now it counts only the retries.

### Issues

- Closes: #1326
