### PR TITLE
test: Mark test_http_status_statistics as flaky

### DIFF
--- a/tests/unit/crawlers/_http/test_http_crawler.py
+++ b/tests/unit/crawlers/_http/test_http_crawler.py
@@ -220,6 +220,10 @@ async def test_do_not_retry_on_client_errors(crawler: HttpCrawler, server_url: U
     assert stats.requests_total == 1
 
 
+@pytest.mark.flaky(
+    reruns=3,
+    reason='Transient transport errors in CI can consume retry budget without registering a status code.',
+)
 async def test_http_status_statistics(crawler: HttpCrawler, server_url: URL) -> None:
     await crawler.add_requests([str(server_url.with_path('status/500').with_query(id=i)) for i in range(10)])
     await crawler.add_requests([str(server_url.with_path('status/402').with_query(id=i)) for i in range(10)])


### PR DESCRIPTION
## Summary

`test_http_status_statistics[httpx]` failed intermittently on macOS Python 3.12 CI ([example run](https://github.com/apify/crawlee-python/actions/runs/25331165214/job/74264952104?pr=1864)) with `'500': 39` vs expected `'500': 40`.

Each `status/500` URL gets 4 attempts (1 initial + 3 retries from `max_request_retries=3`). The httpx client only calls `register_status_code` after a successful response (`_httpx.py:175`); a transient transport error (TCP reset / h2 stream hiccup, common on macOS-hosted runners under load) raises before that line, so the retry budget is consumed without bumping the counter — yielding 39 instead of 40.

Production behavior is correct; only the test's exact-count assumption is fragile under CI network noise. Marking the test with `@pytest.mark.flaky(reruns=3, ...)` follows the existing convention used for the same class of flake (e.g. `test_basic_crawler.py:1376`).