### PR TITLE
refactor: Give more instance caching flexibility to the storage clients

### DIFF
--- a/src/crawlee/storage_clients/_base/_storage_client.py
+++ b/src/crawlee/storage_clients/_base/_storage_client.py
@@ -30,7 +30,7 @@ class StorageClient(ABC):
     (where applicable), and consistent access patterns across all storage types it supports.
     """
 
-    def get_additional_cache_key(self, configuration: Configuration) -> Hashable:  # noqa: ARG002
+    def get_storage_client_cache_key(self, configuration: Configuration) -> Hashable:  # noqa: ARG002
         """Return a cache key that can differentiate between different storages of this and other clients.
 
         Can be based on configuration or on the client itself. By default, returns a module and name of the client

--- a/src/crawlee/storage_clients/_base/_storage_client.py
+++ b/src/crawlee/storage_clients/_base/_storage_client.py
@@ -31,11 +31,11 @@ class StorageClient(ABC):
     """
 
     def get_additional_cache_key(self, configuration: Configuration) -> Hashable:  # noqa: ARG002
-        """Return a cache key that can differentiate between different storages of this client.
+        """Return a cache key that can differentiate between different storages of this and other clients.
 
-        Can be based on configuration or on the client itself. By default, returns an empty string.
+        Can be based on configuration or on the client itself. By default, returns a name of the client class.
         """
-        return ''
+        return self.__class__.__name__
 
     @abstractmethod
     async def create_dataset_client(

--- a/src/crawlee/storage_clients/_base/_storage_client.py
+++ b/src/crawlee/storage_clients/_base/_storage_client.py
@@ -33,9 +33,10 @@ class StorageClient(ABC):
     def get_additional_cache_key(self, configuration: Configuration) -> Hashable:  # noqa: ARG002
         """Return a cache key that can differentiate between different storages of this and other clients.
 
-        Can be based on configuration or on the client itself. By default, returns a name of the client class.
+        Can be based on configuration or on the client itself. By default, returns a module and name of the client
+        class.
         """
-        return self.__class__.__name__
+        return f'{self.__class__.__module__}.{self.__class__.__name__}'
 
     @abstractmethod
     async def create_dataset_client(

--- a/src/crawlee/storage_clients/_file_system/_storage_client.py
+++ b/src/crawlee/storage_clients/_file_system/_storage_client.py
@@ -35,9 +35,9 @@ class FileSystemStorageClient(StorageClient):
     """
 
     @override
-    def get_additional_cache_key(self, configuration: Configuration) -> Hashable:
+    def get_storage_client_cache_key(self, configuration: Configuration) -> Hashable:
         # Even different client instances should return same storage if the storage_dir is the same.
-        return super().get_additional_cache_key(configuration), configuration.storage_dir
+        return super().get_storage_client_cache_key(configuration), configuration.storage_dir
 
     @override
     async def create_dataset_client(

--- a/src/crawlee/storage_clients/_file_system/_storage_client.py
+++ b/src/crawlee/storage_clients/_file_system/_storage_client.py
@@ -37,7 +37,7 @@ class FileSystemStorageClient(StorageClient):
     @override
     def get_additional_cache_key(self, configuration: Configuration) -> Hashable:
         # Even different client instances should return same storage if the storage_dir is the same.
-        return configuration.storage_dir
+        return super().get_additional_cache_key(configuration), configuration.storage_dir
 
     @override
     async def create_dataset_client(

--- a/src/crawlee/storages/_dataset.py
+++ b/src/crawlee/storages/_dataset.py
@@ -118,7 +118,6 @@ class Dataset(Storage):
             name=name,
             alias=alias,
             client_opener_coro=client_opener_coro,
-            storage_client_type=storage_client.__class__,
             additional_cache_key=additional_cache_key,
         )
 

--- a/src/crawlee/storages/_dataset.py
+++ b/src/crawlee/storages/_dataset.py
@@ -110,7 +110,7 @@ class Dataset(Storage):
         client_opener_coro = storage_client.create_dataset_client(
             id=id, name=name, alias=alias, configuration=configuration
         )
-        additional_cache_key = storage_client.get_additional_cache_key(configuration=configuration)
+        storage_client_cache_key = storage_client.get_storage_client_cache_key(configuration=configuration)
 
         return await service_locator.storage_instance_manager.open_storage_instance(
             cls,
@@ -118,7 +118,7 @@ class Dataset(Storage):
             name=name,
             alias=alias,
             client_opener_coro=client_opener_coro,
-            additional_cache_key=additional_cache_key,
+            storage_client_cache_key=storage_client_cache_key,
         )
 
     @override

--- a/src/crawlee/storages/_key_value_store.py
+++ b/src/crawlee/storages/_key_value_store.py
@@ -122,15 +122,15 @@ class KeyValueStore(Storage):
         client_opener_coro = storage_client.create_kvs_client(
             id=id, name=name, alias=alias, configuration=configuration
         )
-        additional_cache_key = storage_client.get_additional_cache_key(configuration=configuration)
+        additional_cache_key = storage_client.get_storage_client_cache_key(configuration=configuration)
 
         return await service_locator.storage_instance_manager.open_storage_instance(
             cls,
             id=id,
             name=name,
-            client_opener_coro=client_opener_coro,
             alias=alias,
-            additional_cache_key=additional_cache_key,
+            client_opener_coro=client_opener_coro,
+            storage_client_cache_key=additional_cache_key,
         )
 
     @override

--- a/src/crawlee/storages/_key_value_store.py
+++ b/src/crawlee/storages/_key_value_store.py
@@ -130,7 +130,6 @@ class KeyValueStore(Storage):
             name=name,
             client_opener_coro=client_opener_coro,
             alias=alias,
-            storage_client_type=storage_client.__class__,
             additional_cache_key=additional_cache_key,
         )
 

--- a/src/crawlee/storages/_request_queue.py
+++ b/src/crawlee/storages/_request_queue.py
@@ -134,7 +134,6 @@ class RequestQueue(Storage, RequestManager):
             name=name,
             alias=alias,
             client_opener_coro=client_opener_coro,
-            storage_client_type=storage_client.__class__,
             additional_cache_key=additional_cache_key,
         )
 

--- a/src/crawlee/storages/_request_queue.py
+++ b/src/crawlee/storages/_request_queue.py
@@ -126,7 +126,7 @@ class RequestQueue(Storage, RequestManager):
         storage_client = service_locator.get_storage_client() if storage_client is None else storage_client
 
         client_opener_coro = storage_client.create_rq_client(id=id, name=name, alias=alias, configuration=configuration)
-        additional_cache_key = storage_client.get_additional_cache_key(configuration=configuration)
+        additional_cache_key = storage_client.get_storage_client_cache_key(configuration=configuration)
 
         return await service_locator.storage_instance_manager.open_storage_instance(
             cls,
@@ -134,7 +134,7 @@ class RequestQueue(Storage, RequestManager):
             name=name,
             alias=alias,
             client_opener_coro=client_opener_coro,
-            additional_cache_key=additional_cache_key,
+            storage_client_cache_key=additional_cache_key,
         )
 
     @override


### PR DESCRIPTION
### Description

- `StorageClient` type is not an individual storage key and is instead used in an additional cache key (can be overridden).
- This allows `StorageClients` to have better control over caching.

### Issues


- Enables: https://github.com/apify/apify-sdk-python/issues/513

### Testing

- Unit tests

