### PR TITLE
ci: Send Slack notification when scheduled e2e tests fail

### DIFF
--- a/.github/workflows/on_schedule_tests.yaml
+++ b/.github/workflows/on_schedule_tests.yaml
@@ -67,3 +67,60 @@ jobs:
         run: uv run poe e2e-templates-tests -m "${{ matrix.http-client }} and ${{ matrix.crawler-type }} and ${{ matrix.package-manager }}"
         env:
           APIFY_TEST_USER_API_TOKEN: ${{ secrets.APIFY_TEST_USER_API_TOKEN }}
+
+  # Send a Slack notification to #tooling-team-python when scheduled e2e tests fail.
+  # Skipped on workflow_dispatch (manual runs) so that ad-hoc triggers don't spam the channel.
+  notify_on_failure:
+    name: Notify Slack on failure
+    needs: end_to_end_tests
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      - name: Build Slack payload
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HEADING: ':red_circle: Scheduled e2e tests failed'
+        run: |
+          failed_jobs=$(gh api \
+            "repos/${REPO}/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}/jobs?per_page=100" \
+            --jq '[.jobs[] | select(.conclusion == "failure") | "• \(.name)"] | join("\n")')
+          jq -n \
+            --arg repo "${REPO}" \
+            --arg url "${WORKFLOW_URL}" \
+            --arg heading "${HEADING}" \
+            --arg failed "${failed_jobs}" \
+            '{
+              text: "\($heading) in \($repo)",
+              blocks: [
+                {
+                  type: "header",
+                  text: { type: "plain_text", text: $heading, emoji: true }
+                },
+                {
+                  type: "section",
+                  fields: [
+                    { type: "mrkdwn", text: "*Repository:*\n\($repo)" },
+                    { type: "mrkdwn", text: "*Workflow run:*\n<\($url)|View on GitHub>" }
+                  ]
+                },
+                {
+                  type: "section",
+                  text: { type: "mrkdwn", text: "*Failed jobs:*\n\($failed)" }
+                }
+              ]
+            }' > slack-payload.json
+
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v3.0.2
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload-file-path: slack-payload.json


### PR DESCRIPTION
## Summary

Closes #1725.

Adds a `notify_on_failure` job to `on_schedule_tests.yaml` that posts to `#tooling-team-python` whenever the daily scheduled e2e tests fail. The message includes a link to the workflow run and a bulleted list of the failed matrix combinations. Manual `workflow_dispatch` runs are intentionally skipped so ad-hoc triggers don't spam the channel.

## Implementation notes

- Uses `slackapi/slack-github-action@v3.0.2` with `webhook-type: incoming-webhook`.
- Webhook URL is read from a new repository secret `SLACK_WEBHOOK_URL` — needs to be configured before this PR has any effect.
- The list of failed matrix jobs is fetched via `gh api .../actions/runs/{run_id}/attempts/{run_attempt}/jobs` (uses the existing `GITHUB_TOKEN` with `actions: read`).
- Job runs only on `failure() && github.event_name == 'schedule'`.

## Setup checklist

- [x] Create an incoming webhook for `#tooling-team-python` in Slack.
- [x] Add the URL as the `SLACK_WEBHOOK_URL` repository secret.