### PR TITLE
refactor!: Rename storages related methods from `get_` to `open_`

### DIFF
--- a/docs/guides/code_examples/error_handling/handle_proxy_error.py
+++ b/docs/guides/code_examples/error_handling/handle_proxy_error.py
@@ -30,7 +30,7 @@ async def main() -> None:
             )
 
             # Add the new `Request` to the `Queue`
-            rq = await crawler.get_request_manager()
+            rq = await crawler.open_request_manager()
             await rq.add_request(new_request)
 
     await crawler.run(['https://crawlee.dev/'])

--- a/docs/guides/code_examples/error_handling/handle_proxy_error.py
+++ b/docs/guides/code_examples/error_handling/handle_proxy_error.py
@@ -30,7 +30,7 @@ async def main() -> None:
             )
 
             # Add the new `Request` to the `Queue`
-            rq = await crawler.open_request_manager()
+            rq = await crawler.get_request_manager()
             await rq.add_request(new_request)
 
     await crawler.run(['https://crawlee.dev/'])

--- a/docs/upgrading/upgrading_to_v1.md
+++ b/docs/upgrading/upgrading_to_v1.md
@@ -214,13 +214,50 @@ service_locator.set_storage_client(MemoryStorageClient())  # Raises an error
 
 ## BasicCrawler changes
 
-### Removed helper methods for opening storages
-- `BasicCrawler.get_dataset` was removed.
-- `BasicCrawler.get_key_value_store` was removed.
+### Renamed methods for opening storages
+- `BasicCrawler.get_dataset` renamed to `BasicCrawler.open_dataset`
+- `BasicCrawler.get_key_value_store` renamed to `BasicCrawler.open_key_value_store`
 
+### Added method for opening RequestQueue that uses configuration and storage client of the crawler
+- `BasicCrawler.open_request_queue`
 
 ### BasicCrawler has its own instance of ServiceLocator to track its own services
-Explicitly passed services to the crawler can be different the global ones accessible in `crawlee.service_locator`. `BasicCrawler` no longer causes the global services in `service_locator` to be set to the crawler's explicitly passed services. This allows two crawlers with different services at the same time.
+Explicitly passed services to the crawler can be different the global ones accessible in `crawlee.service_locator`. `BasicCrawler` no longer causes the global services in `service_locator` to be set to the crawler's explicitly passed services.
+
+**Before (v0.6):**
+
+```python
+from crawlee import service_locator
+from crawlee.crawlers import BasicCrawler
+from crawlee.storage_clients import MemoryStorageClient
+from crawlee.storages import Dataset
+
+
+async def main() -> None:
+    custom_storage_client = MemoryStorageClient()
+    crawler = BasicCrawler(storage_client=custom_storage_client)
+
+    assert service_locator.get_storage_client() is custom_storage_client
+    assert await crawler.get_dataset() is await Dataset.open()
+```
+**Now (v1.0):**
+
+```python
+from crawlee import service_locator
+from crawlee.crawlers import BasicCrawler
+from crawlee.storage_clients import MemoryStorageClient
+from crawlee.storages import Dataset
+
+
+async def main() -> None:
+    custom_storage_client = MemoryStorageClient()
+    crawler = BasicCrawler(storage_client=custom_storage_client)
+
+    assert service_locator.get_storage_client() is not custom_storage_client
+    assert await crawler.open_dataset() is not await Dataset.open()
+```
+
+This allows two crawlers with different services at the same time.
 
 **Now (v1.0):**
 

--- a/docs/upgrading/upgrading_to_v1.md
+++ b/docs/upgrading/upgrading_to_v1.md
@@ -216,6 +216,7 @@ service_locator.set_storage_client(MemoryStorageClient())  # Raises an error
 Explicitly passed services to the crawler can be different the global ones accessible in `crawlee.service_locator`. `BasicCrawler` no longer causes the global services in `service_locator` to be set to the crawler's explicitly passed services.
 
 **Before (v0.6):**
