### PR TITLE
feat: Add `reset` method to `ServiceLocator`

### DIFF
--- a/src/crawlee/_service_locator.py
+++ b/src/crawlee/_service_locator.py
@@ -35,6 +35,12 @@ class ServiceLocator:
         self._event_manager = event_manager
         self._storage_client = storage_client
 
+    def reset(self) -> None:
+        """Reset the service locator."""
+        self._configuration = None
+        self._event_manager = None
+        self._storage_client = None
+
     def get_configuration(self) -> Configuration:
         """Get the configuration."""
         if self._configuration is None:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -64,9 +64,7 @@ def prepare_test_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Callabl
         monkeypatch.setenv('CRAWLEE_STORAGE_DIR', str(tmp_path))
 
         # Reset the services in the service locator.
-        service_locator._configuration = None
-        service_locator._event_manager = None
-        service_locator._storage_client = None
+        service_locator.reset()
         service_locator.storage_instance_manager.clear_cache()
 
         # Verify that the test environment was set up correctly.

--- a/tests/unit/test_service_locator.py
+++ b/tests/unit/test_service_locator.py
@@ -95,3 +95,15 @@ def test_storage_client_conflict() -> None:
 
     with pytest.raises(ServiceConflictError, match=r'StorageClient is already in use.'):
         service_locator.set_storage_client(custom_storage_client)
+
+
+def test_storage_client_overwrite_possible_after_reset() -> None:
+    service_locator.set_event_manager(LocalEventManager())
+    service_locator.set_configuration(Configuration())
+    service_locator.set_storage_client(MemoryStorageClient())
+
+    service_locator.reset()
+
+    service_locator.set_event_manager(LocalEventManager())
+    service_locator.set_configuration(Configuration())
+    service_locator.set_storage_client(MemoryStorageClient())


### PR DESCRIPTION
### Description

- Add `reset` method to service locator to better support tests and multiple `Actor(...)` initialization scenarios

### Issues

- Related to: #[Make Actor consistently reusable without raising ServiceConflictError](https://github.com/apify/apify-sdk-python/issues/678)

### Testing

- Added unit test

### Checklist

- [ ] CI passed
