### PR TITLE
chore: use sync close for impit stream response

### DIFF
--- a/src/crawlee/http_clients/_impit.py
+++ b/src/crawlee/http_clients/_impit.py
@@ -200,6 +200,7 @@ class ImpitHttpClient(HttpClient):
         try:
             yield _ImpitResponse(response)
         finally:
+            # TODO: https://github.com/apify/impit/issues/242
             # Quickly closing Response while reading the response body causes an error in the Rust generator in `impit`.
             # With a short sleep and sync closing, the error does not occur.
             # Replace with `response.aclose` when this is resolved in impit.


### PR DESCRIPTION
### Description

- When using `aclose` and canceling a task in which streaming reading is occurring, an error is generated from the generator in `impit`. When using `close`, the error does not occur.

