### PR TITLE
test: mark test_adaptive_crawling_pre_nav_change_to_context as flaky

### DIFF
--- a/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
+++ b/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
@@ -236,6 +236,11 @@ async def test_adaptive_crawling_parsel(test_urls: list[str]) -> None:
     assert static_handler_count == 1
 
 
+@pytest.mark.flaky(
+    rerun=3,
+    reason='Test is flaky on Windows when Playwright hits net::ERR_NO_BUFFER_SPACE and retries, '
+    'causing the pre-nav hook to fire one extra time.',
+)
 async def test_adaptive_crawling_pre_nav_change_to_context(test_urls: list[str]) -> None:
     """Tests that context can be modified in pre-navigation hooks."""
     static_only_predictor_enforce_detection = _SimpleRenderingTypePredictor()


### PR DESCRIPTION
## Summary

On Windows CI, the test `test_adaptive_crawling_pre_nav_change_to_context` occasionally fails because Playwright's `Page.goto` hits `net::ERR_NO_BUFFER_SPACE` (transient socket buffer exhaustion under concurrent test load). The retry causes the pre-navigation hook to fire 3 times instead of 2 (static probe, failed Playwright probe, Playwright retry), tripping the hard-coded `assert user_data_in_pre_nav_hook == [None, None]`.

The test's actual property under test — that probes don't leak `user_data` between invocations — still holds (every captured value is `None`); only the count is fragile.

This adds `@pytest.mark.flaky(rerun=3)`, matching the existing pattern at lines 633 and 679 of the same file (which use the same marker for the same kind of Windows-only network flakiness).

Failing job: https://github.com/apify/crawlee-python/actions/runs/25424362761/job/74573949683?pr=1762