### PR TITLE
fix: Fix ` max_requests_per_crawl` excluding failed requests

### DIFF
--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -566,7 +566,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
         if self._max_requests_per_crawl is None:
             return
 
-        if self._statistics.state.requests_finished >= self._max_requests_per_crawl:
+        if self._statistics.state.requests_total >= self._max_requests_per_crawl:
             self.stop(
                 reason=f'The crawler has reached its limit of {self._max_requests_per_crawl} requests per crawl. '
             )


### PR DESCRIPTION
### Description

- `BasicCrawler` should also consider failed requests when deciding if `max_requests_per_crawl` was reached

### Issues

- Closes: #1765

### Testing

- Added unit test

### Checklist

- [ ] CI passed
