### PR TITLE
fix: Include reason in the session rotation warning logs

### DIFF
--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -1353,7 +1353,8 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
                 await self._error_handler(context, session_error)
 
             if self._should_retry_request(context, session_error):
-                self._logger.warning('Encountered a session error, rotating session and retrying')
+                exc_only = ''.join(traceback.format_exception_only(session_error)).strip()
+                self._logger.warning('Encountered "%s", rotating session and retrying...', exc_only)
 
                 context.session.retire()
 


### PR DESCRIPTION
### Description

- Include reason in the session rotation warning logs.

### Issues

- Closes: #1318

### Reproduction

```python
import asyncio

from crawlee.crawlers import ParselCrawler, ParselCrawlingContext
from crawlee.errors import SessionError


async def main() -> None:
    crawler = ParselCrawler()

    @crawler.router.default_handler
    async def request_handler(_: ParselCrawlingContext) -> None:
        raise SessionError('Blah blah blah')

    await crawler.run(['https://crawlee.dev'])


if __name__ == '__main__':
    asyncio.run(main())
```

Log:
```
[crawlee._autoscaling.autoscaled_pool] INFO  current_concurrency = 0; desired_concurrency = 2; cpu = 0; mem = 0; event_loop = 0.0; client_info = 0.0
[ParselCrawler] WARN  Encountered "crawlee.errors.SessionError: Blah blah blah", rotating session and retrying...
[ParselCrawler] WARN  Encountered "crawlee.errors.SessionError: Blah blah blah", rotating session and retrying...
[ParselCrawler] WARN  Encountered "crawlee.errors.SessionError: Blah blah blah", rotating session and retrying...
[ParselCrawler] WARN  Encountered "crawlee.errors.SessionError: Blah blah blah", rotating session and retrying...
[ParselCrawler] WARN  Encountered "crawlee.errors.SessionError: Blah blah blah", rotating session and retrying...
[ParselCrawler] WARN  Encountered "crawlee.errors.SessionError: Blah blah blah", rotating session and retrying...
[ParselCrawler] WARN  Encountered "crawlee.errors.SessionError: Blah blah blah", rotating session and retrying...
[ParselCrawler] WARN  Encountered "crawlee.errors.SessionError: Blah blah blah", rotating session and retrying...
[ParselCrawler] WARN  Encountered "crawlee.errors.SessionError: Blah blah blah", rotating session and retrying...
[ParselCrawler] ERROR Request to https://crawlee.dev failed and reached maximum retries
 Traceback (most recent call last):
  File "/home/vdusek/Projects/crawlee-python/src/crawlee/crawlers/_basic/_basic_crawler.py", line 1312, in __run_task_function
    await self._run_request_handler(context=context)
  File "/home/vdusek/Projects/crawlee-python/src/crawlee/crawlers/_basic/_basic_crawler.py", line 1407, in _run_request_handler
    await wait_for(
    ...<5 lines>...
    )
  File "/home/vdusek/Projects/crawlee-python/src/crawlee/_utils/wait.py", line 37, in wait_for
    return await asyncio.wait_for(operation(), timeout.total_seconds())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vdusek/.local/share/uv/python/cpython-3.13.0-linux-x86_64-gnu/lib/python3.13/asyncio/tasks.py", line 507, in wait_for
    return await fut
           ^^^^^^^^^
  File "/home/vdusek/Projects/crawlee-python/src/crawlee/crawlers/_basic/_context_pipeline.py", line 114, in __call__
    await final_context_consumer(cast('TCrawlingContext', crawling_context))
  File "/home/vdusek/Projects/crawlee-python/src/crawlee/router.py", line 98, in __call__
    return await self._default_handler(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vdusek/Projects/crawlee-python/run_crawler.py", line 12, in request_handler
    raise SessionError('Blah blah blah')
crawlee.errors.SessionError: Blah blah blah
[crawlee._autoscaling.autoscaled_pool] INFO  Waiting for remaining tasks to finish
```

### Checklist

- [x] CI passed
