### PR TITLE
ci: fix e2e templates tests failing on mise shim cwd resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ GEMINI.local.md
 # Cache
 __pycache__
 .pytest_cache
+.pytest-tmp
 .ruff_cache
 .ty_cache
 .uv-cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -337,6 +337,7 @@ uv run pytest \
 cmd = """
 uv run pytest \
     --numprocesses=${TESTS_CONCURRENCY:-auto} \
+    --basetemp=./.pytest-tmp \
     tests/e2e/project_template
 """
 

--- a/tests/e2e/project_template/test_static_crawlers_templates.py
+++ b/tests/e2e/project_template/test_static_crawlers_templates.py
@@ -86,7 +86,15 @@ async def test_static_crawler_actor_at_apify(
     )
     subprocess.run(['apify', 'init', '-y', actor_name], capture_output=True, check=True, cwd=tmp_path / actor_name)  # noqa: ASYNC221, S603, S607
 
-    build_process = subprocess.run(['apify', 'push'], capture_output=True, check=False, cwd=tmp_path / actor_name)  # noqa: ASYNC221, S607
+    build_process = subprocess.run(  # noqa: ASYNC221
+        ['apify', 'push'],  # noqa: S607
+        capture_output=True,
+        check=False,
+        cwd=tmp_path / actor_name,
+        # Prevent git from walking up into the surrounding project's .git/ when running under
+        # a basetemp inside the repo (see --basetemp in the e2e-templates-tests poe task).
+        env={**os.environ, 'GIT_CEILING_DIRECTORIES': str(tmp_path)},
+    )
     # Get actor ID from build log
     actor_id_regexp = re.compile(r'https:\/\/console\.apify\.com\/actors\/(.*)#\/builds\/\d*\.\d*\.\d*')
 


### PR DESCRIPTION
## Summary

The scheduled e2e template tests have been failing on every matrix job since #1874 / #1880 adopted `apify/setup-apify-cli-action@v1.0.0`. The action installs apify-cli via a `mise` shim that resolves the apify version by walking up from cwd looking for a `mise.toml`. Our tests run `subprocess.run(['apify', ...], cwd=tmp_path / actor_name)` from pytest's default `tmp_path` (`/tmp/pytest-of-runner/...`), which is outside `MISE_TRUSTED_CONFIG_PATHS` and contains no mise config. The shim therefore errors with `No version is set for shim: apify`.

This mirrors how `apify/crawlee` handles the same situation in `test/e2e/tools.mjs` (running `apify push` from a directory under the project root and setting `GIT_CEILING_DIRECTORIES`).

## Changes

- `pyproject.toml`: pass `--basetemp=./.pytest-tmp` to the `e2e-templates-tests` poe task so pytest's `tmp_path` lives under the project root, where `mise`'s parent traversal finds the `mise.toml` written by `jdx/mise-action` to `$GITHUB_WORKSPACE`.
- `.gitignore`: ignore `.pytest-tmp`.
- `tests/e2e/project_template/test_static_crawlers_templates.py`: set `GIT_CEILING_DIRECTORIES=tmp_path` on the `apify push` call so git stops before reaching the project's `.git/`.

Failing run: https://github.com/apify/crawlee-python/actions/runs/25541426007