### PR TITLE
ci: Fix arg parsing through poe in CI

### DIFF
--- a/.github/workflows/on_schedule_tests.yaml
+++ b/.github/workflows/on_schedule_tests.yaml
@@ -61,6 +61,6 @@ jobs:
         run: uv run poe install-sync
 
       - name: Run templates end-to-end tests
-        run: uv run poe e2e-templates-tests -- -m "${{ matrix.http-client }} and ${{ matrix.crawler-type }} and ${{ matrix.package-manager }}"
+        run: uv run poe e2e-templates-tests -m "${{ matrix.http-client }} and ${{ matrix.crawler-type }} and ${{ matrix.package-manager }}"
         env:
           APIFY_TEST_USER_API_TOKEN: ${{ secrets.APIFY_TEST_USER_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -306,7 +306,11 @@ uv run pytest \
 """
 
 [tool.poe.tasks.e2e-templates-tests]
-cmd = "uv run pytest --numprocesses=${TESTS_CONCURRENCY:-auto} tests/e2e/project_template"
+cmd = """
+uv run pytest \
+    --numprocesses=${TESTS_CONCURRENCY:-auto} \
+    tests/e2e/project_template
+"""
 
 [tool.poe.tasks.build-docs]
 shell = "./build_api_reference.sh && corepack enable && yarn && yarn build"


### PR DESCRIPTION
### Description

- Fix argument passing through `poe` to `Pytets` in `GitHub` workflow
 
Seems ok: https://github.com/apify/crawlee-python/actions/runs/21825241280 
