### PR TITLE
fix: Create correct statistics for `AdaptivePlaywrightCrawler` on initialization with a custom parser

### DIFF
--- a/src/crawlee/crawlers/_adaptive_playwright/_adaptive_playwright_crawler.py
+++ b/src/crawlee/crawlers/_adaptive_playwright/_adaptive_playwright_crawler.py
@@ -157,7 +157,9 @@ class AdaptivePlaywrightCrawler(
         if 'concurrency_settings' not in kwargs or kwargs['concurrency_settings'] is None:
             kwargs['concurrency_settings'] = ConcurrencySettings(desired_concurrency=1)
 
-        super().__init__(statistics=statistics, **kwargs)
+        adaptive_statistics = statistics or Statistics(state_model=AdaptivePlaywrightCrawlerStatisticState)
+
+        super().__init__(statistics=adaptive_statistics, **kwargs)
 
         # Sub crawlers related.
         playwright_crawler_specific_kwargs = playwright_crawler_specific_kwargs or {}


### PR DESCRIPTION
### Description

- Create correct statistics for `AdaptivePlaywrightCrawler` on initialization with a custom parser without classmethods like `with_beautifulsoup_static_parser` and `with_parsel_static_parser`.

### Issues

- Closes: #1630 