### PR TITLE
test: Fix flaky test_timeout_in_handler

### DIFF
--- a/tests/unit/crawlers/_basic/test_basic_crawler.py
+++ b/tests/unit/crawlers/_basic/test_basic_crawler.py
@@ -1375,7 +1375,7 @@ async def test_timeout_in_handler(sleep_type: str) -> None:
     # Test is skipped in older Python versions.
     from asyncio import timeout  # type:ignore[attr-defined] # noqa: PLC0415
 
-    non_realtime_system_coefficient = 2
+    non_realtime_system_coefficient = 10
     handler_timeout = timedelta(seconds=1)
     max_request_retries = 3
     double_handler_timeout_s = handler_timeout.total_seconds() * 2


### PR DESCRIPTION
## Summary
- Increased `non_realtime_system_coefficient` from 2 to 10 in `test_timeout_in_handler` to fix CI flakiness
- The outer `asyncio.timeout(12s)` was too tight for slow CI machines (macOS/Windows), causing the crawler run to be cancelled before all 3 retry attempts could complete
- New timeout of 60s provides sufficient headroom while the test still completes in ~2s locally

## Test plan
- [x] Verified test passes consistently locally (5/5 runs in ~2.1s each)
- [x] CI passes on macOS/Windows runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)