### PR TITLE
docs: fix the overlapping `LLMButtons` dropdown

### DIFF
--- a/website/src/components/LLMButtons.module.css
+++ b/website/src/components/LLMButtons.module.css
@@ -66,7 +66,7 @@
   .menuDropdown {
     position: absolute;
     right: 0;
-    margin-top: 0.5rem;
+    top: calc(100% + 0.5rem); 
     padding: 0.375rem;
     border-radius: 0.75rem;
     border: 1px solid var(--color-separator);


### PR DESCRIPTION
closes: https://github.com/apify/apify-web/issues/5575
Fix the overllaping Menu
<img width="281" height="337" alt="image" src="https://github.com/user-attachments/assets/fb9b6e1e-83cc-4e51-a727-240cd8128e7c" />
