### PR TITLE
fix(playwright): Validate browser context options before calling launch_persistent_context

### DIFF
--- a/src/crawlee/browsers/_playwright_browser.py
+++ b/src/crawlee/browsers/_playwright_browser.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
 
 logger = getLogger(__name__)
 
+_UNSUPPORTED_PERSISTENT_CONTEXT_OPTIONS = frozenset({'storage_state'})
+
 
 @docs_group('Browser management')
 class PlaywrightPersistentBrowser(Browser):
@@ -58,6 +60,14 @@ class PlaywrightPersistentBrowser(Browser):
         """Create persistent context instead of regular one. Merge launch options with context options."""
         if self._context:
             raise RuntimeError('Persistent browser can have only one context')
+
+        unsupported_options = _UNSUPPORTED_PERSISTENT_CONTEXT_OPTIONS.intersection(context_options)
+        if unsupported_options:
+            unsupported_list = ', '.join(sorted(unsupported_options))
+            raise ValueError(
+                'The following browser_new_context_options are not supported when using a persistent browser '
+                f'context: {unsupported_list}. Use `use_incognito_pages=True` if you need these options.'
+            )
 
         launch_options = self._browser_launch_options | context_options
 

--- a/tests/unit/browsers/test_playwright_browser.py
+++ b/tests/unit/browsers/test_playwright_browser.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
 
 import pytest
 from playwright.async_api import async_playwright
@@ -42,3 +43,13 @@ async def test_delete_temp_folder_with_close_browser(playwright: Playwright) -> 
     assert current_temp_dir.exists()
     await persist_browser.close()
     assert not current_temp_dir.exists()
+
+
+async def test_new_context_rejects_storage_state_for_persistent_browser() -> None:
+    mocked_browser_type = AsyncMock()
+    persist_browser = PlaywrightPersistentBrowser(mocked_browser_type, user_data_dir=None, browser_launch_options={})
+
+    with pytest.raises(ValueError, match='storage_state'):
+        await persist_browser.new_context(storage_state={'cookies': []})
+
+    mocked_browser_type.launch_persistent_context.assert_not_awaited()


### PR DESCRIPTION
Fixes the persistent Playwright browser path so unsupported browser_new_context_options are rejected early with a clear error instead of failing later inside launch_persistent_context(). Adds a regression test covering storage_state.