### PR TITLE
fix: remove double usage_count increment in Session.retire()

### DIFF
--- a/src/crawlee/sessions/_session.py
+++ b/src/crawlee/sessions/_session.py
@@ -217,8 +217,6 @@ class Session:
         to use `mark_bad` method.
         """
         self._error_score += self._max_error_score
-        self._usage_count += 1
-        # Note: We emit an event here because of the Puppeteer in TS implementation.
 
     def is_blocked_status_code(
         self,

--- a/tests/unit/sessions/test_session.py
+++ b/tests/unit/sessions/test_session.py
@@ -82,9 +82,27 @@ def test_multiple_marks(session: Session) -> None:
 
 def test_retire_method(session: Session) -> None:
     """Test that retire method properly sets the session as unusable."""
+    initial_usage_count = session.usage_count
     session.retire()
     assert not session.is_usable
     assert session.error_score == 3.0
+    assert session.usage_count == initial_usage_count
+
+
+def test_mark_good_at_usage_limit_no_double_increment() -> None:
+    """Test that mark_good at max usage count does not double-increment usage_count via retire."""
+    session = Session(max_usage_count=5, usage_count=4)
+    session.mark_good()
+    assert session.usage_count == 5
+    assert not session.is_usable
+
+
+def test_mark_bad_at_usage_limit_no_double_increment() -> None:
+    """Test that mark_bad at max usage count does not double-increment usage_count via retire."""
+    session = Session(max_usage_count=5, usage_count=4)
+    session.mark_bad()
+    assert session.usage_count == 5
+    assert not session.is_usable
 
 
 def test_retire_on_blocked_status_code(session: Session) -> None:


### PR DESCRIPTION
## Summary
- `Session.retire()` incremented `_usage_count`, but callers (`mark_good()`, `mark_bad()`) already increment it before calling `retire()`, causing a double-increment when a session is retired at the usage limit.
- Removed the redundant `_usage_count += 1` from `retire()`.
- Added tests covering the no-double-increment invariant for `mark_good()`, `mark_bad()`, and direct `retire()` calls.

## Test plan
- [x] Existing session tests pass
- [x] New tests verify `usage_count` is incremented exactly once per `mark_good()`/`mark_bad()` call, even when retirement is triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)