### PR TITLE
chore: ignore versioned docs in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
     "extends": ["config:base", ":semanticCommitTypeAll(chore)"],
-    "ignorePaths": ["docs/**", "src/crawlee/project_template/**"],
+    "ignorePaths": ["docs/**", "src/crawlee/project_template/**", "website/versioned_docs/**"],
     "pinVersions": false,
     "separateMajorMinor": false,
     "dependencyDashboard": false,


### PR DESCRIPTION
## Summary
- Add `website/versioned_docs/**` to Renovate `ignorePaths` to prevent artifact update failures caused by `pyproject.toml` files (ruff-only config, no `[project]` table) in versioned docs directories.

See https://github.com/apify/crawlee-python/pull/1820#issuecomment-4153186847

🤖 Generated with [Claude Code](https://claude.com/claude-code)