### PR TITLE
test: Relax timing assertion in `test_abort_works` to fix flaky test

### DIFF
--- a/tests/unit/_autoscaling/test_autoscaled_pool.py
+++ b/tests/unit/_autoscaling/test_autoscaled_pool.py
@@ -87,7 +87,7 @@ async def test_abort_works(system_status: SystemStatus | Mock) -> None:
         await run_task
 
     assert elapsed.wall is not None
-    assert elapsed.wall < 0.3
+    assert elapsed.wall < 5
 
 
 async def test_propagates_exceptions(system_status: SystemStatus | Mock) -> None:


### PR DESCRIPTION
## Summary
- `test_abort_works` was flaky on CI due to an overly tight timing assertion (`< 0.3s`), which left only ~0.2s of headroom after the initial `asyncio.sleep(0.1)`.
- Relaxed the threshold to `5s`, which still validates that `abort()` cancels tasks promptly (vs the 60s task sleep) while being resilient to CI scheduling jitter.

## Failed CI runs
- https://github.com/apify/crawlee-python/actions/runs/22064841619/job/63753881516
- https://github.com/apify/crawlee-python/actions/runs/22095987878/job/63853075484

## Test plan
- [x] Existing `test_abort_works` passes with relaxed threshold
- [x] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)