### PR TITLE
fix: Save `RequestQueueState` for `FileSystemRequestQueueClient` in default KVS

### DIFF
--- a/src/crawlee/storage_clients/_file_system/_request_queue_client.py
+++ b/src/crawlee/storage_clients/_file_system/_request_queue_client.py
@@ -115,9 +115,8 @@ class FileSystemRequestQueueClient(RequestQueueClient):
 
         self._state = RecoverableState[RequestQueueState](
             default_state=RequestQueueState(),
-            persist_state_key='request_queue_state',
+            persist_state_key=f'request_queue_{self._metadata.id}_state',
             persistence_enabled=True,
-            persist_state_kvs_name=f'__RQ_STATE_{self._metadata.id}',
             logger=logger,
         )
         """Recoverable state to maintain request ordering, in-progress status, and handled status."""

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -631,6 +631,9 @@ async def test_error_snapshot_through_statistics(server_url: URL) -> None:
     kvs_content = {}
 
     async for key_info in kvs.iterate_keys():
+        # Skip any non-error snapshot keys, e.g. _state.
+        if 'ERROR_SNAPSHOT' not in key_info.key:
+            continue
         kvs_content[key_info.key] = await kvs.get_value(key_info.key)
 
         assert set(key_info.key).issubset(ErrorSnapshotter.ALLOWED_CHARACTERS)


### PR DESCRIPTION
### Description

- Save `RequestQueueState` for `FileSystemRequestQueueClient` in the default KVS.

### Issues

- Closes: #1410
