### PR TITLE
feat: Add RQ id, name, alias args to `add_requests` and `enqueue_links` methods

### DIFF
--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -181,8 +181,7 @@ class AddRequestsKwargs(EnqueueLinksKwargs):
     """Requests to be added to the `RequestManager`."""
 
     rq_name: str | None
-    """Name of the `RequestQueue` to add the requests to. Only one of `rq_name`, `rq_alias` or `rq_id` can be provided.
-    """
+    """Name of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias` can be provided."""
 
     rq_alias: str | None
     """Alias of the `RequestQueue` to add the requests to. Only one of `rq_alias`, `rq_name` or `rq_id` can be provided.

--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -180,6 +180,12 @@ class AddRequestsKwargs(EnqueueLinksKwargs):
     requests: Sequence[str | Request]
     """Requests to be added to the `RequestManager`."""
 
+    rq_name: str | None
+    """Name of the `RequestQueue` to add the requests to. Only one of `rq_name` or `rq_alias` can be provided."""
+
+    rq_alias: str | None
+    """Alias of the `RequestQueue` to add the requests to. Only one of `rq_name` or `rq_alias` can be provided."""
+
 
 class PushDataKwargs(TypedDict):
     """Keyword arguments for dataset's `push_data` method."""
@@ -261,10 +267,16 @@ class RequestHandlerRunResult:
     async def add_requests(
         self,
         requests: Sequence[str | Request],
+        rq_name: str | None = None,
+        rq_alias: str | None = None,
         **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> None:
         """Track a call to the `add_requests` context helper."""
-        self.add_requests_calls.append(AddRequestsKwargs(requests=requests, **kwargs))
+        if rq_name is not None and rq_alias is not None:
+            raise ValueError('Only one of rq_name or rq_alias can be provided.')
+        self.add_requests_calls.append(
+            AddRequestsKwargs(requests=requests, rq_name=rq_name, rq_alias=rq_alias, **kwargs)
+        )
 
     async def push_data(
         self,
@@ -311,12 +323,19 @@ class AddRequestsFunction(Protocol):
     def __call__(
         self,
         requests: Sequence[str | Request],
+        rq_name: str | None = None,
+        rq_alias: str | None = None,
         **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> Coroutine[None, None, None]:
         """Call dunder method.
 
         Args:
-            requests: Requests to be added to the `RequestManager`.
+            requests: Requests to be added to the `RequestManager` or, if `rq_name` or `rq_alias` is specified, to
+                the corresponding `RequestQueue`.
+            rq_name: Name of the `RequestQueue` to add the requests to. Only one of `rq_name` or `rq_alias` can
+                be provided.
+            rq_alias: Alias of the `RequestQueue` to add the requests to. Only one of `rq_name` or `rq_alias` can
+                be provided.
             **kwargs: Additional keyword arguments.
         """
 
@@ -344,12 +363,19 @@ class EnqueueLinksFunction(Protocol):
         label: str | None = None,
         user_data: dict[str, Any] | None = None,
         transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction] | None = None,
+        rq_name: str | None = None,
+        rq_alias: str | None = None,
         **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> Coroutine[None, None, None]: ...
 
     @overload
     def __call__(
-        self, *, requests: Sequence[str | Request] | None = None, **kwargs: Unpack[EnqueueLinksKwargs]
+        self,
+        *,
+        requests: Sequence[str | Request] | None = None,
+        rq_name: str | None = None,
+        rq_alias: str | None = None,
+        **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> Coroutine[None, None, None]: ...
 
     def __call__(
@@ -360,6 +386,8 @@ class EnqueueLinksFunction(Protocol):
         user_data: dict[str, Any] | None = None,
         transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction] | None = None,
         requests: Sequence[str | Request] | None = None,
+        rq_name: str | None = None,
+        rq_alias: str | None = None,
         **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> Coroutine[None, None, None]:
         """Call enqueue links function.
@@ -376,7 +404,12 @@ class EnqueueLinksFunction(Protocol):
                 - Modified `RequestOptions` to update the request configuration,
                 - `'skip'` to exclude the request from being enqueued,
                 - `'unchanged'` to use the original request options without modification.
-            requests: Requests to be added to the `RequestManager`.
+            requests: Requests to be added to the `RequestManager` or, if `rq_name` or `rq_alias` is specified, to
+                the corresponding `RequestQueue`.
+            rq_name: Name of the `RequestQueue` to add the requests to. Only one of `rq_name` or `rq_alias` can
+                be provided.
+            rq_alias: Alias of the `RequestQueue` to add the requests to. Only one of `rq_name` or `rq_alias` can
+                be provided.
             **kwargs: Additional keyword arguments.
         """
 

--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -184,8 +184,7 @@ class AddRequestsKwargs(EnqueueLinksKwargs):
     """Name of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias` can be provided."""
 
     rq_alias: str | None
-    """Alias of the `RequestQueue` to add the requests to. Only one of `rq_alias`, `rq_name` or `rq_id` can be provided.
-    """
+    """Alias of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias` can be provided."""
 
     rq_id: str | None
     """ID of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias` can be provided."""

--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -181,10 +181,15 @@ class AddRequestsKwargs(EnqueueLinksKwargs):
     """Requests to be added to the `RequestManager`."""
 
     rq_name: str | None
-    """Name of the `RequestQueue` to add the requests to. Only one of `rq_name` or `rq_alias` can be provided."""
+    """Name of the `RequestQueue` to add the requests to. Only one of `rq_name`, `rq_alias` or `rq_id` can be provided.
+    """
 
     rq_alias: str | None
-    """Alias of the `RequestQueue` to add the requests to. Only one of `rq_name` or `rq_alias` can be provided."""
+    """Alias of the `RequestQueue` to add the requests to. Only one of `rq_alias`, `rq_name` or `rq_id` can be provided.
+    """
+
+    rq_id: str | None
+    """ID of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias` can be provided."""
 
 
 class PushDataKwargs(TypedDict):
@@ -269,13 +274,15 @@ class RequestHandlerRunResult:
         requests: Sequence[str | Request],
         rq_name: str | None = None,
         rq_alias: str | None = None,
+        rq_id: str | None = None,
         **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> None:
         """Track a call to the `add_requests` context helper."""
-        if rq_name is not None and rq_alias is not None:
-            raise ValueError('Only one of rq_name or rq_alias can be provided.')
+        specified_params = sum(1 for param in [rq_name, rq_alias, rq_id] if param is not None)
+        if specified_params > 1:
+            raise ValueError('Only one of `rq_name`, `rq_alias` or `rq_id` can be provided.')
         self.add_requests_calls.append(
-            AddRequestsKwargs(requests=requests, rq_name=rq_name, rq_alias=rq_alias, **kwargs)
+            AddRequestsKwargs(requests=requests, rq_name=rq_name, rq_alias=rq_alias, rq_id=rq_id, **kwargs)
         )
 
     async def push_data(
@@ -325,6 +332,7 @@ class AddRequestsFunction(Protocol):
         requests: Sequence[str | Request],
         rq_name: str | None = None,
         rq_alias: str | None = None,
+        rq_id: str | None = None,
         **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> Coroutine[None, None, None]:
         """Call dunder method.
@@ -332,10 +340,12 @@ class AddRequestsFunction(Protocol):
         Args:
             requests: Requests to be added to the `RequestManager` or, if `rq_name` or `rq_alias` is specified, to
                 the corresponding `RequestQueue`.
-            rq_name: Name of the `RequestQueue` to add the requests to. Only one of `rq_name` or `rq_alias` can
+            rq_name: Name of the `RequestQueue` to add the requests to. Only one of `rq_name`, `rq_alias` or `rq_id` can
                 be provided.
-            rq_alias: Alias of the `RequestQueue` to add the requests to. Only one of `rq_name` or `rq_alias` can
-                be provided.
+            rq_alias: Alias of the `RequestQueue` to add the requests to. Only one of `rq_alias`, `rq_name` or `rq_id`
+                can be provided.
+            rq_id: ID of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias` can be
+                provided.
             **kwargs: Additional keyword arguments.
         """
 
@@ -365,6 +375,7 @@ class EnqueueLinksFunction(Protocol):
         transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction] | None = None,
         rq_name: str | None = None,
         rq_alias: str | None = None,
+        rq_id: str | None = None,
         **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> Coroutine[None, None, None]: ...
 
@@ -375,6 +386,7 @@ class EnqueueLinksFunction(Protocol):
         requests: Sequence[str | Request] | None = None,
         rq_name: str | None = None,
         rq_alias: str | None = None,
+        rq_id: str | None = None,
         **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> Coroutine[None, None, None]: ...
 
@@ -388,6 +400,7 @@ class EnqueueLinksFunction(Protocol):
         requests: Sequence[str | Request] | None = None,
         rq_name: str | None = None,
         rq_alias: str | None = None,
+        rq_id: str | None = None,
         **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> Coroutine[None, None, None]:
         """Call enqueue links function.
@@ -406,10 +419,12 @@ class EnqueueLinksFunction(Protocol):
                 - `'unchanged'` to use the original request options without modification.
             requests: Requests to be added to the `RequestManager` or, if `rq_name` or `rq_alias` is specified, to
                 the corresponding `RequestQueue`.
-            rq_name: Name of the `RequestQueue` to add the requests to. Only one of `rq_name` or `rq_alias` can
+            rq_name: Name of the `RequestQueue` to add the requests to. Only one of `rq_name`, `rq_alias` or `rq_id` can
                 be provided.
-            rq_alias: Alias of the `RequestQueue` to add the requests to. Only one of `rq_name` or `rq_alias` can
-                be provided.
+            rq_alias: Alias of the `RequestQueue` to add the requests to. Only one of `rq_alias`, `rq_name` or `rq_id`
+                can be provided.
+            rq_id: ID of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias` can be
+                provided.
             **kwargs: Additional keyword arguments.
         """
 

--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -180,14 +180,16 @@ class AddRequestsKwargs(EnqueueLinksKwargs):
     requests: Sequence[str | Request]
     """Requests to be added to the `RequestManager`."""
 
-    rq_name: str | None
-    """Name of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias` can be provided."""
-
-    rq_alias: str | None
-    """Alias of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias` can be provided."""
-
     rq_id: str | None
     """ID of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias` can be provided."""
+
+    rq_name: str | None
+    """Name of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias` can be provided.
+    """
+
+    rq_alias: str | None
+    """Alias of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias` can be provided.
+    """
 
 
 class PushDataKwargs(TypedDict):
@@ -270,17 +272,17 @@ class RequestHandlerRunResult:
     async def add_requests(
         self,
         requests: Sequence[str | Request],
+        rq_id: str | None = None,
         rq_name: str | None = None,
         rq_alias: str | None = None,
-        rq_id: str | None = None,
         **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> None:
         """Track a call to the `add_requests` context helper."""
-        specified_params = sum(1 for param in [rq_name, rq_alias, rq_id] if param is not None)
+        specified_params = sum(1 for param in [rq_id, rq_name, rq_alias] if param is not None)
         if specified_params > 1:
-            raise ValueError('Only one of `rq_name`, `rq_alias` or `rq_id` can be provided.')
+            raise ValueError('Only one of `rq_id`, `rq_name` or `rq_alias` can be provided.')
         self.add_requests_calls.append(
-            AddRequestsKwargs(requests=requests, rq_name=rq_name, rq_alias=rq_alias, rq_id=rq_id, **kwargs)
+            AddRequestsKwargs(requests=requests, rq_id=rq_id, rq_name=rq_name, rq_alias=rq_alias, **kwargs)
         )
 
     async def push_data(
@@ -328,9 +330,9 @@ class AddRequestsFunction(Protocol):
     def __call__(
         self,
         requests: Sequence[str | Request],
+        rq_id: str | None = None,
         rq_name: str | None = None,
         rq_alias: str | None = None,
-        rq_id: str | None = None,
         **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> Coroutine[None, None, None]:
         """Call dunder method.
@@ -338,12 +340,12 @@ class AddRequestsFunction(Protocol):
         Args:
             requests: Requests to be added to the `RequestManager` or, if `rq_name` or `rq_alias` is specified, to
                 the corresponding `RequestQueue`.
-            rq_name: Name of the `RequestQueue` to add the requests to. Only one of `rq_name`, `rq_alias` or `rq_id` can
-                be provided.
-            rq_alias: Alias of the `RequestQueue` to add the requests to. Only one of `rq_alias`, `rq_name` or `rq_id`
-                can be provided.
             rq_id: ID of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias` can be
                 provided.
+            rq_name: Name of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias`
+                can be provided.
+            rq_alias: Alias of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias`
+                can be provided.
             **kwargs: Additional keyword arguments.
         """
 
@@ -371,9 +373,9 @@ class EnqueueLinksFunction(Protocol):
         label: str | None = None,
         user_data: dict[str, Any] | None = None,
         transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction] | None = None,
+        rq_id: str | None = None,
         rq_name: str | None = None,
         rq_alias: str | None = None,
-        rq_id: str | None = None,
         **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> Coroutine[None, None, None]: ...
 
@@ -382,9 +384,9 @@ class EnqueueLinksFunction(Protocol):
         self,
         *,
         requests: Sequence[str | Request] | None = None,
+        rq_id: str | None = None,
         rq_name: str | None = None,
         rq_alias: str | None = None,
-        rq_id: str | None = None,
         **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> Coroutine[None, None, None]: ...
 
@@ -396,9 +398,9 @@ class EnqueueLinksFunction(Protocol):
         user_data: dict[str, Any] | None = None,
         transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction] | None = None,
         requests: Sequence[str | Request] | None = None,
+        rq_id: str | None = None,
         rq_name: str | None = None,
         rq_alias: str | None = None,
-        rq_id: str | None = None,
         **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> Coroutine[None, None, None]:
         """Call enqueue links function.
@@ -417,12 +419,12 @@ class EnqueueLinksFunction(Protocol):
                 - `'unchanged'` to use the original request options without modification.
             requests: Requests to be added to the `RequestManager` or, if `rq_name` or `rq_alias` is specified, to
                 the corresponding `RequestQueue`.
-            rq_name: Name of the `RequestQueue` to add the requests to. Only one of `rq_name`, `rq_alias` or `rq_id` can
-                be provided.
-            rq_alias: Alias of the `RequestQueue` to add the requests to. Only one of `rq_alias`, `rq_name` or `rq_id`
-                can be provided.
             rq_id: ID of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias` can be
                 provided.
+            rq_name: Name of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias`
+                can be provided.
+            rq_alias: Alias of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias`
+                can be provided.
             **kwargs: Additional keyword arguments.
         """
 

--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -338,8 +338,7 @@ class AddRequestsFunction(Protocol):
         """Call dunder method.
 
         Args:
-            requests: Requests to be added to the `RequestManager` or, if `rq_name` or `rq_alias` is specified, to
-                the corresponding `RequestQueue`.
+            requests: Requests to be added to the `RequestManager`.
             rq_id: ID of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias` can be
                 provided.
             rq_name: Name of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias`
@@ -417,8 +416,7 @@ class EnqueueLinksFunction(Protocol):
                 - Modified `RequestOptions` to update the request configuration,
                 - `'skip'` to exclude the request from being enqueued,
                 - `'unchanged'` to use the original request options without modification.
-            requests: Requests to be added to the `RequestManager` or, if `rq_name` or `rq_alias` is specified, to
-                the corresponding `RequestQueue`.
+            requests: Requests to be added to the `RequestManager`.
             rq_id: ID of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias` can be
                 provided.
             rq_name: Name of the `RequestQueue` to add the requests to. Only one of `rq_id`, `rq_name` or `rq_alias`

--- a/tests/unit/crawlers/_basic/test_basic_crawler.py
+++ b/tests/unit/crawlers/_basic/test_basic_crawler.py
@@ -1578,7 +1578,7 @@ async def test_add_requests_with_rq_param(queue_name: str | None, queue_alias: s
     @crawler.router.default_handler
     async def handler(context: BasicCrawlingContext) -> None:
         visit_urls.add(context.request.url)
-        await context.add_requests(check_requests, rq_name=queue_name, rq_alias=queue_alias, rq_id=queue_id)
+        await context.add_requests(check_requests, rq_id=queue_id, rq_name=queue_name, rq_alias=queue_alias)
 
     await crawler.run(['https://start.placeholder.com'])
 
@@ -1600,18 +1600,18 @@ async def test_add_requests_with_rq_param(queue_name: str | None, queue_alias: s
     ],
 )
 async def test_add_requests_error_with_multi_params(
-    queue_name: str | None, queue_alias: str | None, queue_id: str | None
+    queue_id: str | None, queue_name: str | None, queue_alias: str | None
 ) -> None:
     crawler = BasicCrawler()
 
     @crawler.router.default_handler
     async def handler(context: BasicCrawlingContext) -> None:
-        with pytest.raises(ValueError, match='Only one of `rq_name`, `rq_alias` or `rq_id` can be set'):
+        with pytest.raises(ValueError, match='Only one of `rq_id`, `rq_name` or `rq_alias` can be set'):
             await context.add_requests(
                 [Request.from_url('https://a.placeholder.com')],
+                rq_id=queue_id,
                 rq_name=queue_name,
                 rq_alias=queue_alias,
-                rq_id=queue_id,
             )
 
     await crawler.run(['https://start.placeholder.com'])

--- a/tests/unit/crawlers/_basic/test_basic_crawler.py
+++ b/tests/unit/crawlers/_basic/test_basic_crawler.py
@@ -1589,6 +1589,8 @@ async def test_add_requests_with_rq_param(queue_name: str | None, queue_alias: s
     assert requests_from_queue == check_requests
     assert visit_urls == {'https://start.placeholder.com'}
 
+    await rq.drop()
+
 
 @pytest.mark.parametrize(
     ('queue_name', 'queue_alias', 'queue_id'),

--- a/tests/unit/crawlers/_beautifulsoup/test_beautifulsoup_crawler.py
+++ b/tests/unit/crawlers/_beautifulsoup/test_beautifulsoup_crawler.py
@@ -237,6 +237,8 @@ async def test_enqueue_links_with_rq_param(
     assert set(requests_from_queue) == {str(server_url / 'page_1'), str(server_url / 'sub_index')}
     assert visit_urls == {str(server_url / 'start_enqueue')}
 
+    await rq.drop()
+
 
 @pytest.mark.parametrize(
     ('queue_name', 'queue_alias', 'by_id'),
@@ -279,6 +281,8 @@ async def test_enqueue_links_requests_with_rq_param(
 
     assert set(requests_from_queue) == set(check_requests)
     assert visit_urls == {str(server_url / 'start_enqueue')}
+
+    await rq.drop()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/crawlers/_beautifulsoup/test_beautifulsoup_crawler.py
+++ b/tests/unit/crawlers/_beautifulsoup/test_beautifulsoup_crawler.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from unittest import mock
 
+import pytest
+
 from crawlee import ConcurrencySettings, Glob, HttpHeaders, RequestTransformAction, SkippedReason
 from crawlee.crawlers import BeautifulSoupCrawler, BeautifulSoupCrawlingContext
+from crawlee.storages import RequestQueue
 
 if TYPE_CHECKING:
     from yarl import URL
@@ -198,3 +201,78 @@ async def test_extract_links(server_url: URL, http_client: HttpClient) -> None:
 
     assert len(extracted_links) == 1
     assert extracted_links[0] == str(server_url / 'page_1')
+
+
+@pytest.mark.parametrize(
+    ('queue_name', 'queue_alias'),
+    [
+        pytest.param('named-queue', None, id='with rq_name'),
+        pytest.param(None, 'alias-queue', id='with rq_alias'),
+    ],
+)
+async def test_enqueue_links_with_rq_param(
+    server_url: URL, http_client: HttpClient, queue_name: str | None, queue_alias: str | None
+) -> None:
+    crawler = BeautifulSoupCrawler(http_client=http_client)
+    rq = await RequestQueue.open(name=queue_name, alias=queue_alias)
+    visit_urls: set[str] = set()
+
+    @crawler.router.default_handler
+    async def handler(context: BeautifulSoupCrawlingContext) -> None:
+        visit_urls.add(context.request.url)
+        await context.enqueue_links(rq_name=queue_name, rq_alias=queue_alias)
+
+    await crawler.run([str(server_url / 'start_enqueue')])
+
+    requests_from_queue: list[str] = []
+    while request := await rq.fetch_next_request():
+        requests_from_queue.append(request.url)
+
+    assert set(requests_from_queue) == {str(server_url / 'page_1'), str(server_url / 'sub_index')}
+    assert visit_urls == {str(server_url / 'start_enqueue')}
+
+
+@pytest.mark.parametrize(
+    ('queue_name', 'queue_alias'),
+    [
+        pytest.param('named-queue', None, id='with rq_name'),
+        pytest.param(None, 'alias-queue', id='with rq_alias'),
+    ],
+)
+async def test_enqueue_links_requests_with_rq_param(
+    server_url: URL, http_client: HttpClient, queue_name: str | None, queue_alias: str | None
+) -> None:
+    crawler = BeautifulSoupCrawler(http_client=http_client)
+    rq = await RequestQueue.open(name=queue_name, alias=queue_alias)
+    visit_urls: set[str] = set()
+
+    check_requests: list[str] = [
+        'https://a.placeholder.com',
+        'https://b.placeholder.com',
+        'https://c.placeholder.com',
+    ]
+
+    @crawler.router.default_handler
+    async def handler(context: BeautifulSoupCrawlingContext) -> None:
+        visit_urls.add(context.request.url)
+        await context.enqueue_links(requests=check_requests, rq_name=queue_name, rq_alias=queue_alias, strategy='all')
+
+    await crawler.run([str(server_url / 'start_enqueue')])
+
+    requests_from_queue: list[str] = []
+    while request := await rq.fetch_next_request():
+        requests_from_queue.append(request.url)
+
+    assert set(requests_from_queue) == set(check_requests)
+    assert visit_urls == {str(server_url / 'start_enqueue')}
+
+
+async def test_enqueue_links_error_with_rq_alias_and_rq_name(server_url: URL, http_client: HttpClient) -> None:
+    crawler = BeautifulSoupCrawler(http_client=http_client)
+
+    @crawler.router.default_handler
+    async def handler(context: BeautifulSoupCrawlingContext) -> None:
+        with pytest.raises(ValueError, match='Cannot use both `rq_name` and `rq_alias`'):
+            await context.enqueue_links(rq_name='named-queue', rq_alias='alias-queue')
+
+    await crawler.run([str(server_url / 'start_enqueue')])

--- a/tests/unit/crawlers/_beautifulsoup/test_beautifulsoup_crawler.py
+++ b/tests/unit/crawlers/_beautifulsoup/test_beautifulsoup_crawler.py
@@ -204,23 +204,29 @@ async def test_extract_links(server_url: URL, http_client: HttpClient) -> None:
 
 
 @pytest.mark.parametrize(
-    ('queue_name', 'queue_alias'),
+    ('queue_name', 'queue_alias', 'by_id'),
     [
-        pytest.param('named-queue', None, id='with rq_name'),
-        pytest.param(None, 'alias-queue', id='with rq_alias'),
+        pytest.param('named-queue', None, False, id='with rq_name'),
+        pytest.param(None, 'alias-queue', False, id='with rq_alias'),
+        pytest.param('id-queue', None, True, id='with rq_id'),
     ],
 )
 async def test_enqueue_links_with_rq_param(
-    server_url: URL, http_client: HttpClient, queue_name: str | None, queue_alias: str | None
+    server_url: URL, http_client: HttpClient, queue_name: str | None, queue_alias: str | None, *, by_id: bool
 ) -> None:
     crawler = BeautifulSoupCrawler(http_client=http_client)
     rq = await RequestQueue.open(name=queue_name, alias=queue_alias)
+    if by_id:
+        queue_name = None
+        queue_id = rq.id
+    else:
+        queue_id = None
     visit_urls: set[str] = set()
 
     @crawler.router.default_handler
     async def handler(context: BeautifulSoupCrawlingContext) -> None:
         visit_urls.add(context.request.url)
-        await context.enqueue_links(rq_name=queue_name, rq_alias=queue_alias)
+        await context.enqueue_links(rq_name=queue_name, rq_alias=queue_alias, rq_id=queue_id)
 
     await crawler.run([str(server_url / 'start_enqueue')])
 
@@ -233,17 +239,23 @@ async def test_enqueue_links_with_rq_param(
 
 
 @pytest.mark.parametrize(
-    ('queue_name', 'queue_alias'),
+    ('queue_name', 'queue_alias', 'by_id'),
     [
-        pytest.param('named-queue', None, id='with rq_name'),
-        pytest.param(None, 'alias-queue', id='with rq_alias'),
+        pytest.param('named-queue', None, False, id='with rq_name'),
+        pytest.param(None, 'alias-queue', False, id='with rq_alias'),
+        pytest.param('id-queue', None, True, id='with rq_id'),
     ],
 )
 async def test_enqueue_links_requests_with_rq_param(
-    server_url: URL, http_client: HttpClient, queue_name: str | None, queue_alias: str | None
+    server_url: URL, http_client: HttpClient, queue_name: str | None, queue_alias: str | None, *, by_id: bool
 ) -> None:
     crawler = BeautifulSoupCrawler(http_client=http_client)
     rq = await RequestQueue.open(name=queue_name, alias=queue_alias)
+    if by_id:
+        queue_name = None
+        queue_id = rq.id
+    else:
+        queue_id = None
     visit_urls: set[str] = set()
 
     check_requests: list[str] = [
@@ -255,7 +267,9 @@ async def test_enqueue_links_requests_with_rq_param(
     @crawler.router.default_handler
     async def handler(context: BeautifulSoupCrawlingContext) -> None:
         visit_urls.add(context.request.url)
-        await context.enqueue_links(requests=check_requests, rq_name=queue_name, rq_alias=queue_alias, strategy='all')
+        await context.enqueue_links(
+            requests=check_requests, rq_name=queue_name, rq_alias=queue_alias, rq_id=queue_id, strategy='all'
+        )
 
     await crawler.run([str(server_url / 'start_enqueue')])
 
@@ -267,12 +281,23 @@ async def test_enqueue_links_requests_with_rq_param(
     assert visit_urls == {str(server_url / 'start_enqueue')}
 
 
-async def test_enqueue_links_error_with_rq_alias_and_rq_name(server_url: URL, http_client: HttpClient) -> None:
+@pytest.mark.parametrize(
+    ('queue_name', 'queue_alias', 'queue_id'),
+    [
+        pytest.param('named-queue', 'alias-queue', None, id='rq_name and rq_alias'),
+        pytest.param('named-queue', None, 'id-queue', id='rq_name and rq_id'),
+        pytest.param(None, 'alias-queue', 'id-queue', id='rq_alias and rq_id'),
+        pytest.param('named-queue', 'alias-queue', 'id-queue', id='rq_name and rq_alias and rq_id'),
+    ],
+)
+async def test_enqueue_links_error_with_multi_params(
+    server_url: URL, http_client: HttpClient, queue_name: str | None, queue_alias: str | None, queue_id: str | None
+) -> None:
     crawler = BeautifulSoupCrawler(http_client=http_client)
 
     @crawler.router.default_handler
     async def handler(context: BeautifulSoupCrawlingContext) -> None:
         with pytest.raises(ValueError, match='Cannot use both `rq_name` and `rq_alias`'):
-            await context.enqueue_links(rq_name='named-queue', rq_alias='alias-queue')
+            await context.enqueue_links(rq_name=queue_name, rq_alias=queue_alias, rq_id=queue_id)
 
     await crawler.run([str(server_url / 'start_enqueue')])

--- a/tests/unit/crawlers/_beautifulsoup/test_beautifulsoup_crawler.py
+++ b/tests/unit/crawlers/_beautifulsoup/test_beautifulsoup_crawler.py
@@ -226,7 +226,7 @@ async def test_enqueue_links_with_rq_param(
     @crawler.router.default_handler
     async def handler(context: BeautifulSoupCrawlingContext) -> None:
         visit_urls.add(context.request.url)
-        await context.enqueue_links(rq_name=queue_name, rq_alias=queue_alias, rq_id=queue_id)
+        await context.enqueue_links(rq_id=queue_id, rq_name=queue_name, rq_alias=queue_alias)
 
     await crawler.run([str(server_url / 'start_enqueue')])
 
@@ -282,7 +282,7 @@ async def test_enqueue_links_requests_with_rq_param(
 
 
 @pytest.mark.parametrize(
-    ('queue_name', 'queue_alias', 'queue_id'),
+    ('queue_id', 'queue_name', 'queue_alias'),
     [
         pytest.param('named-queue', 'alias-queue', None, id='rq_name and rq_alias'),
         pytest.param('named-queue', None, 'id-queue', id='rq_name and rq_id'),
@@ -291,13 +291,13 @@ async def test_enqueue_links_requests_with_rq_param(
     ],
 )
 async def test_enqueue_links_error_with_multi_params(
-    server_url: URL, http_client: HttpClient, queue_name: str | None, queue_alias: str | None, queue_id: str | None
+    server_url: URL, http_client: HttpClient, queue_id: str | None, queue_name: str | None, queue_alias: str | None
 ) -> None:
     crawler = BeautifulSoupCrawler(http_client=http_client)
 
     @crawler.router.default_handler
     async def handler(context: BeautifulSoupCrawlingContext) -> None:
         with pytest.raises(ValueError, match='Cannot use both `rq_name` and `rq_alias`'):
-            await context.enqueue_links(rq_name=queue_name, rq_alias=queue_alias, rq_id=queue_id)
+            await context.enqueue_links(rq_id=queue_id, rq_name=queue_name, rq_alias=queue_alias)
 
     await crawler.run([str(server_url / 'start_enqueue')])

--- a/tests/unit/crawlers/_parsel/test_parsel_crawler.py
+++ b/tests/unit/crawlers/_parsel/test_parsel_crawler.py
@@ -331,6 +331,8 @@ async def test_enqueue_links_with_rq_param(
     assert set(requests_from_queue) == {str(server_url / 'page_1'), str(server_url / 'sub_index')}
     assert visit_urls == {str(server_url / 'start_enqueue')}
 
+    await rq.drop()
+
 
 @pytest.mark.parametrize(
     ('queue_name', 'queue_alias', 'by_id'),
@@ -373,6 +375,8 @@ async def test_enqueue_links_requests_with_rq_param(
 
     assert set(requests_from_queue) == set(check_requests)
     assert visit_urls == {str(server_url / 'start_enqueue')}
+
+    await rq.drop()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/crawlers/_parsel/test_parsel_crawler.py
+++ b/tests/unit/crawlers/_parsel/test_parsel_crawler.py
@@ -320,7 +320,7 @@ async def test_enqueue_links_with_rq_param(
     @crawler.router.default_handler
     async def handler(context: ParselCrawlingContext) -> None:
         visit_urls.add(context.request.url)
-        await context.enqueue_links(rq_name=queue_name, rq_alias=queue_alias, rq_id=queue_id)
+        await context.enqueue_links(rq_id=queue_id, rq_name=queue_name, rq_alias=queue_alias)
 
     await crawler.run([str(server_url / 'start_enqueue')])
 
@@ -362,7 +362,7 @@ async def test_enqueue_links_requests_with_rq_param(
     async def handler(context: ParselCrawlingContext) -> None:
         visit_urls.add(context.request.url)
         await context.enqueue_links(
-            requests=check_requests, rq_name=queue_name, rq_alias=queue_alias, rq_id=queue_id, strategy='all'
+            requests=check_requests, rq_id=queue_id, rq_name=queue_name, rq_alias=queue_alias, strategy='all'
         )
 
     await crawler.run([str(server_url / 'start_enqueue')])
@@ -376,7 +376,7 @@ async def test_enqueue_links_requests_with_rq_param(
 
 
 @pytest.mark.parametrize(
-    ('queue_name', 'queue_alias', 'queue_id'),
+    ('queue_id', 'queue_name', 'queue_alias'),
     [
         pytest.param('named-queue', 'alias-queue', None, id='rq_name and rq_alias'),
         pytest.param('named-queue', None, 'id-queue', id='rq_name and rq_id'),
@@ -385,13 +385,13 @@ async def test_enqueue_links_requests_with_rq_param(
     ],
 )
 async def test_enqueue_links_error_with_multi_params(
-    server_url: URL, http_client: HttpClient, queue_name: str | None, queue_alias: str | None, queue_id: str | None
+    server_url: URL, http_client: HttpClient, queue_id: str | None, queue_name: str | None, queue_alias: str | None
 ) -> None:
     crawler = ParselCrawler(http_client=http_client)
 
     @crawler.router.default_handler
     async def handler(context: ParselCrawlingContext) -> None:
         with pytest.raises(ValueError, match='Cannot use both `rq_name` and `rq_alias`'):
-            await context.enqueue_links(rq_name=queue_name, rq_alias=queue_alias, rq_id=queue_id)
+            await context.enqueue_links(rq_id=queue_id, rq_name=queue_name, rq_alias=queue_alias)
 
     await crawler.run([str(server_url / 'start_enqueue')])

--- a/tests/unit/crawlers/_parsel/test_parsel_crawler.py
+++ b/tests/unit/crawlers/_parsel/test_parsel_crawler.py
@@ -298,23 +298,29 @@ async def test_extract_links(server_url: URL, http_client: HttpClient) -> None:
 
 
 @pytest.mark.parametrize(
-    ('queue_name', 'queue_alias'),
+    ('queue_name', 'queue_alias', 'by_id'),
     [
-        pytest.param('named-queue', None, id='with rq_name'),
-        pytest.param(None, 'alias-queue', id='with rq_alias'),
+        pytest.param('named-queue', None, False, id='with rq_name'),
+        pytest.param(None, 'alias-queue', False, id='with rq_alias'),
+        pytest.param('id-queue', None, True, id='with rq_id'),
     ],
 )
 async def test_enqueue_links_with_rq_param(
-    server_url: URL, http_client: HttpClient, queue_name: str | None, queue_alias: str | None
+    server_url: URL, http_client: HttpClient, queue_name: str | None, queue_alias: str | None, *, by_id: bool
 ) -> None:
     crawler = ParselCrawler(http_client=http_client)
     rq = await RequestQueue.open(name=queue_name, alias=queue_alias)
+    if by_id:
+        queue_name = None
+        queue_id = rq.id
+    else:
+        queue_id = None
     visit_urls: set[str] = set()
 
     @crawler.router.default_handler
     async def handler(context: ParselCrawlingContext) -> None:
         visit_urls.add(context.request.url)
-        await context.enqueue_links(rq_name=queue_name, rq_alias=queue_alias)
+        await context.enqueue_links(rq_name=queue_name, rq_alias=queue_alias, rq_id=queue_id)
 
     await crawler.run([str(server_url / 'start_enqueue')])
 
@@ -327,17 +333,23 @@ async def test_enqueue_links_with_rq_param(
 
 
 @pytest.mark.parametrize(
-    ('queue_name', 'queue_alias'),
+    ('queue_name', 'queue_alias', 'by_id'),
     [
-        pytest.param('named-queue', None, id='with rq_name'),
-        pytest.param(None, 'alias-queue', id='with rq_alias'),
+        pytest.param('named-queue', None, False, id='with rq_name'),
+        pytest.param(None, 'alias-queue', False, id='with rq_alias'),
+        pytest.param('id-queue', None, True, id='with rq_id'),
     ],
 )
 async def test_enqueue_links_requests_with_rq_param(
-    server_url: URL, http_client: HttpClient, queue_name: str | None, queue_alias: str | None
+    server_url: URL, http_client: HttpClient, queue_name: str | None, queue_alias: str | None, *, by_id: bool
 ) -> None:
     crawler = ParselCrawler(http_client=http_client)
     rq = await RequestQueue.open(name=queue_name, alias=queue_alias)
+    if by_id:
+        queue_name = None
+        queue_id = rq.id
+    else:
+        queue_id = None
     visit_urls: set[str] = set()
 
     check_requests: list[str] = [
@@ -349,7 +361,9 @@ async def test_enqueue_links_requests_with_rq_param(
     @crawler.router.default_handler
     async def handler(context: ParselCrawlingContext) -> None:
         visit_urls.add(context.request.url)
-        await context.enqueue_links(requests=check_requests, rq_name=queue_name, rq_alias=queue_alias, strategy='all')
+        await context.enqueue_links(
+            requests=check_requests, rq_name=queue_name, rq_alias=queue_alias, rq_id=queue_id, strategy='all'
+        )
 
     await crawler.run([str(server_url / 'start_enqueue')])
 
@@ -361,12 +375,23 @@ async def test_enqueue_links_requests_with_rq_param(
     assert visit_urls == {str(server_url / 'start_enqueue')}
 
 
-async def test_enqueue_links_error_with_rq_alias_and_rq_name(server_url: URL, http_client: HttpClient) -> None:
+@pytest.mark.parametrize(
+    ('queue_name', 'queue_alias', 'queue_id'),
+    [
+        pytest.param('named-queue', 'alias-queue', None, id='rq_name and rq_alias'),
+        pytest.param('named-queue', None, 'id-queue', id='rq_name and rq_id'),
+        pytest.param(None, 'alias-queue', 'id-queue', id='rq_alias and rq_id'),
+        pytest.param('named-queue', 'alias-queue', 'id-queue', id='rq_name and rq_alias and rq_id'),
+    ],
+)
+async def test_enqueue_links_error_with_multi_params(
+    server_url: URL, http_client: HttpClient, queue_name: str | None, queue_alias: str | None, queue_id: str | None
+) -> None:
     crawler = ParselCrawler(http_client=http_client)
 
     @crawler.router.default_handler
     async def handler(context: ParselCrawlingContext) -> None:
         with pytest.raises(ValueError, match='Cannot use both `rq_name` and `rq_alias`'):
-            await context.enqueue_links(rq_name='named-queue', rq_alias='alias-queue')
+            await context.enqueue_links(rq_name=queue_name, rq_alias=queue_alias, rq_id=queue_id)
 
     await crawler.run([str(server_url / 'start_enqueue')])

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -821,6 +821,8 @@ async def test_enqueue_links_with_rq_param(
     assert set(requests_from_queue) == {str(server_url / 'page_1'), str(server_url / 'sub_index')}
     assert visit_urls == {str(server_url / 'start_enqueue')}
 
+    await rq.drop()
+
 
 @pytest.mark.parametrize(
     ('queue_name', 'queue_alias', 'by_id'),
@@ -863,6 +865,8 @@ async def test_enqueue_links_requests_with_rq_param(
 
     assert set(requests_from_queue) == set(check_requests)
     assert visit_urls == {str(server_url / 'start_enqueue')}
+
+    await rq.drop()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -810,7 +810,7 @@ async def test_enqueue_links_with_rq_param(
     @crawler.router.default_handler
     async def handler(context: PlaywrightCrawlingContext) -> None:
         visit_urls.add(context.request.url)
-        await context.enqueue_links(rq_name=queue_name, rq_alias=queue_alias, rq_id=queue_id)
+        await context.enqueue_links(rq_id=queue_id, rq_name=queue_name, rq_alias=queue_alias)
 
     await crawler.run([str(server_url / 'start_enqueue')])
 
@@ -852,7 +852,7 @@ async def test_enqueue_links_requests_with_rq_param(
     async def handler(context: PlaywrightCrawlingContext) -> None:
         visit_urls.add(context.request.url)
         await context.enqueue_links(
-            requests=check_requests, rq_name=queue_name, rq_alias=queue_alias, rq_id=queue_id, strategy='all'
+            requests=check_requests, rq_id=queue_id, rq_name=queue_name, rq_alias=queue_alias, strategy='all'
         )
 
     await crawler.run([str(server_url / 'start_enqueue')])
@@ -866,7 +866,7 @@ async def test_enqueue_links_requests_with_rq_param(
 
 
 @pytest.mark.parametrize(
-    ('queue_name', 'queue_alias', 'queue_id'),
+    ('queue_id', 'queue_name', 'queue_alias'),
     [
         pytest.param('named-queue', 'alias-queue', None, id='rq_name and rq_alias'),
         pytest.param('named-queue', None, 'id-queue', id='rq_name and rq_id'),
@@ -875,13 +875,13 @@ async def test_enqueue_links_requests_with_rq_param(
     ],
 )
 async def test_enqueue_links_error_with_multi_params(
-    server_url: URL, queue_name: str | None, queue_alias: str | None, queue_id: str | None
+    server_url: URL, queue_id: str | None, queue_name: str | None, queue_alias: str | None
 ) -> None:
     crawler = PlaywrightCrawler()
 
     @crawler.router.default_handler
     async def handler(context: PlaywrightCrawlingContext) -> None:
         with pytest.raises(ValueError, match='Cannot use both `rq_name` and `rq_alias`'):
-            await context.enqueue_links(rq_name=queue_name, rq_alias=queue_alias, rq_id=queue_id)
+            await context.enqueue_links(rq_id=queue_id, rq_name=queue_name, rq_alias=queue_alias)
 
     await crawler.run([str(server_url / 'start_enqueue')])


### PR DESCRIPTION
### Description

- Add support for specifying RQ dst for `add_requests` and `enqueue_links` methods

### Issues

- Closes: #1402 