### PR TITLE
docs: Remove `statistics` param for `AdaptivePlaywrightCrawler`  example in `HTTP crawlers` guide

### DIFF
--- a/docs/guides/code_examples/http_crawlers/selectolax_adaptive_run.py
+++ b/docs/guides/code_examples/http_crawlers/selectolax_adaptive_run.py
@@ -2,10 +2,8 @@ import asyncio
 
 from crawlee.crawlers import (
     AdaptivePlaywrightCrawler,
-    AdaptivePlaywrightCrawlerStatisticState,
     AdaptivePlaywrightCrawlingContext,
 )
-from crawlee.statistics import Statistics
 
 from .selectolax_parser import SelectolaxLexborParser
 
@@ -15,8 +13,6 @@ async def main() -> None:
         max_requests_per_crawl=10,
         # Use custom Selectolax parser for static content parsing.
         static_parser=SelectolaxLexborParser(),
-        # Set up statistics with AdaptivePlaywrightCrawlerStatisticState.
-        statistics=Statistics(state_model=AdaptivePlaywrightCrawlerStatisticState),
     )
 
     @crawler.router.default_handler


### PR DESCRIPTION
### Description

- follow-up for #1637
