### PR TITLE
ci: inline beta release jobs to fix PyPI trusted publishing

### DIFF
--- a/.github/workflows/manual_release_beta.yaml
+++ b/.github/workflows/manual_release_beta.yaml
@@ -2,10 +2,11 @@ name: Beta release
 
 on:
   # Runs when manually triggered from the GitHub UI.
+  # Note: This workflow is intentionally NOT a reusable workflow (no `workflow_call`)
+  # because PyPI's Trusted Publishing does not currently support reusable workflows.
+  # The same jobs are duplicated in `on_master.yaml` for the automatic beta release on push to master.
+  # See: https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github
   workflow_dispatch:
-
-  # Runs when invoked by another workflow.
-  workflow_call:
 
 permissions:
   contents: read
@@ -16,7 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version_number: ${{ steps.release_prepare.outputs.version_number }}
-      tag_name: ${{ steps.release_prepare.outputs.tag_name }}
       changelog: ${{ steps.release_prepare.outputs.changelog }}
     steps:
       - uses: apify/workflows/git-cliff-release@main

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -45,9 +45,8 @@ jobs:
     uses: ./.github/workflows/_tests.yaml
     secrets: inherit
 
-  # The beta release jobs are intentionally inlined here (instead of calling
-  # `manual_release_beta.yaml` via `uses:`) because PyPI's Trusted Publishing
-  # does not currently support reusable workflows.
+  # The beta release jobs are intentionally inlined here (instead of calling `manual_release_beta.yaml` via `uses:`)
+  # because PyPI's Trusted Publishing does not currently support reusable workflows.
   # See: https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github
   release_prepare:
     # Run this only for "feat", "fix", "perf", "refactor" and "style" commits.

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -45,7 +45,11 @@ jobs:
     uses: ./.github/workflows/_tests.yaml
     secrets: inherit
 
-  beta_release:
+  # The beta release jobs are intentionally inlined here (instead of calling
+  # `manual_release_beta.yaml` via `uses:`) because PyPI's Trusted Publishing
+  # does not currently support reusable workflows.
+  # See: https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github
+  release_prepare:
     # Run this only for "feat", "fix", "perf", "refactor" and "style" commits.
     if: >-
       startsWith(github.event.head_commit.message, 'feat') ||
@@ -53,11 +57,63 @@ jobs:
       startsWith(github.event.head_commit.message, 'perf') ||
       startsWith(github.event.head_commit.message, 'refactor') ||
       startsWith(github.event.head_commit.message, 'style')
-    name: Beta release
+    name: Beta release / Release prepare
     needs: [code_checks, tests]
+    runs-on: ubuntu-latest
+    outputs:
+      version_number: ${{ steps.release_prepare.outputs.version_number }}
+      changelog: ${{ steps.release_prepare.outputs.changelog }}
+    steps:
+      - uses: apify/workflows/git-cliff-release@main
+        id: release_prepare
+        name: Release prepare
+        with:
+          release_type: prerelease
+          existing_changelog_path: CHANGELOG.md
+
+  changelog_update:
+    name: Beta release / Changelog update
+    needs: [release_prepare]
     permissions:
       contents: write
-      id-token: write
+    uses: apify/workflows/.github/workflows/python_bump_and_update_changelog.yaml@main
+    with:
+      version_number: ${{ needs.release_prepare.outputs.version_number }}
+      changelog: ${{ needs.release_prepare.outputs.changelog }}
+    secrets: inherit
+
+  pypi_publish:
+    name: Beta release / PyPI publish
+    needs: [release_prepare, changelog_update]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write # Required for OIDC authentication.
+    environment:
+      name: pypi
+      url: https://pypi.org/project/crawlee
+    steps:
+      - name: Prepare distribution
+        uses: apify/workflows/prepare-pypi-distribution@main
+        with:
+          package_name: crawlee
+          is_prerelease: "yes"
+          version_number: ${{ needs.release_prepare.outputs.version_number }}
+          ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
+
+      # Publish the package to PyPI using PyPA official GitHub action with OIDC authentication.
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  doc_release_post_publish:
+    name: Beta release / Doc release post publish
+    needs: [changelog_update, pypi_publish]
+    permissions:
+      contents: write
       pages: write
-    uses: ./.github/workflows/manual_release_beta.yaml
+      id-token: write
+    uses: ./.github/workflows/manual_release_docs.yaml
+    with:
+      # Use the ref from the changelog update to include the updated changelog.
+      ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
     secrets: inherit


### PR DESCRIPTION
## Summary

PyPI's Trusted Publishing rejects OIDC tokens issued from reusable workflows:

> The claims in this token suggest that the calling workflow is a reusable workflow. Reusable workflows are not currently supported by PyPI's Trusted Publishing.

`on_master.yaml` was invoking `manual_release_beta.yaml` via `uses:`, which made the OIDC token reflect a reusable workflow call. The same fix was applied in `apify/apify-shared-python#63`.

## Changes

- `on_master.yaml`: inline the four beta release jobs (`release_prepare`, `changelog_update`, `pypi_publish`, `doc_release_post_publish`) directly, instead of calling `manual_release_beta.yaml` as a reusable workflow.
- `manual_release_beta.yaml`: remove the `workflow_call` trigger (no longer invoked from another workflow) and add a comment explaining why the duplication exists.
- Drop the unused `tag_name` output from `release_prepare` in both files.

## Follow-up

The PyPI Trusted Publisher for `crawlee` is currently configured for `manual_release_beta.yaml`. After this is merged, an entry for `on_master.yaml` needs to be added on PyPI so the automatic beta release passes verification.

See: https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github