### PR TITLE
feat: Dynamic memory snapshots 

### DIFF
--- a/src/crawlee/_autoscaling/_types.py
+++ b/src/crawlee/_autoscaling/_types.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
+
+from pydantic import Field
+from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 if TYPE_CHECKING:
-    from crawlee._utils.byte_size import ByteSize, Ratio
+    from crawlee._utils.byte_size import ByteSize
 
 SYSTEM_WIDE_MEMORY_OVERLOAD_THRESHOLD = 0.97
 
@@ -96,12 +99,8 @@ class MemorySnapshot:
     system_wide_used_size: ByteSize | None
     """Memory usage of all processes, system-wide."""
 
-    max_memory_size: ByteSize | Ratio
-    """The maximum memory that can be used by `AutoscaledPool`.
-
-    When of type `ByteSize` then it is used as fixed memory size. When of type `Ratio` then it allows for dynamic memory
-    scaling based on the available system memory.
-    """
+    max_memory_size: ByteSize
+    """The maximum memory that can be used by `AutoscaledPool`."""
 
     system_wide_memory_size: ByteSize | None
     """Total memory available in the whole system."""
@@ -170,3 +169,10 @@ class ClientSnapshot:
 
 
 Snapshot = MemorySnapshot | CpuSnapshot | EventLoopSnapshot | ClientSnapshot
+
+
+@pydantic_dataclass
+class Ratio:
+    """Represents ratio of memory."""
+
+    value: Annotated[float, Field(gt=0.0, le=1.0)]

--- a/src/crawlee/_utils/byte_size.py
+++ b/src/crawlee/_utils/byte_size.py
@@ -1,20 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Annotated, Any
-
-from pydantic import BaseModel, Field
+from typing import Any
 
 _BYTES_PER_KB = 1024
 _BYTES_PER_MB = _BYTES_PER_KB**2
 _BYTES_PER_GB = _BYTES_PER_KB**3
 _BYTES_PER_TB = _BYTES_PER_KB**4
-
-
-class Ratio(BaseModel):
-    """Represents ratio of memory."""
-
-    value: Annotated[float, Field(gt=0.0, le=1.0)]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
### Description

- Add `Ratio` type to represent the maximum relative available memory of the system.
- Allow to initialize the `Snapshotter.max_memory_size` with either `Ratio` (dynamic memory) or `ByteSize` (fixed memory)
- When `Ratio` is used, `Snapshotter` will take into account the current available memory. (Previously, it would take into account only the initial available memory.)

**Top level usage in Crawlers:**
Fixed memory 
```
BasicCrawler(configuration=Configuration(memory_mbytes=1024))
```

Dynamic memory
```
BasicCrawler(configuration=Configuration(available_memory_ratio=0.5))
```

### Issues

- Closes: #1704

### Testing

- Unit test

### Checklist

- [ ] CI passed
