### PR TITLE
perf: offload BeautifulSoup parsing to a thread via `asyncio.to_thread`

### DIFF
--- a/src/crawlee/crawlers/_beautifulsoup/_beautifulsoup_parser.py
+++ b/src/crawlee/crawlers/_beautifulsoup/_beautifulsoup_parser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Literal
 
 from bs4 import BeautifulSoup, Tag
@@ -23,11 +24,12 @@ class BeautifulSoupParser(AbstractHttpParser[BeautifulSoup, Tag]):
 
     @override
     async def parse(self, response: HttpResponse) -> BeautifulSoup:
-        return BeautifulSoup(await response.read(), features=self._parser)
+        body = await response.read()
+        return await asyncio.to_thread(BeautifulSoup, body, features=self._parser)
 
     @override
     async def parse_text(self, text: str) -> BeautifulSoup:
-        return BeautifulSoup(text, features=self._parser)
+        return await asyncio.to_thread(BeautifulSoup, text, features=self._parser)
 
     @override
     def is_matching_selector(self, parsed_content: Tag, selector: str) -> bool:


### PR DESCRIPTION
## Summary
- `BeautifulSoup()` constructor performs synchronous HTML parsing that blocks the event loop, degrading concurrency.
- Wrapped `parse()` and `parse_text()` in `asyncio.to_thread()` to offload parsing to a worker thread, consistent with how `ParselParser.parse()` already works.

## Test plan
- [x] All 78 existing BeautifulSoup crawler tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)