### PR TITLE
chore: Cleanup after 1.0.0rc1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.0.0rc1](https://github.com/apify/crawlee-python/releases/tag/v1.0.0rc1) (2025-08-22)
+<!-- git-cliff-unreleased-start -->
+
+## 0.6.13 - **not yet released**
 
 ### 🚀 Features
 
@@ -37,6 +39,7 @@ All notable changes to this project will be documented in this file.
 - [**breaking**] Change Dataset unwind parameter to accept list of strings ([#1357](https://github.com/apify/crawlee-python/pull/1357)) ([862a203](https://github.com/apify/crawlee-python/commit/862a20398f00fe91802fe7a1ccd58b05aee053a1)) by [@vdusek](https://github.com/vdusek)
 - [**breaking**] Remove `Request.id` field ([#1366](https://github.com/apify/crawlee-python/pull/1366)) ([32f3580](https://github.com/apify/crawlee-python/commit/32f3580e9775a871924ab1233085d0c549c4cd52)) by [@Pijukatel](https://github.com/Pijukatel), closes [#1358](https://github.com/apify/crawlee-python/issues/1358)
 
+<!-- git-cliff-unreleased-end -->
 
 ## [0.6.12](https://github.com/apify/crawlee-python/releases/tag/v0.6.12) (2025-07-30)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "crawlee"
-version = "1.0.0rc1"
+version = "0.6.13"
 description = "Crawlee for Python"
 authors = [{ name = "Apify Technologies s.r.o.", email = "support@apify.com" }]
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -577,7 +577,7 @@ toml = [
 
 [[package]]
 name = "crawlee"
-version = "1.0.0rc1"
+version = "0.6.13"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
This basically reverts https://github.com/apify/crawlee-python/commit/0dfbad56744c412885ee8956d4ec88c947fcec2f. Since we don't have a proper RC pipeline, I used the standard one, which resulted in this commit.

