### PR TITLE
docs: Add conventional commit types to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,26 @@ To run the documentation locally, ensure you have `Node.js` 20+ installed, then 
 uv run poe run-docs
 ```
 
+## Commits
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) format for commit messages. This convention is used to automatically determine version bumps during the release process.
+
+### Available commit types
+
+| Type | Description |
+| ---- | ----------- |
+| `feat` | A new feature |
+| `fix` | A bug fix |
+| `docs` | Documentation only changes |
+| `style` | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) |
+| `refactor` | A code change that neither fixes a bug nor adds a feature |
+| `perf` | A code change that improves performance |
+| `test` | Adding missing tests or correcting existing tests |
+| `build` | Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm) |
+| `ci` | Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs) |
+| `chore` | Other changes that don't modify src or test files |
+| `revert` | Reverts a previous commit |
+
 ## Release process
 
 Publishing new versions to [PyPI](https://pypi.org/project/crawlee) is automated through GitHub Actions.


### PR DESCRIPTION
## Summary
- Added a new "Commits" section to `CONTRIBUTING.md` with a table of available conventional commit types.
- Placed before the "Release process" section to provide context for how version bumps are determined.

## Test plan
- [ ] Verify the markdown table renders correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)