### PR TITLE
ci: install Apify CLI with pnpm in scheduled e2e tests

### DIFF
--- a/.github/workflows/on_schedule_tests.yaml
+++ b/.github/workflows/on_schedule_tests.yaml
@@ -42,8 +42,13 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Install dependencies
-        run: npm install -g apify-cli
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install Apify CLI
+        run: pnpm add -g apify-cli
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v6

--- a/.github/workflows/on_schedule_tests.yaml
+++ b/.github/workflows/on_schedule_tests.yaml
@@ -42,13 +42,10 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
       - name: Install Apify CLI
-        run: pnpm add -g apify-cli
+        uses: apify/setup-apify-cli-action@v1
+        with:
+          token: ${{ secrets.APIFY_TEST_USER_API_TOKEN }}
 
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v6


### PR DESCRIPTION
### Description

The scheduled E2E tests workflow has been failing on every matrix job at the **Install dependencies** step (latest example: [run 25421420663](https://github.com/apify/crawlee-python/actions/runs/25421420663)).

`npm install -g apify-cli` now fails because the published `apify-cli` package ships a `preinstall` hook (`npx only-allow pnpm`) that refuses non-pnpm installs. On the GitHub runners that hook can't auto-fetch `only-allow` and exits before any test runs:

```
npm error code 127
npm error path /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/apify-cli
npm error command sh -c npx only-allow pnpm
npm error sh: 1: only-allow: not found
```

### Changes

- Add a `Setup pnpm` step using `pnpm/action-setup@v4`.
- Install `apify-cli` globally via `pnpm add -g apify-cli` instead of `npm install -g`.

This mirrors the pnpm-based approach already adopted by the docs workflows in #1871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)