### PR TITLE
docs: Add docs versioning section [#1354]

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,3 +213,11 @@ Your code contributions are welcome, and you'll be praised for eternity! If you 
 ## License
 
 This project is licensed under the Apache License 2.0 - see the [LICENSE](https://github.com/apify/crawlee-python/blob/master/LICENSE) file for details.
+
+## Docs Versioning
+
+Crawlee documentation uses version numbers to track updates. Example:
+
+- v1.0.0 → Initial release
+- v1.1.0 → Added new guides
+- v1.2.0 → Minor fixes and typos


### PR DESCRIPTION
### Description

Added Docs Versioning section to README.md as per issue #1354.  
All crawlee persistance names should be valid names for Apify platform.

### Issues

- Closes: #1354

### Testing

- Verified README.md locally
- Checked formatting in VSCode

### Checklist

- [x] CI passed (if applicable)
- [x] Changes are saved and committed
