### PR TITLE
chore: Resolve some warnings in tests

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -29,9 +29,12 @@ if TYPE_CHECKING:
     from crawlee.http_clients._base import HttpClient
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 async def suppress_user_warning() -> AsyncGenerator[None, None]:
-    """Suppress user warnings during tests."""
+    """Suppress user warnings during tests.
+
+    Mostly to suppress warnings about the experimental status of the SqlStorageClient.
+    """
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', UserWarning)
         yield

--- a/tests/unit/crawlers/_basic/test_basic_crawler.py
+++ b/tests/unit/crawlers/_basic/test_basic_crawler.py
@@ -1504,7 +1504,7 @@ async def test_status_message_callback() -> None:
     async def status_callback(
         state: StatisticsState, previous_state: StatisticsState | None, message: str
     ) -> str | None:
-        status_message_callback(message)
+        await status_message_callback(message)
         states.append({'state': state, 'previous_state': previous_state})
         return message
 

--- a/tests/unit/storage_clients/_sql/test_sql_dataset_client.py
+++ b/tests/unit/storage_clients/_sql/test_sql_dataset_client.py
@@ -39,7 +39,6 @@ def get_tables(sync_conn: Connection) -> list[str]:
 async def dataset_client(
     configuration: Configuration,
     monkeypatch: pytest.MonkeyPatch,
-    suppress_user_warning: None,  # noqa: ARG001
 ) -> AsyncGenerator[SqlDatasetClient, None]:
     """A fixture for a SQL dataset client."""
     async with SqlStorageClient() as storage_client:
