### PR TITLE
chore: Exclude docs and cookiecutter template from Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
     "extends": ["config:base", ":semanticCommitTypeAll(chore)"],
+    "ignorePaths": ["docs/**", "src/crawlee/project_template/**"],
     "pinVersions": false,
     "separateMajorMinor": false,
     "dependencyDashboard": false,


### PR DESCRIPTION
To eliminate artifact update problems - https://github.com/apify/crawlee-python/pull/1687#issuecomment-3797712615