+
 ```python
 from crawlee import service_locator
 from crawlee.crawlers import BasicCrawler
@@ -228,7 +229,7 @@ async def main() -> None:
     crawler = BasicCrawler(storage_client=custom_storage_client)
 
     assert service_locator.get_storage_client() is custom_storage_client
-    assert await crawler.get_dataset() is await Dataset.open()
+    assert await crawler.open_dataset() is await Dataset.open()
 ```
 **Now (v1.0):**
 
@@ -244,7 +245,7 @@ async def main() -> None:
     crawler = BasicCrawler(storage_client=custom_storage_client)
 
     assert service_locator.get_storage_client() is not custom_storage_client
-    assert await crawler.get_dataset() is not await Dataset.open()
+    assert await crawler.open_dataset() is not await Dataset.open()
 ```
 
 This allows two crawlers with different services at the same time.

--- a/docs/upgrading/upgrading_to_v1.md
+++ b/docs/upgrading/upgrading_to_v1.md
@@ -214,50 +214,13 @@ service_locator.set_storage_client(MemoryStorageClient())  # Raises an error
 
 ## BasicCrawler changes
 
-### Renamed methods for opening storages
-- `BasicCrawler.get_dataset` renamed to `BasicCrawler.open_dataset`
-- `BasicCrawler.get_key_value_store` renamed to `BasicCrawler.open_key_value_store`
+### Removed helper methods for opening storages
+- `BasicCrawler.get_dataset` was removed.
+- `BasicCrawler.get_key_value_store` was removed.
 
-### Added method for opening RequestQueue that uses configuration and storage client of the crawler
-- `BasicCrawler.open_request_queue`
 
 ### BasicCrawler has its own instance of ServiceLocator to track its own services
-Explicitly passed services to the crawler can be different the global ones accessible in `crawlee.service_locator`. `BasicCrawler` no longer causes the global services in `service_locator` to be set to the crawler's explicitly passed services.
-
-**Before (v0.6):**
-
-```python
-from crawlee import service_locator
-from crawlee.crawlers import BasicCrawler
-from crawlee.storage_clients import MemoryStorageClient
-from crawlee.storages import Dataset
-
-
-async def main() -> None:
-    custom_storage_client = MemoryStorageClient()
-    crawler = BasicCrawler(storage_client=custom_storage_client)
-
-    assert service_locator.get_storage_client() is custom_storage_client
-    assert await crawler.get_dataset() is await Dataset.open()
-```
-**Now (v1.0):**
-
-```python
-from crawlee import service_locator
-from crawlee.crawlers import BasicCrawler
-from crawlee.storage_clients import MemoryStorageClient
-from crawlee.storages import Dataset
-
-
-async def main() -> None:
-    custom_storage_client = MemoryStorageClient()
-    crawler = BasicCrawler(storage_client=custom_storage_client)
-
-    assert service_locator.get_storage_client() is not custom_storage_client
-    assert await crawler.open_dataset() is not await Dataset.open()
-```
-
-This allows two crawlers with different services at the same time.
+Explicitly passed services to the crawler can be different the global ones accessible in `crawlee.service_locator`. `BasicCrawler` no longer causes the global services in `service_locator` to be set to the crawler's explicitly passed services. This allows two crawlers with different services at the same time.
 
 **Now (v1.0):**
 

--- a/docs/upgrading/upgrading_to_v1.md
+++ b/docs/upgrading/upgrading_to_v1.md
@@ -215,11 +215,11 @@ service_locator.set_storage_client(MemoryStorageClient())  # Raises an error
 ## BasicCrawler changes
 
 ### Renamed methods for opening storages
-`BasicCrawler.get_dataset` -> `BasicCrawler.open_dataset`
-`BasicCrawler.get_key_value_store` -> `BasicCrawler.open_key_value_store`
+- `BasicCrawler.get_dataset` renamed to `BasicCrawler.open_dataset`
+- `BasicCrawler.get_key_value_store` renamed to `BasicCrawler.open_key_value_store`
 
 ### Added method for opening RequestQueue that uses configuration and storage client of the crawler
-`BasicCrawler.open_request_queue`
+- `BasicCrawler.open_request_queue`
 
 ### BasicCrawler has its own instance of ServiceLocator to track its own services
 Explicitly passed services to the crawler can be different the global ones accessible in `crawlee.service_locator`. `BasicCrawler` no longer causes the global services in `service_locator` to be set to the crawler's explicitly passed services.

--- a/docs/upgrading/upgrading_to_v1.md
+++ b/docs/upgrading/upgrading_to_v1.md
@@ -212,6 +212,15 @@ service_locator.set_storage_client(MemoryStorageClient())
 service_locator.set_storage_client(MemoryStorageClient())  # Raises an error
 ```
 
