### PR TITLE
chore: Add `macos` executor for unit tests

### DIFF
--- a/.github/workflows/run_code_checks.yaml
+++ b/.github/workflows/run_code_checks.yaml
@@ -36,6 +36,7 @@ jobs:
       httpbin_url: ${{ secrets.APIFY_HTTPBIN_TOKEN && format('https://httpbin.apify.actor?token={0}', secrets.APIFY_HTTPBIN_TOKEN) || 'https://httpbin.org'}}
     with:
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+      os: '["ubuntu-latest", "windows-latest", "macos-latest"]'
 
   docs_check:
     name: Docs check


### PR DESCRIPTION
### Description

- Run unit tests in CI also on `macOs` to prevent os OS-specific incompatible changes, for example: https://github.com/apify/crawlee-python/issues/1329

