### PR TITLE
chore: Fix accidentally missing name of the test

### DIFF
--- a/tests/unit/crawlers/_adaptive_playwright/test_predictor.py
+++ b/tests/unit/crawlers/_adaptive_playwright/test_predictor.py
@@ -24,7 +24,7 @@ from crawlee.storages import KeyValueStore
         ('http://www.ddf.com/some', 'client only'),
     ],
 )
-async def ictor_same_label(url: str, expected_prediction: RenderingType, label: str | None) -> None:
+async def test_predictor_same_label(url: str, expected_prediction: RenderingType, label: str | None) -> None:
     async with DefaultRenderingTypePredictor() as predictor:
         learning_inputs: tuple[tuple[str, RenderingType], ...] = (
             ('http://www.aaa.com/some/stuff', 'static'),


### PR DESCRIPTION
The name of the test was mangled by accident, and the test was not running. Fix the name so that the test runs again.
