### PR TITLE
chore: Update dev deps specifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,24 +96,24 @@ crawlee = "crawlee._cli:cli"
 [dependency-groups]
 dev = [
     "apify_client", # For e2e tests.
-    "build~=1.3.0", # For e2e tests.
-    "dycw-pytest-only~=2.1.0",
-    "mypy~=1.18.1",
-    "pre-commit~=4.3.0",
-    "proxy-py~=2.4.0",
-    "pydoc-markdown~=4.8.0",
-    "pytest-asyncio~=1.2.0",
-    "pytest-cov~=7.0.0",
-    "pytest-timeout~=2.4.0",
-    "pytest-xdist~=3.8.0",
-    "pytest~=8.4.0",
+    "build<2.0.0", # For e2e tests.
+    "dycw-pytest-only<3.0.0",
+    "mypy~=1.18.0",
+    "pre-commit<5.0.0",
+    "proxy-py<3.0.0",
+    "pydoc-markdown<5.0.0",
+    "pytest-asyncio<2.0.0",
+    "pytest-cov<8.0.0",
+    "pytest-timeout<3.0.0",
+    "pytest-xdist<4.0.0",
+    "pytest<9.0.0",
     "ruff~=0.14.0",
     "setuptools", # setuptools are used by pytest, but not explicitly required
-    "types-beautifulsoup4~=4.12.0.20240229",
-    "types-cachetools~=6.2.0.20250827",
-    "types-colorama~=0.4.15.20240106",
-    "types-psutil~=7.0.0.20250218",
-    "types-python-dateutil~=2.9.0.20240316",
+    "types-beautifulsoup4<5.0.0",
+    "types-cachetools<7.0.0",
+    "types-colorama<1.0.0",
+    "types-psutil<8.0.0",
+    "types-python-dateutil<3.0.0",
     "uvicorn[standard]~=0.35.0", # https://github.com/apify/crawlee-python/issues/1441
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -875,24 +875,24 @@ provides-extras = ["all", "adaptive-crawler", "beautifulsoup", "cli", "curl-impe
 [package.metadata.requires-dev]
 dev = [
     { name = "apify-client" },
-    { name = "build", specifier = "~=1.3.0" },
-    { name = "dycw-pytest-only", specifier = "~=2.1.0" },
-    { name = "mypy", specifier = "~=1.18.1" },
-    { name = "pre-commit", specifier = "~=4.3.0" },
-    { name = "proxy-py", specifier = "~=2.4.0" },
-    { name = "pydoc-markdown", specifier = "~=4.8.0" },
-    { name = "pytest", specifier = "~=8.4.0" },
-    { name = "pytest-asyncio", specifier = "~=1.2.0" },
-    { name = "pytest-cov", specifier = "~=7.0.0" },
-    { name = "pytest-timeout", specifier = "~=2.4.0" },
-    { name = "pytest-xdist", specifier = "~=3.8.0" },
+    { name = "build", specifier = "<2.0.0" },
+    { name = "dycw-pytest-only", specifier = "<3.0.0" },
+    { name = "mypy", specifier = "~=1.18.0" },
+    { name = "pre-commit", specifier = "<5.0.0" },
+    { name = "proxy-py", specifier = "<3.0.0" },
+    { name = "pydoc-markdown", specifier = "<5.0.0" },
+    { name = "pytest", specifier = "<9.0.0" },
+    { name = "pytest-asyncio", specifier = "<2.0.0" },
+    { name = "pytest-cov", specifier = "<8.0.0" },
+    { name = "pytest-timeout", specifier = "<3.0.0" },
+    { name = "pytest-xdist", specifier = "<4.0.0" },
     { name = "ruff", specifier = "~=0.14.0" },
     { name = "setuptools" },
-    { name = "types-beautifulsoup4", specifier = "~=4.12.0.20240229" },
-    { name = "types-cachetools", specifier = "~=6.2.0.20250827" },
-    { name = "types-colorama", specifier = "~=0.4.15.20240106" },
-    { name = "types-psutil", specifier = "~=7.0.0.20250218" },
-    { name = "types-python-dateutil", specifier = "~=2.9.0.20240316" },
+    { name = "types-beautifulsoup4", specifier = "<5.0.0" },
+    { name = "types-cachetools", specifier = "<7.0.0" },
+    { name = "types-colorama", specifier = "<1.0.0" },
+    { name = "types-psutil", specifier = "<8.0.0" },
+    { name = "types-python-dateutil", specifier = "<3.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = "~=0.35.0" },
 ]
 
@@ -1051,7 +1051,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [


### PR DESCRIPTION
- Switch from tilde version constraints to using only an upper major version bound. Since the lockfile already pins exact versions, the tilde constraint is unnecessary and causes frequent (and unnecessary) Renovate PRs.
- Use major-only upper-bound version specifiers for most development dependencies.
- Keep the tilde specifier for Ruff and Mypy, since even minor updates can—and often do—break CI.
- Updating Uvicorn to a newer version is currently blocked due to incompatibility, so staying with tilde there as well.
