### PR TITLE
fix(playwright): dispose of `APIResponse` body for `send_request`

### DIFF
--- a/src/crawlee/crawlers/_playwright/_types.py
+++ b/src/crawlee/crawlers/_playwright/_types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, Protocol, TypedDict
 
-from playwright.async_api import APIResponse, Response
+from playwright.async_api import APIResponse
 
 from crawlee import HttpHeaders
 from crawlee._utils.docs import docs_group
@@ -11,6 +11,7 @@ from crawlee._utils.docs import docs_group
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
+    from playwright.async_api import Response
     from typing_extensions import NotRequired, Self
 
 


### PR DESCRIPTION
### Description

Dispose of Playwright's APIResponse body, otherwise it stays in memory until the context closes.

If not done, this can lead to excessive memory usage during crawling when using `send_request` within a handler.

### Issues

...

### Testing

`send_request` is already covered by tests, so if they pass I think it should be OK.

### Checklist

- [x] CI passed
