### PR TITLE
fix: Prevent mutation of default URL patterns list in `block_requests`

### DIFF
--- a/src/crawlee/crawlers/_playwright/_utils.py
+++ b/src/crawlee/crawlers/_playwright/_utils.py
@@ -88,8 +88,7 @@ async def block_requests(
         url_patterns: List of URL patterns to block. If None, uses default patterns.
         extra_url_patterns: Additional URL patterns to append to the main patterns list.
     """
-    url_patterns = url_patterns or _DEFAULT_BLOCK_REQUEST_URL_PATTERNS
-
+    url_patterns = list(url_patterns or _DEFAULT_BLOCK_REQUEST_URL_PATTERNS)
     url_patterns.extend(extra_url_patterns or [])
 
     browser_type = page.context.browser.browser_type.name if page.context.browser else 'undefined'


### PR DESCRIPTION
When `url_patterns` was `None`, the code assigned it to the module-level `_DEFAULT_BLOCK_REQUEST_URL_PATTERNS` constant and then called `extend()` on it, permanently mutating the shared default list. This caused `extra_url_patterns` to accumulate across all subsequent calls that used the default patterns.

Fixed by creating a copy of the list before extending it.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>