+## BasicCrawler changes
+
+### Renamed methods for opening storages
+`BasicCrawler.get_dataset` -> `BasicCrawler.open_dataset`
+`BasicCrawler.get_key_value_store` -> `BasicCrawler.open_key_value_store`
+
+### Added method for opening RequestQueue that uses configuration and storage client of the crawler
+`BasicCrawler.open_request_queue`
+
 ### BasicCrawler has its own instance of ServiceLocator to track its own services
 Explicitly passed services to the crawler can be different the global ones accessible in `crawlee.service_locator`. `BasicCrawler` no longer causes the global services in `service_locator` to be set to the crawler's explicitly passed services.
 
@@ -229,7 +238,7 @@ async def main() -> None:
     crawler = BasicCrawler(storage_client=custom_storage_client)
 
     assert service_locator.get_storage_client() is custom_storage_client
-    assert await crawler.open_dataset() is await Dataset.open()
+    assert await crawler.get_dataset() is await Dataset.open()
 ```
 **Now (v1.0):**
 

--- a/src/crawlee/crawlers/_adaptive_playwright/_adaptive_playwright_crawler.py
+++ b/src/crawlee/crawlers/_adaptive_playwright/_adaptive_playwright_crawler.py
@@ -291,7 +291,7 @@ class AdaptivePlaywrightCrawler(
             use_state_function = context.use_state
 
         # New result is created and injected to newly created context. This is done to ensure isolation of sub crawlers.
-        result = RequestHandlerRunResult(key_value_store_getter=self.get_key_value_store)
+        result = RequestHandlerRunResult(key_value_store_getter=self.open_key_value_store)
         context_linked_to_result = BasicCrawlingContext(
             request=deepcopy(context.request),
             session=deepcopy(context.session),

--- a/src/crawlee/crawlers/_adaptive_playwright/_adaptive_playwright_crawler.py
+++ b/src/crawlee/crawlers/_adaptive_playwright/_adaptive_playwright_crawler.py
@@ -291,7 +291,7 @@ class AdaptivePlaywrightCrawler(
             use_state_function = context.use_state
 
         # New result is created and injected to newly created context. This is done to ensure isolation of sub crawlers.
-        result = RequestHandlerRunResult(key_value_store_getter=self.open_key_value_store)
+        result = RequestHandlerRunResult(key_value_store_getter=self._open_key_value_store)
         context_linked_to_result = BasicCrawlingContext(
             request=deepcopy(context.request),
             session=deepcopy(context.session),

--- a/src/crawlee/crawlers/_adaptive_playwright/_adaptive_playwright_crawler.py
+++ b/src/crawlee/crawlers/_adaptive_playwright/_adaptive_playwright_crawler.py
@@ -291,7 +291,7 @@ class AdaptivePlaywrightCrawler(
             use_state_function = context.use_state
 
         # New result is created and injected to newly created context. This is done to ensure isolation of sub crawlers.
-        result = RequestHandlerRunResult(key_value_store_getter=self._open_key_value_store)
+        result = RequestHandlerRunResult(key_value_store_getter=self.open_key_value_store)
         context_linked_to_result = BasicCrawlingContext(
             request=deepcopy(context.request),
             session=deepcopy(context.session),

--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -671,7 +671,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
             request_manager = await self.open_request_manager()
             if purge_request_queue and isinstance(request_manager, RequestQueue):
                 await request_manager.drop()
-                self._request_manager = await self.open_request_manager()
+                self._request_manager = await self.open_request_queue()
 
         if requests is not None:
             await self.add_requests(requests)

--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -563,42 +563,13 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
     async def get_request_manager(self) -> RequestManager:
         """Return the configured request manager. If none is configured, open and return the default request queue."""
         if not self._request_manager:
-            self._request_manager = await self.open_request_queue()
+            self._request_manager = await RequestQueue.open(
+                storage_client=self._service_locator.get_storage_client(),
+                configuration=self._service_locator.get_configuration(),
+            )
         return self._request_manager
 
-    async def open_request_queue(
-        self,
-        *,
-        id: str | None = None,
-        name: str | None = None,
-        alias: str | None = None,
-    ) -> RequestQueue:
-        """Return `RequestQueue` with the given ID or name or alias. If none is provided, return the default one."""
-        return await RequestQueue.open(
-            id=id,
-            name=name,
-            alias=alias,
-            storage_client=self._service_locator.get_storage_client(),
-            configuration=self._service_locator.get_configuration(),
-        )
-
-    async def open_dataset(
-        self,
-        *,
-        id: str | None = None,
-        name: str | None = None,
-        alias: str | None = None,
-    ) -> Dataset:
-        """Return `Dataset` with the given ID or name or alias. If none is provided, return the default one."""
-        return await Dataset.open(
-            id=id,
-            name=name,
-            alias=alias,
-            storage_client=self._service_locator.get_storage_client(),
-            configuration=self._service_locator.get_configuration(),
-        )
-
-    async def open_key_value_store(
+    async def _open_key_value_store(
         self,
         *,
         id: str | None = None,
@@ -671,7 +642,10 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
             request_manager = await self.get_request_manager()
             if purge_request_queue and isinstance(request_manager, RequestQueue):
                 await request_manager.drop()
-                self._request_manager = await self.open_request_queue()
+                self._request_manager = await RequestQueue.open(
+                    storage_client=self._service_locator.get_storage_client(),
+                    configuration=self._service_locator.get_configuration(),
+                )
 
         if requests is not None:
             await self.add_requests(requests)
@@ -805,11 +779,11 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
         self,
         default_value: dict[str, JsonSerializable] | None = None,
     ) -> dict[str, JsonSerializable]:
-        kvs = await self.open_key_value_store()
+        kvs = await self._open_key_value_store()
         return await kvs.get_auto_saved_value(self._CRAWLEE_STATE_KEY, default_value)
 
     async def _save_crawler_state(self) -> None:
-        store = await self.open_key_value_store()
+        store = await self._open_key_value_store()
         await store.persist_autosaved_values()
 
     async def get_data(
@@ -899,7 +873,13 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
             dataset_alias: The alias of the `Dataset` (run scope, unnamed storage).
             kwargs: Keyword arguments to be passed to the `Dataset.push_data()` method.
         """
-        dataset = await self.open_dataset(id=dataset_id, name=dataset_name, alias=dataset_alias)
+        dataset = await Dataset.open(
+            id=dataset_id,
+            name=dataset_name,
+            alias=dataset_alias,
+            storage_client=self._service_locator.get_storage_client(),
+            configuration=self._service_locator.get_configuration(),
+        )
         await dataset.push_data(data, **kwargs)
 
     def _should_retry_request(self, context: BasicCrawlingContext, error: Exception) -> bool:
@@ -1281,7 +1261,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
         for push_data_call in result.push_data_calls:
             await self._push_data(**push_data_call)
 
-        await self._commit_key_value_store_changes(result, get_kvs=self.open_key_value_store)
+        await self._commit_key_value_store_changes(result, get_kvs=self._open_key_value_store)
 
     @staticmethod
     async def _commit_key_value_store_changes(
@@ -1348,7 +1328,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
         else:
             session = await self._get_session()
         proxy_info = await self._get_proxy_info(request, session)
-        result = RequestHandlerRunResult(key_value_store_getter=self.open_key_value_store)
+        result = RequestHandlerRunResult(key_value_store_getter=self._open_key_value_store)
 
         context = BasicCrawlingContext(
             request=request,

--- a/src/crawlee/storages/_storage_instance_manager.py
+++ b/src/crawlee/storages/_storage_instance_manager.py
@@ -187,21 +187,33 @@ class StorageInstanceManager:
         """
         storage_type = type(storage_instance)
 
-        for storage_client_cache in self._cache_by_storage_client.values():
+        for storage_client_type in self._cache_by_storage_client:
             # Remove from ID cache
-            for additional_key in storage_client_cache.by_id[storage_type][storage_instance.id]:
-                del storage_client_cache.by_id[storage_type][storage_instance.id][additional_key]
+            for additional_key in self._cache_by_storage_client[storage_client_type].by_id[storage_type][
+                storage_instance.id
+            ]:
+                del self._cache_by_storage_client[storage_client_type].by_id[storage_type][storage_instance.id][
+                    additional_key
+                ]
                 break
 
             # Remove from name cache or alias cache. It can never be in both.
             if storage_instance.name is not None:
-                for additional_key in storage_client_cache.by_name[storage_type][storage_instance.name]:
-                    del storage_client_cache.by_name[storage_type][storage_instance.name][additional_key]
+                for additional_key in self._cache_by_storage_client[storage_client_type].by_name[storage_type][
+                    storage_instance.name
+                ]:
+                    del self._cache_by_storage_client[storage_client_type].by_name[storage_type][storage_instance.name][
+                        additional_key
+                    ]
                     break
             else:
-                for alias_key in storage_client_cache.by_alias[storage_type]:
-                    for additional_key in storage_client_cache.by_alias[storage_type][alias_key]:
-                        del storage_client_cache.by_alias[storage_type][alias_key][additional_key]
+                for alias_key in self._cache_by_storage_client[storage_client_type].by_alias[storage_type]:
+                    for additional_key in self._cache_by_storage_client[storage_client_type].by_alias[storage_type][
+                        alias_key
+                    ]:
+                        del self._cache_by_storage_client[storage_client_type].by_alias[storage_type][alias_key][
+                            additional_key
+                        ]
                         break
 
     def clear_cache(self) -> None:

--- a/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
+++ b/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
@@ -30,7 +30,7 @@ from crawlee.crawlers._adaptive_playwright._adaptive_playwright_crawling_context
     AdaptiveContextError,
 )
 from crawlee.statistics import Statistics
-from crawlee.storages import Dataset, KeyValueStore
+from crawlee.storages import KeyValueStore
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Iterator
@@ -461,7 +461,7 @@ async def test_adaptive_crawler_exceptions_in_sub_crawlers(*, error_in_pw_crawle
 
     await crawler.run(test_urls[:1])
 
-    dataset = await Dataset.open()
+    dataset = await crawler.open_dataset()
     stored_results = [item async for item in dataset.iterate_items()]
 
     if error_in_pw_crawler:

--- a/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
+++ b/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
@@ -461,7 +461,7 @@ async def test_adaptive_crawler_exceptions_in_sub_crawlers(*, error_in_pw_crawle
 
     await crawler.run(test_urls[:1])
 
-    dataset = await crawler.get_dataset()
+    dataset = await crawler.open_dataset()
     stored_results = [item async for item in dataset.iterate_items()]
 
     if error_in_pw_crawler:

--- a/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
+++ b/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
@@ -30,7 +30,7 @@ from crawlee.crawlers._adaptive_playwright._adaptive_playwright_crawling_context
     AdaptiveContextError,
 )
 from crawlee.statistics import Statistics
-from crawlee.storages import KeyValueStore
+from crawlee.storages import Dataset, KeyValueStore
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Iterator
@@ -461,7 +461,7 @@ async def test_adaptive_crawler_exceptions_in_sub_crawlers(*, error_in_pw_crawle
 
     await crawler.run(test_urls[:1])
 
-    dataset = await crawler.open_dataset()
+    dataset = await Dataset.open()
     stored_results = [item async for item in dataset.iterate_items()]
 
     if error_in_pw_crawler:

--- a/tests/unit/crawlers/_basic/test_basic_crawler.py
+++ b/tests/unit/crawlers/_basic/test_basic_crawler.py
@@ -1551,22 +1551,24 @@ async def test_status_message_emit() -> None:
     assert status_message_listener.called
 
 
-async def test_crawler_purge_request_queue_uses_same_request_manager() -> None:
-    """Make sure that purge on start does not replace the `request_manager`"""
+async def test_crawler_purge_request_queue_uses_same_storage_client() -> None:
+    """Make sure that purge on start does not replace the storage client in the underlying storage manager"""
 
-    # Set some different storage_client that what Crawler is using.
+    # Set some different storage_client globally and different for Crawlee.
     service_locator.set_storage_client(FileSystemStorageClient())
+    unrelated_rq = await RequestQueue.open()
+    unrelated_request = Request.from_url('https://x.placeholder.com')
+    await unrelated_rq.add_request(unrelated_request)
 
-    # Make sure that the Crawler is correctly isolated from global storage client
-    crawler_storage_client = MemoryStorageClient()
-    rq = await RequestQueue.open(storage_client=crawler_storage_client)
-    crawler = BasicCrawler(storage_client=crawler_storage_client)
+    crawler = BasicCrawler(storage_client=MemoryStorageClient())
 
     @crawler.router.default_handler
     async def handler(context: BasicCrawlingContext) -> None:
-        pass
+        context.log.info(context.request.url)
 
     for _ in (1, 2):
         await crawler.run(requests=[Request.from_url('https://a.placeholder.com')], purge_request_queue=True)
         assert crawler.statistics.state.requests_finished == 1
-        assert await crawler.open_request_manager() is rq
+
+    # Crawler should not fall back to the default storage after the purge
+    assert await unrelated_rq.fetch_next_request() == unrelated_request

--- a/tests/unit/crawlers/_basic/test_basic_crawler.py
+++ b/tests/unit/crawlers/_basic/test_basic_crawler.py
@@ -608,7 +608,7 @@ async def test_final_statistics() -> None:
 async def test_crawler_get_storages() -> None:
     crawler = BasicCrawler()
 
-    rp = await crawler.open_request_manager()
+    rp = await crawler.get_request_manager()
     assert isinstance(rp, RequestQueue)
 
     dataset = await crawler.open_dataset()
@@ -1111,7 +1111,7 @@ async def test_crawler_uses_default_storages(tmp_path: Path) -> None:
 
     assert dataset is await crawler.open_dataset()
     assert kvs is await crawler.open_key_value_store()
-    assert rq is await crawler.open_request_manager()
+    assert rq is await crawler.get_request_manager()
 
 
 async def test_crawler_can_use_other_storages(tmp_path: Path) -> None:
@@ -1129,7 +1129,7 @@ async def test_crawler_can_use_other_storages(tmp_path: Path) -> None:
 
     assert dataset is not await crawler.open_dataset()
     assert kvs is not await crawler.open_key_value_store()
-    assert rq is not await crawler.open_request_manager()
+    assert rq is not await crawler.get_request_manager()
 
 
 async def test_crawler_can_use_other_storages_of_same_type(tmp_path: Path) -> None:
@@ -1166,7 +1166,7 @@ async def test_crawler_can_use_other_storages_of_same_type(tmp_path: Path) -> No
     # Assert that the storages are different
     assert dataset is not await crawler.open_dataset()
     assert kvs is not await crawler.open_key_value_store()
-    assert rq is not await crawler.open_request_manager()
+    assert rq is not await crawler.get_request_manager()
 
     # Assert that all storages exists on the filesystem
     for path in expected_paths:

--- a/tests/unit/crawlers/_basic/test_basic_crawler.py
+++ b/tests/unit/crawlers/_basic/test_basic_crawler.py
@@ -611,12 +611,6 @@ async def test_crawler_get_storages() -> None:
     rp = await crawler.get_request_manager()
     assert isinstance(rp, RequestQueue)
 
-    dataset = await crawler.open_dataset()
-    assert isinstance(dataset, Dataset)
-
-    kvs = await crawler.open_key_value_store()
-    assert isinstance(kvs, KeyValueStore)
-
 
 async def test_crawler_run_requests() -> None:
     crawler = BasicCrawler()
@@ -725,7 +719,7 @@ async def test_context_update_kv_store() -> None:
 
     await crawler.run(['https://hello.world'])
 
-    store = await crawler.open_key_value_store()
+    store = await crawler._open_key_value_store()
     assert (await store.get_value('foo')) == 'bar'
 
 
@@ -738,7 +732,7 @@ async def test_context_use_state() -> None:
 
     await crawler.run(['https://hello.world'])
 
-    kvs = await crawler.open_key_value_store()
+    kvs = await crawler._open_key_value_store()
     value = await kvs.get_value(BasicCrawler._CRAWLEE_STATE_KEY)
 
     assert value == {'hello': 'world'}
@@ -781,7 +775,7 @@ async def test_context_handlers_use_state(key_value_store: KeyValueStore) -> Non
     # The state in handler_three must match the final state updated in previous run
     assert state_in_handler_three == {'hello': 'last_world'}
 
-    store = await crawler.open_key_value_store()
+    store = await crawler._open_key_value_store()
 
     # The state in the KVS must match with the last set state
     assert (await store.get_value(BasicCrawler._CRAWLEE_STATE_KEY)) == {'hello': 'last_world'}
@@ -1103,14 +1097,10 @@ async def test_crawler_uses_default_storages(tmp_path: Path) -> None:
     )
     service_locator.set_configuration(configuration)
 
-    dataset = await Dataset.open()
-    kvs = await KeyValueStore.open()
     rq = await RequestQueue.open()
 
     crawler = BasicCrawler()
 
-    assert dataset is await crawler.open_dataset()
-    assert kvs is await crawler.open_key_value_store()
     assert rq is await crawler.get_request_manager()
 
 
@@ -1121,14 +1111,10 @@ async def test_crawler_can_use_other_storages(tmp_path: Path) -> None:
     )
     service_locator.set_configuration(configuration)
 
-    dataset = await Dataset.open()
-    kvs = await KeyValueStore.open()
     rq = await RequestQueue.open()
 
     crawler = BasicCrawler(storage_client=MemoryStorageClient())
 
-    assert dataset is not await crawler.open_dataset()
-    assert kvs is not await crawler.open_key_value_store()
     assert rq is not await crawler.get_request_manager()
 
 
@@ -1138,10 +1124,7 @@ async def test_crawler_can_use_other_storages_of_same_type(tmp_path: Path) -> No
     b_path = tmp_path / 'b'
     a_path.mkdir()
     b_path.mkdir()
-    expected_paths = {
-        path / storage
-        for path, storage in product({a_path, b_path}, {'datasets', 'key_value_stores', 'request_queues'})
-    }
+    expected_paths = {path / storage for path, storage in product({a_path, b_path}, {'request_queues'})}
 
     configuration_a = Configuration(
         crawlee_storage_dir=str(a_path),  # type: ignore[call-arg]
@@ -1156,16 +1139,12 @@ async def test_crawler_can_use_other_storages_of_same_type(tmp_path: Path) -> No
     service_locator.set_configuration(configuration_a)
     service_locator.set_storage_client(FileSystemStorageClient())
     # Create storages based on the global services
-    dataset = await Dataset.open()
-    kvs = await KeyValueStore.open()
     rq = await RequestQueue.open()
 
     # Set the crawler to use different storage client
     crawler = BasicCrawler(storage_client=FileSystemStorageClient(), configuration=configuration_b)
 
     # Assert that the storages are different
-    assert dataset is not await crawler.open_dataset()
-    assert kvs is not await crawler.open_key_value_store()
     assert rq is not await crawler.get_request_manager()
 
     # Assert that all storages exists on the filesystem
@@ -1193,7 +1172,7 @@ async def test_allows_storage_client_overwrite_before_run(monkeypatch: pytest.Mo
         await crawler.run(['https://does-not-matter.com'])
         assert spy.call_count >= 1
 
-    dataset = await crawler.open_dataset()
+    dataset = await Dataset.open()
     data = await dataset.get_data()
     assert data.items == [{'foo': 'bar'}]
 
@@ -1208,7 +1187,7 @@ async def test_context_use_state_race_condition_in_handlers(key_value_store: Key
     from asyncio import Barrier  # type:ignore[attr-defined] # noqa: PLC0415
 
     crawler = BasicCrawler()
-    store = await crawler.open_key_value_store()
+    store = await crawler._open_key_value_store()
     await store.set_value(BasicCrawler._CRAWLEE_STATE_KEY, {'counter': 0})
     handler_barrier = Barrier(2)
 
@@ -1221,7 +1200,7 @@ async def test_context_use_state_race_condition_in_handlers(key_value_store: Key
 
     await crawler.run(['https://crawlee.dev/', 'https://crawlee.dev/docs/quick-start'])
 
-    store = await crawler.open_key_value_store()
+    store = await crawler._open_key_value_store()
     # Ensure that local state is pushed back to kvs.
     await store.persist_autosaved_values()
     assert (await store.get_value(BasicCrawler._CRAWLEE_STATE_KEY))['counter'] == 2

--- a/tests/unit/crawlers/_http/test_http_crawler.py
+++ b/tests/unit/crawlers/_http/test_http_crawler.py
@@ -562,7 +562,7 @@ async def test_error_snapshot_through_statistics(server_url: URL) -> None:
 
     await crawler.run([str(server_url)])
 
-    kvs = await crawler.open_key_value_store()
+    kvs = await crawler._open_key_value_store()
     kvs_content = {}
     async for key_info in kvs.iterate_keys():
         kvs_content[key_info.key] = await kvs.get_value(key_info.key)

--- a/tests/unit/crawlers/_http/test_http_crawler.py
+++ b/tests/unit/crawlers/_http/test_http_crawler.py
@@ -562,7 +562,7 @@ async def test_error_snapshot_through_statistics(server_url: URL) -> None:
 
     await crawler.run([str(server_url)])
 
-    kvs = await crawler._open_key_value_store()
+    kvs = await crawler.open_key_value_store()
     kvs_content = {}
     async for key_info in kvs.iterate_keys():
         kvs_content[key_info.key] = await kvs.get_value(key_info.key)

--- a/tests/unit/crawlers/_http/test_http_crawler.py
+++ b/tests/unit/crawlers/_http/test_http_crawler.py
@@ -562,7 +562,7 @@ async def test_error_snapshot_through_statistics(server_url: URL) -> None:
 
     await crawler.run([str(server_url)])
 
-    kvs = await crawler.get_key_value_store()
+    kvs = await crawler.open_key_value_store()
     kvs_content = {}
     async for key_info in kvs.iterate_keys():
         kvs_content[key_info.key] = await kvs.get_value(key_info.key)

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -627,7 +627,7 @@ async def test_error_snapshot_through_statistics(server_url: URL) -> None:
         [str(server_url), str(server_url / 'page_1'), str(server_url / 'page_2'), str(server_url / 'headers')]
     )
 
-    kvs = await crawler.get_key_value_store()
+    kvs = await crawler.open_key_value_store()
     kvs_content = {}
 
     async for key_info in kvs.iterate_keys():

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -627,7 +627,7 @@ async def test_error_snapshot_through_statistics(server_url: URL) -> None:
         [str(server_url), str(server_url / 'page_1'), str(server_url / 'page_2'), str(server_url / 'headers')]
     )
 
-    kvs = await crawler._open_key_value_store()
+    kvs = await crawler.open_key_value_store()
     kvs_content = {}
 
     async for key_info in kvs.iterate_keys():

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -627,7 +627,7 @@ async def test_error_snapshot_through_statistics(server_url: URL) -> None:
         [str(server_url), str(server_url / 'page_1'), str(server_url / 'page_2'), str(server_url / 'headers')]
     )
 
-    kvs = await crawler.open_key_value_store()
+    kvs = await crawler._open_key_value_store()
     kvs_content = {}
 
     async for key_info in kvs.iterate_keys():


### PR DESCRIPTION
### Description

-Rename:
`BasicCrawler.get_dataset` -> `BasicCrawler.open_dataset `
`BasicCrawler.get_key_value_store` -> `BasicCrawler.open_key_value_store `

-Add:
`BasicCrawler.open_request_queue `

-Fix:
Potential storage client change when running crawler again, and `purge_on_start=True`

### Issues

<!-- If applicable, reference any related GitHub issues -->

- Closes: #1415

### Testing

<!-- Describe the testing process for these changes -->

- Added test

### Checklist

- [ ] CI passed
