### PR TITLE
chore: fix `timeout` for `stream` method in `ImpitHttpClient`

### DIFF
--- a/src/crawlee/http_clients/_impit.py
+++ b/src/crawlee/http_clients/_impit.py
@@ -193,6 +193,7 @@ class ImpitHttpClient(HttpClient):
             url=url,
             content=payload,
             headers=dict(headers) if headers else None,
+            timeout=timeout.total_seconds() if timeout else None,
             stream=True,
         )
         try:


### PR DESCRIPTION
### Description

- fix `timeout` for `stream` method in `ImpitHttpClient`
