### PR TITLE
fix: Improve indexing of the `request_queue_records` table for `SqlRequestQueueClient`

### DIFF
--- a/src/crawlee/storage_clients/_sql/_db_models.py
+++ b/src/crawlee/storage_clients/_sql/_db_models.py
@@ -206,7 +206,7 @@ class RequestDb(Base):
             'request_queue_id',
             'is_handled',
             'sequence_number',
-            postgresql_where=text('is_handled = false'),
+            postgresql_where=text('is_handled is false'),
         ),
     )
 


### PR DESCRIPTION
### Description

- This PR improves the index for the `request_queue_records` table, as the previous version of the index was not efficient for retrieving requests.

EXPLAIN result for over a million requests
Old index

<img width="1133" height="573" alt="image" src="https://github.com/user-attachments/assets/6c75d6ac-bd86-4b8e-9abf-3dc897a42ad7" />

New index

<img width="1028" height="443" alt="image" src="https://github.com/user-attachments/assets/e79780e8-fba7-42e2-aa47-f70d83e8c372" />

### Issues

- Closes: #1526