### PR TITLE
fix: Fix `Snapshotter` handling of out of order samples

### DIFF
--- a/src/crawlee/_autoscaling/snapshotter.py
+++ b/src/crawlee/_autoscaling/snapshotter.py
@@ -279,8 +279,8 @@ class Snapshotter:
         )
 
         snapshots = cast('list[Snapshot]', self._cpu_snapshots)
-        self._prune_snapshots(snapshots, event_data.cpu_info.created_at)
         self._cpu_snapshots.add(snapshot)
+        self._prune_snapshots(snapshots, self._cpu_snapshots[-1].created_at)
 
     async def _snapshot_memory(self, event_data: EventSystemInfoData) -> None:
         """Capture a snapshot of the current memory usage.
@@ -334,8 +334,8 @@ class Snapshotter:
         )
 
         snapshots = cast('list[Snapshot]', self._memory_snapshots)
-        self._prune_snapshots(snapshots, snapshot.created_at)
         self._memory_snapshots.add(snapshot)
+        self._prune_snapshots(snapshots, self._memory_snapshots[-1].created_at)
 
         self._evaluate_memory_load(
             event_data.memory_info.current_size,
@@ -361,8 +361,8 @@ class Snapshotter:
             snapshot.delay = event_loop_delay
 
         snapshots = cast('list[Snapshot]', self._event_loop_snapshots)
-        self._prune_snapshots(snapshots, snapshot.created_at)
         self._event_loop_snapshots.add(snapshot)
+        self._prune_snapshots(snapshots, self._event_loop_snapshots[-1].created_at)
 
     async def _snapshot_client(self) -> None:
         """Capture a snapshot of the current API state by checking for rate limit errors (HTTP 429).
@@ -385,8 +385,8 @@ class Snapshotter:
         )
 
         snapshots = cast('list[Snapshot]', self._client_snapshots)
-        self._prune_snapshots(snapshots, snapshot.created_at)
         self._client_snapshots.add(snapshot)
+        self._prune_snapshots(snapshots, self._client_snapshots[-1].created_at)
 
     def _prune_snapshots(self, snapshots: list[Snapshot], now: datetime) -> None:
         """Remove snapshots that are older than the `self._snapshot_history`.

--- a/tests/unit/_autoscaling/test_snapshotter.py
+++ b/tests/unit/_autoscaling/test_snapshotter.py
@@ -242,7 +242,7 @@ async def test_snapshot_pruning_removes_outdated_records(
                 cpu_info=CpuInfo(used_ratio=0.5, created_at=now - timedelta(hours=delta)),
                 memory_info=default_memory_info,
             )
-            for delta in [3, 2, 5, 0]  # Out of order timestamps. Snapshotter can not rely on natural ordering.
+            for delta in [0, 3, 2, 5]  # Out of order timestamps. Snapshotter can not rely on natural ordering.
         ]
 
         for event_data in events_data:


### PR DESCRIPTION
### Description:
- Update `test_snapshot_pruning_removes_outdated_records` to remove the expected source of flaky behavior
- The root cause of the flaky test behavior is a design flaw in snapshot handling:
`event_manager.on(event=Event.SYSTEM_INFO, listener=self._snapshot_cpu)` adds `self._snapshot_cpu` listener, but event manager runs sync listeners through `asyncio.to_thread`. `self._snapshot_cpu` modifies in-place instance list (for example `self._cpu_snapshots`) - it does `bisect.insort` and `del` operations on the same list from several threads, which creates oportunity for a race condition.
- Changed order of operations. The new `Snapshot` is now added first, and the pruning of the snapshot list is done based on `Snapshot` with the newest date in the list (the newest date does not have to be the last added Snapshot). This fixes the bug when the last out-of-order `Snapshot` could cause wrong pruning.

### Issues:
Closes: #1734
