### PR TITLE
fix: Set default `http3=False` for `ImpitHttpClient`

### DIFF
--- a/src/crawlee/http_clients/_impit.py
+++ b/src/crawlee/http_clients/_impit.py
@@ -92,7 +92,7 @@ class ImpitHttpClient(HttpClient):
         self,
         *,
         persist_cookies_per_session: bool = True,
-        http3: bool = True,
+        http3: bool = False,
         verify: bool = True,
         browser: Browser | None = 'firefox',
         **async_client_kwargs: Any,


### PR DESCRIPTION
### Description

- Set default `http3=False` for `ImpitHttpClient`.Since in some cases the `http3=True` flag causes the proxy to be ignored

### Issues

- Closes: #1683
