### PR TITLE
ci: pin setup-apify-cli-action to v1.0.0

### DIFF
--- a/.github/workflows/on_schedule_tests.yaml
+++ b/.github/workflows/on_schedule_tests.yaml
@@ -43,7 +43,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Apify CLI
-        uses: apify/setup-apify-cli-action@v1
+        uses: apify/setup-apify-cli-action@v1.0.0
         with:
           token: ${{ secrets.APIFY_TEST_USER_API_TOKEN }}
 


### PR DESCRIPTION
Floating tag v1 does not work, using the full version instead.