### PR TITLE
test: Fix flaky tests in adaptive crawler and sitemap loader

### DIFF
--- a/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
+++ b/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
@@ -631,6 +631,10 @@ async def test_adaptive_playwright_crawler_default_predictor(test_urls: list[str
     mocked_browser_handler.assert_called_once_with()
 
 
+@pytest.mark.flaky(
+    rerun=3,
+    reason='Test is flaky on Windows and MacOS, see https://github.com/apify/crawlee-python/issues/1650.',
+)
 async def test_adaptive_context_query_selector_beautiful_soup(test_urls: list[str]) -> None:
     """Test that `context.query_selector_one` works regardless of the crawl type for BeautifulSoup variant.
 

--- a/tests/unit/request_loaders/test_sitemap_request_loader.py
+++ b/tests/unit/request_loaders/test_sitemap_request_loader.py
@@ -144,7 +144,7 @@ async def test_data_persistence_for_sitemap_loading(
     sitemap_loader = SitemapRequestLoader([str(sitemap_url)], http_client=http_client, persist_state_key=persist_key)
 
     # Give time to load
-    await asyncio.wait_for(wait_for_sitemap_loader_not_empty(sitemap_loader), timeout=2)
+    await asyncio.wait_for(wait_for_sitemap_loader_not_empty(sitemap_loader), timeout=10)
 
     await sitemap_loader.close()
 


### PR DESCRIPTION
## Summary

- Add `@pytest.mark.flaky(rerun=3)` to `test_adaptive_context_query_selector_beautiful_soup` — the parsel variant already had this marker for the same timing issue (#1650), but the BeautifulSoup variant was missing it. The test relies on Playwright detecting a JS-injected `<h2>` within a 200ms window, which is racy on macOS/Windows CI.
- Increase `asyncio.wait_for` timeout from 2s to 10s in `test_data_persistence_for_sitemap_loading` — on Windows CI with httpx, the HTTP client hit a connection error and started retrying, exhausting the 2-second window. The test validates data persistence, not latency.

Failed CI jobs:
- [Unit tests (macos-latest, 3.14)](https://github.com/apify/crawlee-python/actions/runs/24454238446/job/71450602394)
- [Unit tests (windows-latest, 3.12)](https://github.com/apify/crawlee-python/actions/runs/24454238446/job/71450602420)

🤖 Generated with [Claude Code](https://claude.com/claude-code)