### PR TITLE
docs: expand .rules.md with commit type guidance

### DIFF
--- a/.rules.md
+++ b/.rules.md
@@ -51,7 +51,13 @@ Note: `uv run poe unit-tests` first runs tests marked `@pytest.mark.run_alone` i
 - **Docstrings**: Google format (enforced by Ruff)
 - **Type checker**: ty (Astral's type checker), target Python 3.10
 - **Async mode**: pytest-asyncio in `auto` mode (no need for `@pytest.mark.asyncio`)
-- **Commit format**: Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, etc.)
+- **Commits**: [Conventional Commits](https://www.conventionalcommits.org/) format. Choose the type based on *what* changed, not just *why*:
+  - `feat:` / `fix:` / `perf:` / `refactor:` / `style:` — **source code only**; these trigger a release and appear in the changelog
+  - `test:` — test additions or changes (no release triggered)
+  - `docs:` — documentation changes; also triggers a doc release on master
+  - `ci:` — CI/workflow changes
+  - `chore:` — dependency bumps, tooling, and other housekeeping
+  - `build:` — build system changes
 
 ## Architecture
 


### PR DESCRIPTION
Clarifies which Conventional Commit types (`feat`/`fix`/`perf`/`refactor`/`style`) trigger a release and must be used for source code only, and maps the remaining types (`test:`, `docs:`, `ci:`, `chore:`, `build:`) to their correct scope.