### PR TITLE
fix: prevent get_request from permanently blocking requests

### DIFF
--- a/src/crawlee/storage_clients/_file_system/_request_queue_client.py
+++ b/src/crawlee/storage_clients/_file_system/_request_queue_client.py
@@ -452,8 +452,6 @@ class FileSystemRequestQueueClient(RequestQueueClient):
                 logger.warning(f'Request with unique key "{unique_key}" not found in the queue.')
                 return None
 
-            state = self._state.current_value
-            state.in_progress_requests.add(request.unique_key)
             await self._update_metadata(update_accessed_at=True)
             return request
 


### PR DESCRIPTION
• Fixed a file-system request-queue bug where get_request() incorrectly marked requests as in-progress, which could permanently block them from fetch_next_request(). I removed the side effect and added a regression test to ensure get_request() remains read-only