### PR TITLE
fix: bump `BrowserPool` default `operation_timeout` to 60 seconds

### DIFF
--- a/src/crawlee/browsers/_browser_pool.py
+++ b/src/crawlee/browsers/_browser_pool.py
@@ -49,7 +49,7 @@ class BrowserPool:
         self,
         plugins: Sequence[BrowserPlugin] | None = None,
         *,
-        operation_timeout: timedelta = timedelta(seconds=15),
+        operation_timeout: timedelta = timedelta(seconds=60),
         browser_inactive_threshold: timedelta = timedelta(seconds=10),
         identify_inactive_browsers_interval: timedelta = timedelta(seconds=20),
         close_inactive_browsers_interval: timedelta = timedelta(seconds=30),


### PR DESCRIPTION
## Summary

The previous 15s default of `BrowserPool.operation_timeout` was too tight for chromium cold-start on slow runners. Windows CI with Python 3.14 has been flaking out with:

```
TimeoutError: Creating a new page with plugin <PlaywrightBrowserPlugin ...> timed out.
```

Bumping the default to 60s gives chromium enough headroom on slow machines without changing behavior for users who already pass an explicit `operation_timeout`. Same value used in the existing precedent fix for `test_with_default_plugin_constructor` (PR #1806).

Failing CI run: https://github.com/apify/crawlee-python/actions/runs/25332581547/job/74269691220?pr=1869