### PR TITLE
docs: Update docs about alias storages to match the implementation

### DIFF
--- a/docs/guides/code_examples/storages/opening.py
+++ b/docs/guides/code_examples/storages/opening.py
@@ -10,9 +10,8 @@ async def main() -> None:
     # Unnamed storage with alias (purged on start)
     dataset_unnamed = await Dataset.open(alias='temporary-results')
 
-    # Default unnamed storage (both are equivalent and purged on start)
+    # Default unnamed storage (purged on start)
     dataset_default = await Dataset.open()
-    dataset_default = await Dataset.open(alias='default')
 
 
 if __name__ == '__main__':

--- a/docs/guides/storages.mdx
+++ b/docs/guides/storages.mdx
@@ -83,7 +83,7 @@ Crawlee supports two types of storages:
 
 ### Default storage
 
-Each storage type (<ApiLink to="class/Dataset">`Dataset`</ApiLink>, <ApiLink to="class/KeyValueStore">`KeyValueStore`</ApiLink>, <ApiLink to="class/RequestQueue">`RequestQueue`</ApiLink>) has a default instance that can be accessed without specifying `id`, `name` or `alias`. Default unnamed storage is accessed by calling storage's `open` method without parameters. This is the most common way to use storages in simple crawlers. The special alias `"default"` is equivalent to calling `open` without parameters
+Each storage type (<ApiLink to="class/Dataset">`Dataset`</ApiLink>, <ApiLink to="class/KeyValueStore">`KeyValueStore`</ApiLink>, <ApiLink to="class/RequestQueue">`RequestQueue`</ApiLink>) has a default instance that can be accessed without specifying `id`, `name` or `alias`. Default unnamed storage is accessed by calling storage's `open` method without parameters. This is the most common way to use storages in simple crawlers.
 
 <RunnableCodeBlock className="language-python" language="python">
     {OpeningExample}

--- a/src/crawlee/storages/_storage_instance_manager.py
+++ b/src/crawlee/storages/_storage_instance_manager.py
@@ -117,8 +117,7 @@ class StorageInstanceManager:
             # Validate input parameters.
             raise_if_too_many_kwargs(id=id, name=name, alias=alias)
 
-            # Auto-set alias='default' when no parameters are specified.
-            # Default unnamed storage is equal to alias=default unnamed storage.
+            # Auto-set alias='__default__' when no parameters are specified.
             if not any([name, alias, id]):
                 alias = self._DEFAULT_STORAGE_ALIAS
 


### PR DESCRIPTION
### Description

- Current implementation does not give `alias='default'` any special meaning.
- Unnamed default storage should be accessed without mentioning the alias.

