### PR TITLE
chore: Replace `populate_by_name` with `validate_by_name` and `validate_by_alias` for Pydantic `ConfigDict`

### DIFF
--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -163,7 +163,7 @@ class Request(BaseModel):
     ```
     """
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     unique_key: Annotated[str, Field(alias='uniqueKey')]
     """A unique key identifying the request. Two requests with the same `unique_key` are considered as pointing

--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -69,7 +69,7 @@ def _normalize_headers(headers: Mapping[str, str]) -> dict[str, str]:
 class HttpHeaders(RootModel, Mapping[str, str]):
     """A dictionary-like object representing HTTP headers."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     root: Annotated[
         dict[str, str],

--- a/src/crawlee/_utils/system.py
+++ b/src/crawlee/_utils/system.py
@@ -36,7 +36,7 @@ else:
 class CpuInfo(BaseModel):
     """Information about the CPU usage."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     used_ratio: Annotated[float, Field(alias='usedRatio')]
     """The ratio of CPU currently in use, represented as a float between 0 and 1."""
@@ -51,7 +51,7 @@ class CpuInfo(BaseModel):
 class MemoryUsageInfo(BaseModel):
     """Information about the memory usage."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     current_size: Annotated[
         ByteSize,
@@ -71,7 +71,7 @@ class MemoryUsageInfo(BaseModel):
 class MemoryInfo(MemoryUsageInfo):
     """Information about system memory."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     total_size: Annotated[
         ByteSize, PlainValidator(ByteSize.validate), PlainSerializer(lambda size: size.bytes), Field(alias='totalSize')

--- a/src/crawlee/crawlers/_adaptive_playwright/_adaptive_playwright_crawler_statistics.py
+++ b/src/crawlee/crawlers/_adaptive_playwright/_adaptive_playwright_crawler_statistics.py
@@ -12,7 +12,7 @@ from crawlee.statistics import StatisticsState
 class AdaptivePlaywrightCrawlerStatisticState(StatisticsState):
     """Statistic data about a crawler run with additional information related to adaptive crawling."""
 
-    model_config = ConfigDict(populate_by_name=True, ser_json_inf_nan='constants')
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True, ser_json_inf_nan='constants')
 
     http_only_request_handler_runs: Annotated[int, Field(alias='http_only_request_handler_runs')] = 0
     """Number representing how many times static http based crawling was used."""

--- a/src/crawlee/crawlers/_adaptive_playwright/_rendering_type_predictor.py
+++ b/src/crawlee/crawlers/_adaptive_playwright/_rendering_type_predictor.py
@@ -32,7 +32,7 @@ FeatureVector = tuple[float, float]
 
 
 class RenderingTypePredictorState(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     model: Annotated[
         LogisticRegression,

--- a/src/crawlee/events/_types.py
+++ b/src/crawlee/events/_types.py
@@ -40,7 +40,7 @@ class Event(str, Enum):
 class EventPersistStateData(BaseModel):
     """Data for the persist state event."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     is_migrating: Annotated[bool, Field(alias='isMigrating')]
 
@@ -49,7 +49,7 @@ class EventPersistStateData(BaseModel):
 class EventSystemInfoData(BaseModel):
     """Data for the system info event."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     cpu_info: Annotated[CpuInfo, Field(alias='cpuInfo')]
     memory_info: Annotated[
@@ -62,7 +62,7 @@ class EventSystemInfoData(BaseModel):
 class EventMigratingData(BaseModel):
     """Data for the migrating event."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     # The remaining time in seconds before the migration is forced and the process is killed
     # Optional because it's not present when the event handler is called manually
@@ -73,21 +73,21 @@ class EventMigratingData(BaseModel):
 class EventAbortingData(BaseModel):
     """Data for the aborting event."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
 
 @docs_group('Event data')
 class EventExitData(BaseModel):
     """Data for the exit event."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
 
 @docs_group('Event data')
 class EventCrawlerStatusData(BaseModel):
     """Data for the crawler status event."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     message: str
     """A message describing the current status of the crawler."""

--- a/src/crawlee/fingerprint_suite/_types.py
+++ b/src/crawlee/fingerprint_suite/_types.py
@@ -11,7 +11,7 @@ SupportedBrowserType = Literal['chrome', 'firefox', 'safari', 'edge']
 
 
 class ScreenOptions(BaseModel):
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(extra='forbid', validate_by_name=True, validate_by_alias=True)
 
     """Defines the screen constrains for the fingerprint generator."""
 
@@ -31,7 +31,7 @@ class ScreenOptions(BaseModel):
 class HeaderGeneratorOptions(BaseModel):
     """Collection of header related attributes that can be used by the fingerprint generator."""
 
-    model_config = ConfigDict(extra='forbid', populate_by_name=True)
+    model_config = ConfigDict(extra='forbid', validate_by_name=True, validate_by_alias=True)
 
     browsers: list[SupportedBrowserType] | None = None
     """List of BrowserSpecifications to generate the headers for."""

--- a/src/crawlee/request_loaders/_request_list.py
+++ b/src/crawlee/request_loaders/_request_list.py
@@ -17,7 +17,7 @@ logger = getLogger(__name__)
 
 
 class RequestListState(BaseModel):
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     next_index: Annotated[int, Field(alias='nextIndex')] = 0
     next_unique_key: Annotated[str | None, Field(alias='nextUniqueKey')] = None

--- a/src/crawlee/request_loaders/_sitemap_request_loader.py
+++ b/src/crawlee/request_loaders/_sitemap_request_loader.py
@@ -56,7 +56,7 @@ class SitemapRequestLoaderState(BaseModel):
     `in_progress` is cleared.
     """
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     url_queue: Annotated[deque[str], Field(alias='urlQueue')]
     """Queue of URLs extracted from sitemaps and ready for processing."""

--- a/src/crawlee/sessions/_models.py
+++ b/src/crawlee/sessions/_models.py
@@ -20,7 +20,7 @@ from ._session import Session
 class SessionModel(BaseModel):
     """Model for a Session object."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     id: Annotated[str, Field(alias='id')]
     max_age: Annotated[timedelta, Field(alias='maxAge')]
@@ -38,7 +38,7 @@ class SessionModel(BaseModel):
 class SessionPoolModel(BaseModel):
     """Model for a SessionPool object."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     max_pool_size: Annotated[int, Field(alias='maxPoolSize')]
 

--- a/src/crawlee/statistics/_models.py
+++ b/src/crawlee/statistics/_models.py
@@ -57,7 +57,7 @@ class FinalStatistics:
 class StatisticsState(BaseModel):
     """Statistic data about a crawler run."""
 
-    model_config = ConfigDict(populate_by_name=True, ser_json_inf_nan='constants')
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True, ser_json_inf_nan='constants')
     stats_id: Annotated[int | None, Field(alias='statsId')] = None
 
     requests_finished: Annotated[int, Field(alias='requestsFinished')] = 0

--- a/src/crawlee/storage_clients/models.py
+++ b/src/crawlee/storage_clients/models.py
@@ -20,7 +20,7 @@ class StorageMetadata(BaseModel):
     It contains common fields shared across all specific storage types.
     """
 
-    model_config = ConfigDict(populate_by_name=True, extra='allow')
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True, extra='allow')
 
     id: Annotated[str, Field(alias='id')]
     """The unique identifier of the storage."""
@@ -42,7 +42,7 @@ class StorageMetadata(BaseModel):
 class DatasetMetadata(StorageMetadata):
     """Model for a dataset metadata."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     item_count: Annotated[int, Field(alias='itemCount')]
     """The number of items in the dataset."""
@@ -52,14 +52,14 @@ class DatasetMetadata(StorageMetadata):
 class KeyValueStoreMetadata(StorageMetadata):
     """Model for a key-value store metadata."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
 
 @docs_group('Storage data')
 class RequestQueueMetadata(StorageMetadata):
     """Model for a request queue metadata."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     had_multiple_clients: Annotated[bool, Field(alias='hadMultipleClients')]
     """Indicates whether the queue has been accessed by multiple clients (consumers)."""
@@ -78,7 +78,7 @@ class RequestQueueMetadata(StorageMetadata):
 class KeyValueStoreRecordMetadata(BaseModel):
     """Model for a key-value store record metadata."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     key: Annotated[str, Field(alias='key')]
     """The key of the record.
@@ -100,7 +100,7 @@ class KeyValueStoreRecordMetadata(BaseModel):
 class KeyValueStoreRecord(KeyValueStoreRecordMetadata, Generic[KvsValueType]):
     """Model for a key-value store record."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     value: Annotated[KvsValueType, Field(alias='value')]
     """The value of the record."""
@@ -110,7 +110,7 @@ class KeyValueStoreRecord(KeyValueStoreRecordMetadata, Generic[KvsValueType]):
 class DatasetItemsListPage(BaseModel):
     """Model for a single page of dataset items returned from a collection list method."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     count: Annotated[int, Field(default=0)]
     """The number of objects returned on this page."""
@@ -135,7 +135,7 @@ class DatasetItemsListPage(BaseModel):
 class ProcessedRequest(BaseModel):
     """Represents a processed request."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     id: Annotated[str | None, Field(alias='requestId', default=None)] = None
     """Internal representation of the request by the storage client. Only some clients use id."""
@@ -149,7 +149,7 @@ class ProcessedRequest(BaseModel):
 class UnprocessedRequest(BaseModel):
     """Represents an unprocessed request."""
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     unique_key: Annotated[str, Field(alias='uniqueKey')]
     url: Annotated[str, BeforeValidator(validate_http_url), Field()]
@@ -165,7 +165,7 @@ class AddRequestsResponse(BaseModel):
     encountered issues during processing.
     """
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(validate_by_name=True, validate_by_alias=True)
 
     processed_requests: Annotated[list[ProcessedRequest], Field(alias='processedRequests')]
     """Successfully processed requests, including information about whether they were


### PR DESCRIPTION
### Description

- Since we have bumped the minimum version of pydantic to 2.11, using `populate_by_name` is [not recommended](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.populate_by_name).
