### PR TITLE
fix(redis): Do not remove handled request data from request queue

### DIFF
--- a/tests/unit/storage_clients/_redis/test_redis_rq_client.py
+++ b/tests/unit/storage_clients/_redis/test_redis_rq_client.py
@@ -95,17 +95,6 @@ async def test_request_records_persistence(rq_client: RedisRequestQueueClient) -
         assert request_data['url'].startswith('https://example.com/')
 
 
-async def test_handled_request_records_persistence(rq_client: RedisRequestQueueClient) -> None:
-    request = Request.from_url('https://example.com/1')
-    await rq_client.add_batch_of_requests([request])
-    fetched_request = await rq_client.fetch_next_request()
-    assert isinstance(fetched_request, Request)
-    await rq_client.mark_request_as_handled(fetched_request)
-    fetched_request = await rq_client.get_request(request.unique_key)
-    assert isinstance(fetched_request, Request)
-    assert fetched_request.unique_key == request.unique_key
-
-
 async def test_drop_removes_records(rq_client: RedisRequestQueueClient) -> None:
     """Test that drop removes all request records from Redis."""
     await rq_client.add_batch_of_requests([Request.from_url('https://example.com')])

--- a/tests/unit/storages/test_request_queue.py
+++ b/tests/unit/storages/test_request_queue.py
@@ -361,6 +361,17 @@ async def test_get_request_by_id(rq: RequestQueue) -> None:
     assert retrieved_request.url == 'https://example.com'
 
 
+async def test_handled_request_records_persistence(rq: RequestQueue) -> None:
+    request = Request.from_url('https://example.com/1')
+    await rq.add_request(request)
+    fetched_request = await rq.fetch_next_request()
+    assert isinstance(fetched_request, Request)
+    await rq.mark_request_as_handled(fetched_request)
+    fetched_request = await rq.get_request(request.unique_key)
+    assert isinstance(fetched_request, Request)
+    assert fetched_request.unique_key == request.unique_key
+
+
 async def test_get_non_existent_request(rq: RequestQueue) -> None:
     """Test retrieving a request that doesn't exist."""
     non_existent_request = await rq.get_request('non-existent-id')


### PR DESCRIPTION
### Description

Unlike FS and SQL storages that keep handled requests data, Redis removes it.

### Issues

?

### Testing

A dedicated unit test added.

Manual testing: using RedisQueueClient, enqueue a page, run crawler, check if `:data` key holds request info.

### Checklist

- [ ] CI passed
