### PR TITLE
fix: Reset all counter in metadata with `purge` for `RequestQueue`

### DIFF
--- a/src/crawlee/storage_clients/_file_system/_request_queue_client.py
+++ b/src/crawlee/storage_clients/_file_system/_request_queue_client.py
@@ -312,6 +312,8 @@ class FileSystemRequestQueueClient(RequestQueueClient):
                 update_modified_at=True,
                 update_accessed_at=True,
                 new_pending_request_count=0,
+                new_handled_request_count=0,
+                new_total_request_count=0,
             )
 
             # Invalidate is_empty cache.

--- a/src/crawlee/storage_clients/_memory/_request_queue_client.py
+++ b/src/crawlee/storage_clients/_memory/_request_queue_client.py
@@ -133,6 +133,8 @@ class MemoryRequestQueueClient(RequestQueueClient):
             update_modified_at=True,
             update_accessed_at=True,
             new_pending_request_count=0,
+            new_handled_request_count=0,
+            new_total_request_count=0,
         )
 
     @override

--- a/src/crawlee/storage_clients/_redis/_request_queue_client.py
+++ b/src/crawlee/storage_clients/_redis/_request_queue_client.py
@@ -237,6 +237,8 @@ class RedisRequestQueueClient(RequestQueueClient, RedisClientMixin):
                 update_accessed_at=True,
                 update_modified_at=True,
                 new_pending_request_count=0,
+                new_handled_request_count=0,
+                new_total_request_count=0,
             ),
         )
 

--- a/src/crawlee/storage_clients/_sql/_request_queue_client.py
+++ b/src/crawlee/storage_clients/_sql/_request_queue_client.py
@@ -179,6 +179,8 @@ class SqlRequestQueueClient(RequestQueueClient, SqlClientMixin):
                 update_accessed_at=True,
                 update_modified_at=True,
                 new_pending_request_count=0,
+                new_handled_request_count=0,
+                new_total_request_count=0,
                 force=True,
             )
         )

--- a/tests/unit/storages/test_request_queue.py
+++ b/tests/unit/storages/test_request_queue.py
@@ -629,7 +629,7 @@ async def test_purge(
 
     # Queue should be empty now
     metadata = await rq.get_metadata()
-    assert metadata.total_request_count == 3
+    assert metadata.total_request_count == 0
     assert metadata.pending_request_count == 0
     assert metadata.handled_request_count == 0
     assert await rq.is_empty() is True
@@ -1144,12 +1144,12 @@ async def test_purge_on_start_enabled(storage_client: StorageClient) -> None:
     assert alias_metadata_after.pending_request_count == 0
     assert named_metadata_after.pending_request_count == 2
 
-    assert default_metadata_after.handled_request_count == 1
-    assert alias_metadata_after.handled_request_count == 1
+    assert default_metadata_after.handled_request_count == 0
+    assert alias_metadata_after.handled_request_count == 0
     assert named_metadata_after.handled_request_count == 1
 
-    assert default_metadata_after.total_request_count == 3
-    assert alias_metadata_after.total_request_count == 3
+    assert default_metadata_after.total_request_count == 0
+    assert alias_metadata_after.total_request_count == 0
     assert named_metadata_after.total_request_count == 3
 
     # Clean up


### PR DESCRIPTION
### Description

- Reset all counter in metadata with `purge` for `RequestQueue`. This will be more consistent with JS. Also, saving the `total_request_count` and `handled_request_count` counters causes confusion among users, especially when this happens with the `default` queue.

### Issues

- Closes: #1682
