### PR TITLE
ci: Add Impit HTTP client to scheduled E2E templates matrix

### DIFF
--- a/.github/workflows/on_schedule_tests.yaml
+++ b/.github/workflows/on_schedule_tests.yaml
@@ -28,7 +28,7 @@ jobs:
       max-parallel: 12
       matrix:
         crawler-type: ["playwright_camoufox", "playwright_chrome", "playwright_firefox", "playwright_webkit", "playwright", "parsel", "beautifulsoup"]
-        http-client: ["httpx", "curl_impersonate"]
+        http-client: ["httpx", "curl_impersonate", "impit"]
         package-manager: ["pip", "uv", "poetry"]
 
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
## Summary

The e2e template test parametrization and the project template CLI both already support the `impit` HTTP client, but the scheduled CI matrix in `on_schedule_tests.yaml` only exercised `httpx` and `curl_impersonate`, leaving the `impit` variant untested.

This PR adds `"impit"` to the `http-client` matrix so the daily scheduled run covers all three HTTP client variants the templates ship with.

Matrix size goes from 7×2×3 = 42 jobs to 7×3×3 = 63 jobs (`max-parallel` stays at 12).