### PR TITLE
fix: Prevent list modification during iteration in BrowserPool

### DIFF
--- a/src/crawlee/browsers/_browser_pool.py
+++ b/src/crawlee/browsers/_browser_pool.py
@@ -346,14 +346,14 @@ class BrowserPool:
 
     def _identify_inactive_browsers(self) -> None:
         """Identify inactive browsers and move them to the inactive list if their idle time exceeds the threshold."""
-        for browser in self._active_browsers:
+        for browser in list(self._active_browsers):
             if browser.idle_time >= self._browser_inactive_threshold:
                 self._active_browsers.remove(browser)
                 self._inactive_browsers.append(browser)
 
     async def _close_inactive_browsers(self) -> None:
         """Close the browsers that have no active pages and have been idle for a certain period."""
-        for browser in self._inactive_browsers:
+        for browser in list(self._inactive_browsers):
             if not browser.pages:
                 await browser.close()
                 self._inactive_browsers.remove(browser)


### PR DESCRIPTION
Both `_identify_inactive_browsers` and `_close_inactive_browsers` methods were modifying their respective lists (`_active_browsers` and `_inactive_browsers`) while iterating over them. This is a classic bug that can cause items to be skipped or raise `RuntimeError`.

The fix iterates over a copy of the list (`list(...)`) while modifying the original, ensuring all items are properly processed.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>