@@ -52,7 +51,6 @@ async def dataset_client(
         await client.drop()
 
 
-@pytest.mark.usefixtures('suppress_user_warning')
 async def test_create_tables_with_connection_string(configuration: Configuration, tmp_path: Path) -> None:
     """Test that SQL dataset client creates tables with a connection string."""
     storage_dir = tmp_path / 'test_table.db'
@@ -69,7 +67,6 @@ async def test_create_tables_with_connection_string(configuration: Configuration
             assert 'datasets' in tables
 
 
-@pytest.mark.usefixtures('suppress_user_warning')
 async def test_create_tables_with_engine(configuration: Configuration, tmp_path: Path) -> None:
     """Test that SQL dataset client creates tables with a pre-configured engine."""
     storage_dir = tmp_path / 'test_table.db'
@@ -88,7 +85,6 @@ async def test_create_tables_with_engine(configuration: Configuration, tmp_path:
             assert 'datasets' in tables
 
 
-@pytest.mark.usefixtures('suppress_user_warning')
 async def test_tables_and_metadata_record(configuration: Configuration) -> None:
     """Test that SQL dataset creates proper tables and metadata records."""
     async with SqlStorageClient() as storage_client:
@@ -215,7 +211,6 @@ async def test_metadata_record_updates(dataset_client: SqlDatasetClient) -> None
         assert orm_metadata.modified_at == metadata.modified_at
 
 
-@pytest.mark.usefixtures('suppress_user_warning')
 async def test_data_persistence_across_reopens(configuration: Configuration) -> None:
     """Test that data persists correctly when reopening the same dataset."""
     async with SqlStorageClient() as storage_client:

--- a/tests/unit/storage_clients/_sql/test_sql_kvs_client.py
+++ b/tests/unit/storage_clients/_sql/test_sql_kvs_client.py
@@ -35,7 +35,6 @@ def configuration(tmp_path: Path) -> Configuration:
 async def kvs_client(
     configuration: Configuration,
     monkeypatch: pytest.MonkeyPatch,
-    suppress_user_warning: None,  # noqa: ARG001
 ) -> AsyncGenerator[SqlKeyValueStoreClient, None]:
     """A fixture for a SQL key-value store client."""
     async with SqlStorageClient() as storage_client:
@@ -55,7 +54,6 @@ def get_tables(sync_conn: Connection) -> list[str]:
     return inspector.get_table_names()
 
 
-@pytest.mark.usefixtures('suppress_user_warning')
 async def test_create_tables_with_connection_string(configuration: Configuration, tmp_path: Path) -> None:
     """Test that SQL key-value store client creates tables with a connection string."""
     storage_dir = tmp_path / 'test_table.db'
@@ -72,7 +70,6 @@ async def test_create_tables_with_connection_string(configuration: Configuration
             assert 'key_value_store_records' in tables
 
 
-@pytest.mark.usefixtures('suppress_user_warning')
 async def test_create_tables_with_engine(configuration: Configuration, tmp_path: Path) -> None:
     """Test that SQL key-value store client creates tables with a pre-configured engine."""
     storage_dir = tmp_path / 'test_table.db'
@@ -91,7 +88,6 @@ async def test_create_tables_with_engine(configuration: Configuration, tmp_path:
             assert 'key_value_store_records' in tables
 
 
-@pytest.mark.usefixtures('suppress_user_warning')
 async def test_tables_and_metadata_record(configuration: Configuration) -> None:
     """Test that SQL key-value store creates proper tables and metadata records."""
     async with SqlStorageClient() as storage_client:
@@ -264,7 +260,6 @@ async def test_metadata_record_updates(kvs_client: SqlKeyValueStoreClient) -> No
         assert orm_metadata.modified_at == metadata.modified_at
 
 
-@pytest.mark.usefixtures('suppress_user_warning')
 async def test_data_persistence_across_reopens(configuration: Configuration) -> None:
     """Test that data persists correctly when reopening the same key-value store."""
     async with SqlStorageClient() as storage_client:

--- a/tests/unit/storage_clients/_sql/test_sql_rq_client.py
+++ b/tests/unit/storage_clients/_sql/test_sql_rq_client.py
@@ -36,7 +36,6 @@ def configuration(tmp_path: Path) -> Configuration:
 async def rq_client(
     configuration: Configuration,
     monkeypatch: pytest.MonkeyPatch,
-    suppress_user_warning: None,  # noqa: ARG001
 ) -> AsyncGenerator[SqlRequestQueueClient, None]:
     """A fixture for a SQL request queue client."""
     async with SqlStorageClient() as storage_client:
@@ -56,7 +55,6 @@ def get_tables(sync_conn: Connection) -> list[str]:
     return inspector.get_table_names()
 
 
-@pytest.mark.usefixtures('suppress_user_warning')
 async def test_create_tables_with_connection_string(configuration: Configuration, tmp_path: Path) -> None:
     """Test that SQL request queue client creates tables with a connection string."""
     storage_dir = tmp_path / 'test_table.db'
@@ -74,7 +72,6 @@ async def test_create_tables_with_connection_string(configuration: Configuration
             assert 'request_queue_state' in tables
 
 
-@pytest.mark.usefixtures('suppress_user_warning')
 async def test_create_tables_with_engine(configuration: Configuration, tmp_path: Path) -> None:
     """Test that SQL request queue client creates tables with a pre-configured engine."""
     storage_dir = tmp_path / 'test_table.db'
@@ -94,7 +91,6 @@ async def test_create_tables_with_engine(configuration: Configuration, tmp_path:
             assert 'request_queue_state' in tables
 
 
-@pytest.mark.usefixtures('suppress_user_warning')
 async def test_tables_and_metadata_record(configuration: Configuration) -> None:
     """Test that SQL request queue creates proper tables and metadata records."""
     async with SqlStorageClient() as storage_client:
@@ -207,7 +203,6 @@ async def test_metadata_record_updates(rq_client: SqlRequestQueueClient) -> None
         assert orm_metadata.modified_at == metadata.modified_at
 
 
-@pytest.mark.usefixtures('suppress_user_warning')
 async def test_data_persistence_across_reopens(configuration: Configuration) -> None:
     """Test that data persists correctly when reopening the same request queue."""
     async with SqlStorageClient() as storage_client:

--- a/tests/unit/storages/conftest.py
+++ b/tests/unit/storages/conftest.py
@@ -5,10 +5,7 @@ from crawlee.storage_clients import FileSystemStorageClient, MemoryStorageClient
 
 
 @pytest.fixture(params=['memory', 'file_system', 'sql'])
-def storage_client(
-    request: pytest.FixtureRequest,
-    suppress_user_warning: None,  # noqa: ARG001
-) -> StorageClient:
+def storage_client(request: pytest.FixtureRequest) -> StorageClient:
     """Parameterized fixture to test with different storage clients."""
     storage_client: StorageClient
     if request.param == 'memory':


### PR DESCRIPTION
```
 D:\a\crawlee-python\crawlee-python\tests\unit\storages\test_key_value_store.py:1073: UserWarning: The SqlStorageClient is experimental and may change or be removed in future releases.
    pytest.param(SqlStorageClient(), id='tested=SqlStorageClient'),
```  
- `suppress_user_warning` fixture has autouse

```
tests/unit/crawlers/_basic/test_basic_crawler.py::test_status_message_callback
  D:\a\crawlee-python\crawlee-python\tests\unit\crawlers\_basic\test_basic_crawler.py:1507: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    status_message_callback(message)
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
```
- added missing await