### PR TITLE
test: Fix flaky `test_emit_system_info_event` by waiting on event

### DIFF
--- a/tests/unit/events/test_local_event_manager.py
+++ b/tests/unit/events/test_local_event_manager.py
@@ -11,15 +11,19 @@ from crawlee.events._types import Event, EventSystemInfoData
 
 async def test_emit_system_info_event() -> None:
     mocked_listener = AsyncMock()
+    received = asyncio.Event()
 
     async def async_listener(payload: Any) -> None:
         await mocked_listener(payload)
+        received.set()
 
     system_info_interval = timedelta(milliseconds=50)
-    test_tolerance_coefficient = 10
     async with LocalEventManager(system_info_interval=system_info_interval) as event_manager:
         event_manager.on(event=Event.SYSTEM_INFO, listener=async_listener)
-        await asyncio.sleep(system_info_interval.total_seconds() * test_tolerance_coefficient)
+        # Wait until the listener is invoked at least once. A generous timeout avoids flakiness on
+        # loaded CI runners, where `psutil.cpu_percent(interval=0.1)` in `asyncio.to_thread` can
+        # delay the first emission well beyond the configured interval.
+        await asyncio.wait_for(received.wait(), timeout=10)
 
     assert mocked_listener.call_count >= 1
     assert isinstance(mocked_listener.call_args[0][0], EventSystemInfoData)


### PR DESCRIPTION
## Summary

The `test_emit_system_info_event` test was flaking on macOS CI (e.g. [run 25595850020](https://github.com/apify/crawlee-python/actions/runs/25595850020/job/75141531498)). It registered a listener and slept for `50ms × 10 = 500ms` hoping at least one `SYSTEM_INFO` event would fire. Under heavy parallel xdist load, `psutil.cpu_percent(interval=0.1)` running inside `asyncio.to_thread` could be delayed enough that no event reached the listener within the 500ms window.

This replaces the fixed sleep with an `asyncio.Event` that the listener sets, awaited via `asyncio.wait_for(..., timeout=10)`. The test now returns as soon as the first event is observed and only waits up to 10s as a safety net — same pattern as #1830 for the sibling tests in `test_event_manager.py`.