### PR TITLE
feat: Expose `use_state` in `BasicCrawler`

### DIFF
--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -840,7 +840,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
             wait_for_all_requests_to_be_added_timeout=wait_for_all_requests_to_be_added_timeout,
         )
 
-    async def _use_state(
+    async def use_state(
         self,
         default_value: dict[str, JsonSerializable] | None = None,
     ) -> dict[str, JsonSerializable]:
@@ -1421,7 +1421,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
             add_requests=result.add_requests,
             push_data=result.push_data,
             get_key_value_store=result.get_key_value_store,
-            use_state=self._use_state,
+            use_state=self.use_state,
             log=self._logger,
         )
         self._context_result_map[context] = result

--- a/tests/unit/crawlers/_basic/test_basic_crawler.py
+++ b/tests/unit/crawlers/_basic/test_basic_crawler.py
@@ -815,6 +815,20 @@ async def test_context_use_state() -> None:
     assert value == {'hello': 'world'}
 
 
+async def test_crawler_use_state() -> None:
+    crawler = BasicCrawler()
+
+    await crawler.use_state({'hello': 'world'})
+
+    @crawler.router.default_handler
+    async def handler(context: BasicCrawlingContext) -> None:
+        # The state set by the crawler must be available in the context of the request handler
+        state = await context.use_state()
+        assert state == {'hello': 'world'}
+
+    await crawler.run(['https://hello.world'])
+
+
 async def test_context_use_state_crawlers_share_state() -> None:
     async def handler(context: BasicCrawlingContext) -> None:
         state = await context.use_state({'urls': []})


### PR DESCRIPTION
### Description

- Expose `use_state` in `BasicCrawler`. This can be useful for passing data initialized during crawler setup into a handler.

Example:

```python
async def main():
    crawler = BasicCrawler()
    await crawler.use_state({'state': 'init'})

    @crawler.router.default_handler
    async def handler(context):
        data = await context.use_state()

        context.log.info(f'State: {data["state"]}')

    await crawler.run(["https://www.example.com/"])


if __name__ == '__main__':
    asyncio.run(main())
```