### PR TITLE
fix: Fix memory estimation not working on MacOS

### DIFF
--- a/tests/unit/_utils/test_system.py
+++ b/tests/unit/_utils/test_system.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import os
+import sys
 from multiprocessing import Barrier, Process, Value, synchronize
 from multiprocessing.shared_memory import SharedMemory
 from typing import TYPE_CHECKING
@@ -26,7 +26,7 @@ def test_get_cpu_info_returns_valid_values() -> None:
     assert 0 <= cpu_info.used_ratio <= 1
 
 
-@pytest.mark.skipif(os.name == 'nt', reason='Improved estimation not available on Windows')
+@pytest.mark.skipif(sys.platform != 'linux', reason='Improved estimation available only on Linux')
 def test_memory_estimation_does_not_overestimate_due_to_shared_memory() -> None:
     """Test that memory usage estimation is not overestimating memory usage by counting shared memory multiple times.
 


### PR DESCRIPTION
### Description
- Use `pss` for memory estimation only on Linux.
- Use `rss` for memory estimation only on MacOs.

### Issues

- Closes: #1329 
