### PR TITLE
ci: Increase unit tests concurrency from 2 to 8

### DIFF
--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -17,4 +17,4 @@ jobs:
       operating_systems: '["ubuntu-latest", "windows-latest", "macos-latest"]'
       python_version_for_codecov: "3.14"
       operating_system_for_codecov: ubuntu-latest
-      tests_concurrency: "1"
+      tests_concurrency: "8"


### PR DESCRIPTION
Increase unit tests concurrency from 2 to 8, to make them faster and identify all the weak points.