### PR TITLE
fix: Ignore unknown parameters passed in cookies

### DIFF
--- a/src/crawlee/sessions/_cookies.py
+++ b/src/crawlee/sessions/_cookies.py
@@ -94,6 +94,7 @@ class SessionCookies:
         http_only: bool = False,
         secure: bool = False,
         same_site: Literal['Lax', 'None', 'Strict'] | None = None,
+        **_kwargs: Any,  # Unknown parameters will be ignored.
     ) -> None:
         """Create and store a cookie with modern browser attributes.
 

--- a/tests/unit/server.py
+++ b/tests/unit/server.py
@@ -347,7 +347,7 @@ async def set_complex_cookies(_scope: dict[str, Any], _receive: Receive, send: S
         [b'set-cookie', b'basic=1; Path=/; HttpOnly; SameSite=Lax'],
         [b'set-cookie', b'withpath=2; Path=/html; SameSite=None'],
         [b'set-cookie', b'strict=3; Path=/; SameSite=Strict'],
-        [b'set-cookie', b'secure=4; Path=/; HttpOnly; Secure; SameSite=Strict'],
+        [b'set-cookie', b'secure=4; Path=/; HttpOnly; Secure; SameSite=Strict; Partitioned'],
         [b'set-cookie', b'short=5; Path=/;'],
         [b'set-cookie', b'domain=6; Path=/; Domain=.127.0.0.1;'],
     ]


### PR DESCRIPTION
### Description

- Ignore unknown parameters passed in cookies

### Issues

- Closes: #1333

### Testing

- Added a test that sets `Partitioned` cookies. To reproduce the behaviour that causes Playwright to throw an error
