### PR TITLE
ci: install pnpm in docs release workflow

### DIFF
--- a/.github/workflows/manual_release_docs.yaml
+++ b/.github/workflows/manual_release_docs.yaml
@@ -55,6 +55,11 @@ jobs:
       - name: Install Python dependencies
         run: uv run poe install-dev
 
+      - name: Install pnpm and website dependencies
+        uses: apify/workflows/pnpm-install@main
+        with:
+          working-directory: website
+
       - name: Build Docusaurus docs
         run: uv run poe build-docs
         env:


### PR DESCRIPTION
### Description

The `Doc release` workflow ([example failing run](https://github.com/apify/crawlee-python/actions/runs/25373653575/job/74404711100)) runs `uv run poe build-docs`, which shells out to `./build_api_reference.sh && pnpm install && uv run pnpm build` inside `website/`. The runner sets up Node but does not install `pnpm`, so the step fails with:

```
/usr/bin/sh: 1: pnpm: not found
##[error]Process completed with exit code 127.
```

The pnpm install step was lost when the docs release workflow was extracted in #1846.

### Changes

- Add the missing `Install pnpm and website dependencies` step using `apify/workflows/pnpm-install@main`, matching the pattern already used in `manual_version_docs.yaml`.