### PR TITLE
fix: Keep None values for `user_data` in `Request`

### DIFF
--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -217,7 +217,7 @@ class Request(BaseModel):
                 lambda instance: user_data_adapter.dump_python(
                     instance,
                     by_alias=True,
-                    exclude_none=True,
+                    exclude_none=False,
                     exclude_unset=True,
                     exclude_defaults=True,
                 )


### PR DESCRIPTION
### Description

- This PR fixes loss of `None` values in `user_data` during `Request` serialization

### Issues

- Closes: #1706
