### PR TITLE
fix: add bounds checking to proxy tier prediction

### DIFF
--- a/src/crawlee/proxy_configuration.py
+++ b/src/crawlee/proxy_configuration.py
@@ -241,6 +241,9 @@ class _ProxyTierTracker:
 
     def predict_tier(self, domain: str) -> int:
         histogram = self._histogram_by_domain[domain]
+        max_tier = len(histogram) - 1
+
+        self._current_tier_by_domain[domain] = max(0, min(max_tier, self._current_tier_by_domain[domain]))
         current_tier = self._current_tier_by_domain[domain]
 
         for index, value in enumerate(histogram):
@@ -250,12 +253,14 @@ class _ProxyTierTracker:
                 histogram[index] -= 1
 
         left = histogram[current_tier - 1] if current_tier > 0 else float('inf')
-        right = histogram[current_tier + 1] if current_tier < len(histogram) - 1 else float('inf')
+        right = histogram[current_tier + 1] if current_tier < max_tier else float('inf')
 
         if histogram[current_tier] > min(left, right):
             self._current_tier_by_domain[domain] = current_tier - 1 if left <= right else current_tier + 1
         elif histogram[current_tier] == left:
             self._current_tier_by_domain[domain] -= 1
+
+        self._current_tier_by_domain[domain] = max(0, min(max_tier, self._current_tier_by_domain[domain]))
 
         return self._current_tier_by_domain[domain]
 

--- a/tests/unit/proxy_configuration/test_tiers.py
+++ b/tests/unit/proxy_configuration/test_tiers.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from yarl import URL
+
 from crawlee import Request
-from crawlee.proxy_configuration import ProxyConfiguration
+from crawlee.proxy_configuration import ProxyConfiguration, _ProxyTierTracker
 
 
 async def test_rotates_proxies_uniformly_with_no_request() -> None:
@@ -176,3 +178,15 @@ async def test_none_proxy_rotates_proxies_uniformly_with_no_request() -> None:
     # Proxy rotation starts from the beginning of the proxy list after last proxy in tier was used. No proxy used again.
     info = await config.new_proxy_info(None, None, None)
     assert info is None, 'First entry in tired_proxy_urls is None. config.new_proxy_info is expected to generate None.'
+
+
+def test_predict_tier_bounds_with_single_tier() -> None:
+    """With a single tier, predict_tier should always return 0."""
+    tracker = _ProxyTierTracker([[URL('http://proxy:1111')]])
+    tracker.add_error('example.com', 0)
+
+    # Each call mutates internal state (decaying histogram, potentially shifting tiers). The error score starts
+    # at 10 and decays by 1 per call, so 20 iterations covers the full decay to zero and beyond.
+    for _ in range(20):
+        tier = tracker.predict_tier('example.com')
+        assert tier == 0


### PR DESCRIPTION
## Summary
- Add bounds clamping in `_ProxyTierTracker.predict_tier()` to prevent negative or out-of-bounds tier index that could cause `IndexError` on proxy selection
- Normalize stored tier on entry and clamp after adjustment, using a cached `max_tier` local

## Test plan
- [x] Added `test_predict_tier_bounds_with_single_tier` to verify tier stays at 0 across repeated calls with a single-tier config
- [x] All existing proxy tier tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)