### PR TITLE
chore: update `TestServer` for support `uvicorn` v0.36+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ dev = [
     "types-colorama<1.0.0",
     "types-psutil<8.0.0",
     "types-python-dateutil<3.0.0",
-    "uvicorn[standard]~=0.35.0", # https://github.com/apify/crawlee-python/issues/1441
+    "uvicorn[standard]<1.0.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/tests/unit/server.py
+++ b/tests/unit/server.py
@@ -470,8 +470,9 @@ class TestServer(Server):
         # Set the event loop policy in thread with server for Windows and Python 3.12+.
         # This is necessary because there are problems with closing connections when using `ProactorEventLoop`
         if sys.version_info >= (3, 12) and sys.platform == 'win32':
-            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+            return asyncio.run(self.serve(sockets=sockets), loop_factory=asyncio.SelectorEventLoop)
         super().run(sockets=sockets)
+        return None
 
 
 def serve_in_thread(server: TestServer) -> Iterator[TestServer]:

--- a/uv.lock
+++ b/uv.lock
@@ -888,7 +888,7 @@ dev = [
     { name = "types-colorama", specifier = "<1.0.0" },
     { name = "types-psutil", specifier = "<8.0.0" },
     { name = "types-python-dateutil", specifier = "<3.0.0" },
-    { name = "uvicorn", extras = ["standard"], specifier = "~=0.35.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = "<1.0.0" },
 ]
 
 [[package]]
@@ -1046,7 +1046,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -3762,16 +3762,16 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.35.0"
+version = "0.38.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/42/e0e305207bb88c6b8d3061399c6a961ffe5fbb7e2aa63c9234df7259e9cd/uvicorn-0.35.0.tar.gz", hash = "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01", size = 78473, upload-time = "2025-06-28T16:15:46.058Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/ce/f06b84e2697fef4688ca63bdb2fdf113ca0a3be33f94488f2cadb690b0cf/uvicorn-0.38.0.tar.gz", hash = "sha256:fd97093bdd120a2609fc0d3afe931d4d4ad688b6e75f0f929fde1bc36fe0e91d", size = 80605, upload-time = "2025-10-18T13:46:44.63Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl", hash = "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a", size = 66406, upload-time = "2025-06-28T16:15:44.816Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/d9/d88e73ca598f4f6ff671fb5fde8a32925c2e08a637303a1d12883c7305fa/uvicorn-0.38.0-py3-none-any.whl", hash = "sha256:48c0afd214ceb59340075b4a052ea1ee91c16fbc2a9b1469cca0e54566977b02", size = 68109, upload-time = "2025-10-18T13:46:42.958Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
### Description

The update is necessary because `uvicorn` changed the initialization of `asyncio` and no longer receives the set policies. This was the reason why the configuration using `SelectorEventLoop` for Windows was not applied.