### PR TITLE
ci: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/_check_code.yaml
+++ b/.github/workflows/_check_code.yaml
@@ -7,6 +7,9 @@ on:
   # Runs when invoked by another workflow.
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   actions_lint_check:
     name: Actions lint check

--- a/.github/workflows/_check_docs.yaml
+++ b/.github/workflows/_check_docs.yaml
@@ -7,6 +7,9 @@ on:
   # Runs when invoked by another workflow.
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   doc_checks:
     name: Doc checks

--- a/.github/workflows/_release_docs.yaml
+++ b/.github/workflows/_release_docs.yaml
@@ -11,6 +11,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: 22
   PYTHON_VERSION: 3.14

--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -7,6 +7,9 @@ on:
   # Runs when invoked by another workflow.
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   unit_tests:
     name: Unit tests

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -25,6 +25,9 @@ concurrency:
   group: release
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   code_checks:
     name: Code checks
@@ -51,6 +54,8 @@ jobs:
   changelog_update:
     name: Changelog update
     needs: [release_prepare]
+    permissions:
+      contents: write
     uses: apify/workflows/.github/workflows/python_bump_and_update_changelog.yaml@main
     with:
       version_number: ${{ needs.release_prepare.outputs.version_number }}
@@ -61,6 +66,8 @@ jobs:
     name: GitHub release
     needs: [release_prepare, changelog_update]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -100,6 +107,10 @@ jobs:
   doc_release:
     name: Doc release
     needs: [changelog_update, pypi_publish]
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     uses: ./.github/workflows/_release_docs.yaml
     with:
       # Use the ref from the changelog update to include the updated changelog.

--- a/.github/workflows/on_issue.yaml
+++ b/.github/workflows/on_issue.yaml
@@ -6,6 +6,9 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   label_issues:
     name: Add labels

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -11,6 +11,9 @@ concurrency:
   group: release
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   doc_checks:
     name: Doc checks
@@ -21,6 +24,10 @@ jobs:
     if: startsWith(github.event.head_commit.message, 'docs')
     name: Doc release
     needs: [doc_checks]
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     uses: ./.github/workflows/_release_docs.yaml
     with:
       # Use the same ref as the one that triggered the workflow.
@@ -64,6 +71,8 @@ jobs:
   changelog_update:
     name: Changelog update
     needs: [release_prepare]
+    permissions:
+      contents: write
     uses: apify/workflows/.github/workflows/python_bump_and_update_changelog.yaml@main
     with:
       version_number: ${{ needs.release_prepare.outputs.version_number }}
@@ -95,6 +104,10 @@ jobs:
   doc_release_post_publish:
     name: Doc release post publish
     needs: [changelog_update, pypi_publish]
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
     uses: ./.github/workflows/_release_docs.yaml
     with:
       # Use the ref from the changelog update to include the updated changelog.

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -4,6 +4,10 @@ on:
   # Runs whenever a pull request is opened or updated.
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   pr_title_check:
     name: PR title check

--- a/.github/workflows/on_schedule_tests.yaml
+++ b/.github/workflows/on_schedule_tests.yaml
@@ -12,6 +12,9 @@ concurrency:
   group: scheduled-tests
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: 22
   PYTHON_VERSION: 3.14


### PR DESCRIPTION
## Summary

- Adds explicit `permissions` blocks to all 9 workflow files (addressing all CodeQL "Workflow does not contain permissions" security alerts).
- Follows the principle of least privilege: `contents: read` as the default, with elevated permissions only on jobs that need write access (releases, changelog updates, docs deployment).
- Pre-existing permissions on `pypi_publish` and `_release_docs.yaml` jobs are preserved.
- Same as apify/apify-client-python#614.

## Test plan

- [ ] Verify CI passes on this PR (code checks, tests, doc checks)
- [ ] Verify release workflows still work correctly (can be validated on next release)
- [ ] Confirm CodeQL alerts are resolved after the next run of CodeQL checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)