### PR TITLE
docs: port docs fixes from apify-docs

### DIFF
--- a/website/patches/@signalwire+docusaurus-plugin-llms-txt+1.2.2.patch
+++ b/website/patches/@signalwire+docusaurus-plugin-llms-txt+1.2.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@signalwire/docusaurus-plugin-llms-txt/lib/transformation/plugins/plugin-registry.js b/node_modules/@signalwire/docusaurus-plugin-llms-txt/lib/transformation/plugins/plugin-registry.js
+index f35c2df..4d8b9bd 100644
+--- a/node_modules/@signalwire/docusaurus-plugin-llms-txt/lib/transformation/plugins/plugin-registry.js
++++ b/node_modules/@signalwire/docusaurus-plugin-llms-txt/lib/transformation/plugins/plugin-registry.js
+@@ -73,7 +73,7 @@ export class PluginRegistry {
+         }
+         // Always last - converts HTML AST to Markdown AST
+         processor.use(rehypeRemark, {
+-            handlers: { br: () => ({ type: 'html', value: '<br />' }) },
++            handlers: { br: () => ({ type: 'break' }) },
+         });
+     }
+     /**

--- a/website/roa-loader/index.js
+++ b/website/roa-loader/index.js
@@ -3,11 +3,13 @@ const { inspect } = require('node:util');
 
 const { urlToRequest } = require('loader-utils');
 
+const SIGNING_TOKEN = process.env.APIFY_SIGNING_TOKEN;
 const signingUrl = new URL('https://api.apify.com/v2/tools/encode-and-sign');
-signingUrl.searchParams.set('token', process.env.APIFY_SIGNING_TOKEN);
+signingUrl.searchParams.set('token', SIGNING_TOKEN || '');
 const queue = [];
 const cache = {};
 let working = false;
+let warnedAboutMissingToken = false;
 
 function hash(source) {
     return createHash('sha1').update(source).digest('hex');
@@ -87,6 +89,15 @@ async function encodeAndSign(source) {
 module.exports = async function (code) {
     if (process.env.CRAWLEE_DOCS_FAST) {
         return { code, hash: 'fast' };
+    }
+
+    // Skip signing if token is not configured
+    if (!SIGNING_TOKEN) {
+        if (!warnedAboutMissingToken) {
+            console.warn('APIFY_SIGNING_TOKEN is not set, skipping code signing for runnable examples.');
+            warnedAboutMissingToken = true;
+        }
+        return { code, hash: 'unsigned' };
     }
 
     console.log(`Signing ${urlToRequest(this.resourcePath)}...`, { working, queue: queue.length });

--- a/website/src/theme/DocItem/Content/index.js
+++ b/website/src/theme/DocItem/Content/index.js
@@ -1,3 +1,4 @@
+import BrowserOnly from '@docusaurus/BrowserOnly';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';
 import LLMButtons from '@site/src/components/LLMButtons';
 import Heading from '@theme/Heading';
@@ -26,7 +27,7 @@ export default function DocItemContent({ children }) {
             {syntheticTitle && (
                 <div className={styles.docItemContent}>
                     {syntheticTitle && <Heading as="h1">{syntheticTitle}</Heading>}
-                    <LLMButtons />
+                    <BrowserOnly>{() => <LLMButtons />}</BrowserOnly>
                 </div>
             )}
             <MDXContent>{children}</MDXContent>


### PR DESCRIPTION
## Summary
- Wrap LLMButtons in `BrowserOnly` to prevent "Copy for LLM" text from leaking into `.md` exports and `llms-full.txt`
- Gracefully skip code signing in roa-loader when `APIFY_SIGNING_TOKEN` is not set (warn once instead of failing)
- Patch `@signalwire/docusaurus-plugin-llms-txt` to emit proper mdast `break` nodes instead of raw `<br />` HTML in `.md` export

Ported from apify/apify-docs#2207 and apify/apify-docs#2239. Same fixes as apify/crawlee#3544.

🤖 Generated with [Claude Code](https://claude.com/claude-code)