### PR TITLE
fix: Update `push_data` and `user_data` annotation  with `JsonSerializable` instead of `Any`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "pydantic>=2.11.0",
     "pyee>=9.0.0",
     "tldextract>=5.1.0",
-    "typing-extensions>=4.1.0",
+    "typing-extensions>=4.10.0",
     "yarl>=1.18.0",
 ]
 

--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterator, MutableMapping
+from collections.abc import Iterator, Mapping, MutableMapping
 from datetime import datetime
 from enum import IntEnum
 from typing import TYPE_CHECKING, Annotated, Any, TypedDict, cast
@@ -135,7 +135,7 @@ class RequestOptions(TypedDict):
     keep_url_fragment: NotRequired[bool]
     use_extended_unique_key: NotRequired[bool]
     always_enqueue: NotRequired[bool]
-    user_data: NotRequired[dict[str, JsonSerializable]]
+    user_data: NotRequired[Mapping[str, JsonSerializable]]
     no_retry: NotRequired[bool]
     enqueue_strategy: NotRequired[EnqueueStrategy]
     max_retries: NotRequired[int | None]
@@ -200,7 +200,7 @@ class Request(BaseModel):
         headers: HttpHeaders = HttpHeaders()
         """HTTP request headers."""
 
-        user_data: dict[str, JsonSerializable] = {}
+        user_data: MutableMapping[str, JsonSerializable] = {}
         """Custom user data assigned to the request. Use this to save any request related data to the
         request's scope, keeping them accessible on retries, failures etc.
         """
@@ -209,8 +209,9 @@ class Request(BaseModel):
         headers: Annotated[HttpHeaders, Field(default_factory=HttpHeaders)]
         """HTTP request headers."""
 
+        # Internally, the model contains `UserData`, this is just for convenience
         user_data: Annotated[
-            dict[str, JsonSerializable],  # Internally, the model contains `UserData`, this is just for convenience
+            MutableMapping[str, JsonSerializable],
             Field(alias='userData', default_factory=UserData),
             PlainValidator(user_data_adapter.validate_python),
             PlainSerializer(

--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -198,7 +198,7 @@ class PushDataKwargs(TypedDict):
 
 
 class PushDataFunctionCall(PushDataKwargs):
-    data: list[dict[str, Any]] | dict[str, Any]
+    data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable]
     dataset_id: str | None
     dataset_name: str | None
     dataset_alias: str | None
@@ -300,7 +300,7 @@ class RequestHandlerRunResult:
 
     async def push_data(
         self,
-        data: list[dict[str, Any]] | dict[str, Any],
+        data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable],
         dataset_id: str | None = None,
         dataset_name: str | None = None,
         dataset_alias: str | None = None,
@@ -392,7 +392,7 @@ class EnqueueLinksFunction(Protocol):
         selector: str | None = None,
         attribute: str | None = None,
         label: str | None = None,
-        user_data: dict[str, Any] | None = None,
+        user_data: dict[str, JsonSerializable] | None = None,
         transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction] | None = None,
         rq_id: str | None = None,
         rq_name: str | None = None,
@@ -417,7 +417,7 @@ class EnqueueLinksFunction(Protocol):
         selector: str | None = None,
         attribute: str | None = None,
         label: str | None = None,
-        user_data: dict[str, Any] | None = None,
+        user_data: dict[str, JsonSerializable] | None = None,
         transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction] | None = None,
         requests: Sequence[str | Request] | None = None,
         rq_id: str | None = None,
@@ -465,7 +465,7 @@ class ExtractLinksFunction(Protocol):
         selector: str = 'a',
         attribute: str = 'href',
         label: str | None = None,
-        user_data: dict[str, Any] | None = None,
+        user_data: dict[str, JsonSerializable] | None = None,
         transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction] | None = None,
         **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> Coroutine[None, None, list[Request]]:
@@ -543,7 +543,7 @@ class PushDataFunction(Protocol):
 
     def __call__(
         self,
-        data: list[dict[str, Any]] | dict[str, Any],
+        data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable],
         dataset_id: str | None = None,
         dataset_name: str | None = None,
         dataset_alias: str | None = None,

--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -27,9 +27,7 @@ if TYPE_CHECKING:
     from crawlee.storage_clients import StorageClient
     from crawlee.storages import KeyValueStore
 
-    # Workaround for https://github.com/pydantic/pydantic/issues/9445
-    J = TypeVar('J', bound='JsonSerializable')
-    JsonSerializable = list[J] | dict[str, J] | str | bool | int | float | None
+    JsonSerializable = dict[str, 'JsonSerializable'] | list['JsonSerializable'] | str | int | float | bool | None
 else:
     from pydantic import JsonValue as JsonSerializable
 

--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     import json
     import logging
     import re
-    from collections.abc import Awaitable, Coroutine, Sequence
+    from collections.abc import Awaitable, Coroutine, MutableMapping, Sequence
 
     from typing_extensions import NotRequired, Required, Self, Unpack
 
@@ -390,7 +390,7 @@ class EnqueueLinksFunction(Protocol):
         selector: str | None = None,
         attribute: str | None = None,
         label: str | None = None,
-        user_data: dict[str, JsonSerializable] | None = None,
+        user_data: Mapping[str, JsonSerializable] | None = None,
         transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction] | None = None,
         rq_id: str | None = None,
         rq_name: str | None = None,
@@ -415,7 +415,7 @@ class EnqueueLinksFunction(Protocol):
         selector: str | None = None,
         attribute: str | None = None,
         label: str | None = None,
-        user_data: dict[str, JsonSerializable] | None = None,
+        user_data: Mapping[str, JsonSerializable] | None = None,
         transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction] | None = None,
         requests: Sequence[str | Request] | None = None,
         rq_id: str | None = None,
@@ -463,7 +463,7 @@ class ExtractLinksFunction(Protocol):
         selector: str = 'a',
         attribute: str = 'href',
         label: str | None = None,
-        user_data: dict[str, JsonSerializable] | None = None,
+        user_data: Mapping[str, JsonSerializable] | None = None,
         transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction] | None = None,
         **kwargs: Unpack[EnqueueLinksKwargs],
     ) -> Coroutine[None, None, list[Request]]:
@@ -614,8 +614,8 @@ class UseStateFunction(Protocol):
 
     def __call__(
         self,
-        default_value: dict[str, JsonSerializable] | None = None,
-    ) -> Coroutine[None, None, dict[str, JsonSerializable]]:
+        default_value: MutableMapping[str, JsonSerializable] | None = None,
+    ) -> Coroutine[None, None, MutableMapping[str, JsonSerializable]]:
         """Call dunder method.
 
         Args:

--- a/src/crawlee/_utils/file.py
+++ b/src/crawlee/_utils/file.py
@@ -10,12 +10,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, overload
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Mapping
     from typing import Any, TextIO
 
     from typing_extensions import Unpack
 
-    from crawlee._types import ExportDataCsvKwargs, ExportDataJsonKwargs
+    from crawlee._types import ExportDataCsvKwargs, ExportDataJsonKwargs, JsonSerializable
 
 if sys.platform == 'win32':
 
@@ -150,7 +150,7 @@ async def atomic_write(
 
 
 async def export_json_to_stream(
-    iterator: AsyncIterator[dict[str, Any]],
+    iterator: AsyncIterator[Mapping[str, JsonSerializable]],
     dst: TextIO,
     **kwargs: Unpack[ExportDataJsonKwargs],
 ) -> None:
@@ -159,7 +159,7 @@ async def export_json_to_stream(
 
 
 async def export_csv_to_stream(
-    iterator: AsyncIterator[dict[str, Any]],
+    iterator: AsyncIterator[Mapping[str, JsonSerializable]],
     dst: TextIO,
     **kwargs: Unpack[ExportDataCsvKwargs],
 ) -> None:

--- a/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
+++ b/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
@@ -21,7 +21,7 @@ from crawlee.statistics import StatisticsState
 from ._http_crawling_context import HttpCrawlingContext, ParsedHttpCrawlingContext, TParseResult, TSelectResult
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Awaitable, Callable, Iterator
+    from collections.abc import AsyncGenerator, Awaitable, Callable, Iterator, Mapping
 
     from typing_extensions import Unpack
 
@@ -200,7 +200,7 @@ class AbstractHttpCrawler(
             selector: str = 'a',
             attribute: str = 'href',
             label: str | None = None,
-            user_data: dict[str, JsonSerializable] | None = None,
+            user_data: Mapping[str, JsonSerializable] | None = None,
             transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction]
             | None = None,
             **kwargs: Unpack[EnqueueLinksKwargs],

--- a/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
+++ b/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from abc import ABC
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Generic
+from typing import TYPE_CHECKING, Generic
 
 from more_itertools import partition
 from pydantic import ValidationError
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from typing_extensions import Unpack
 
     from crawlee import RequestTransformAction
-    from crawlee._types import BasicCrawlingContext, EnqueueLinksKwargs, ExtractLinksFunction
+    from crawlee._types import BasicCrawlingContext, EnqueueLinksKwargs, ExtractLinksFunction, JsonSerializable
 
     from ._abstract_http_parser import AbstractHttpParser
 
@@ -200,7 +200,7 @@ class AbstractHttpCrawler(
             selector: str = 'a',
             attribute: str = 'href',
             label: str | None = None,
-            user_data: dict[str, Any] | None = None,
+            user_data: dict[str, JsonSerializable] | None = None,
             transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction]
             | None = None,
             **kwargs: Unpack[EnqueueLinksKwargs],

--- a/src/crawlee/crawlers/_adaptive_playwright/_adaptive_playwright_crawler.py
+++ b/src/crawlee/crawlers/_adaptive_playwright/_adaptive_playwright_crawler.py
@@ -42,6 +42,7 @@ from ._rendering_type_predictor import DefaultRenderingTypePredictor, RenderingT
 from ._result_comparator import create_default_comparator
 
 if TYPE_CHECKING:
+    from collections.abc import MutableMapping
     from types import TracebackType
 
     from typing_extensions import Unpack
@@ -286,7 +287,7 @@ class AdaptivePlaywrightCrawler(
         self,
         rendering_type: RenderingType,
         context: BasicCrawlingContext,
-        state: dict[str, JsonSerializable] | None = None,
+        state: MutableMapping[str, JsonSerializable] | None = None,
     ) -> SubCrawlerRun:
         """Perform a one request crawl with specific context pipeline and return `SubCrawlerRun`.
 
@@ -297,8 +298,8 @@ class AdaptivePlaywrightCrawler(
         if state is not None:
 
             async def get_input_state(
-                default_value: dict[str, JsonSerializable] | None = None,  # noqa:ARG001  # Intentionally unused arguments. Closure, that generates same output regardless of inputs.
-            ) -> dict[str, JsonSerializable]:
+                default_value: MutableMapping[str, JsonSerializable] | None = None,  # noqa:ARG001  # Intentionally unused arguments. Closure, that generates same output regardless of inputs.
+            ) -> MutableMapping[str, JsonSerializable]:
                 return state
 
             use_state_function = get_input_state
@@ -411,8 +412,10 @@ class AdaptivePlaywrightCrawler(
             # avoid static crawl to modify the state.
             # (This static crawl is performed only to evaluate rendering type detection.)
             kvs = await context.get_key_value_store()
-            default_value = dict[str, JsonSerializable]()
-            old_state: dict[str, JsonSerializable] = await kvs.get_value(self._CRAWLEE_STATE_KEY, default_value)
+            default_value: MutableMapping[str, JsonSerializable] = {}
+            old_state: MutableMapping[str, JsonSerializable] = await kvs.get_value(
+                self._CRAWLEE_STATE_KEY, default_value
+            )
             old_state_copy = deepcopy(old_state)
 
         pw_run = await self._crawl_one('client only', context=context)

--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -80,7 +80,7 @@ from ._logging_utils import (
 
 if TYPE_CHECKING:
     import re
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Mapping
     from contextlib import AbstractAsyncContextManager
 
     from crawlee._types import (
@@ -941,7 +941,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
 
     async def _push_data(
         self,
-        data: list[dict[str, Any]] | dict[str, Any],
+        data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable],
         dataset_id: str | None = None,
         dataset_name: str | None = None,
         dataset_alias: str | None = None,
@@ -1015,7 +1015,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
             selector: str | None = None,
             attribute: str | None = None,
             label: str | None = None,
-            user_data: dict[str, Any] | None = None,
+            user_data: dict[str, JsonSerializable] | None = None,
             transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction]
             | None = None,
             requests: Sequence[str | Request] | None = None,

--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -80,7 +80,7 @@ from ._logging_utils import (
 
 if TYPE_CHECKING:
     import re
-    from collections.abc import Iterator, Mapping
+    from collections.abc import Iterator, Mapping, MutableMapping
     from contextlib import AbstractAsyncContextManager
 
     from crawlee._types import (
@@ -856,8 +856,8 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
 
     async def use_state(
         self,
-        default_value: dict[str, JsonSerializable] | None = None,
-    ) -> dict[str, JsonSerializable]:
+        default_value: MutableMapping[str, JsonSerializable] | None = None,
+    ) -> MutableMapping[str, JsonSerializable]:
         kvs = await self.get_key_value_store()
         return await kvs.get_auto_saved_value(f'{self._CRAWLEE_STATE_KEY}_{self._id}', default_value)
 
@@ -1015,7 +1015,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
             selector: str | None = None,
             attribute: str | None = None,
             label: str | None = None,
-            user_data: dict[str, JsonSerializable] | None = None,
+            user_data: Mapping[str, JsonSerializable] | None = None,
             transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction]
             | None = None,
             requests: Sequence[str | Request] | None = None,

--- a/src/crawlee/crawlers/_playwright/_playwright_crawler.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_crawler.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
         HttpHeaders,
         HttpMethod,
         HttpPayload,
+        JsonSerializable,
     )
     from crawlee.browsers._types import BrowserType
 
@@ -384,7 +385,7 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext, StatisticsState]
             selector: str = 'a',
             attribute: str = 'href',
             label: str | None = None,
-            user_data: dict | None = None,
+            user_data: dict[str, JsonSerializable] | None = None,
             transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction]
             | None = None,
             **kwargs: Unpack[EnqueueLinksKwargs],

--- a/src/crawlee/crawlers/_playwright/_playwright_crawler.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_crawler.py
@@ -385,7 +385,7 @@ class PlaywrightCrawler(BasicCrawler[PlaywrightCrawlingContext, StatisticsState]
             selector: str = 'a',
             attribute: str = 'href',
             label: str | None = None,
-            user_data: dict[str, JsonSerializable] | None = None,
+            user_data: Mapping[str, JsonSerializable] | None = None,
             transform_request_function: Callable[[RequestOptions], RequestOptions | RequestTransformAction]
             | None = None,
             **kwargs: Unpack[EnqueueLinksKwargs],

--- a/src/crawlee/sessions/_models.py
+++ b/src/crawlee/sessions/_models.py
@@ -13,6 +13,8 @@ from pydantic import (
     computed_field,
 )
 
+from crawlee._types import JsonSerializable
+
 from ._cookies import CookieParam
 from ._session import Session
 
@@ -24,7 +26,7 @@ class SessionModel(BaseModel):
 
     id: Annotated[str, Field(alias='id')]
     max_age: Annotated[timedelta, Field(alias='maxAge')]
-    user_data: Annotated[dict, Field(alias='userData')]
+    user_data: Annotated[dict[str, JsonSerializable], Field(alias='userData')]
     max_error_score: Annotated[float, Field(alias='maxErrorScore')]
     error_score_decrement: Annotated[float, Field(alias='errorScoreDecrement')]
     created_at: Annotated[datetime, Field(alias='createdAt')]

--- a/src/crawlee/sessions/_models.py
+++ b/src/crawlee/sessions/_models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import MutableMapping
 from datetime import datetime, timedelta
 from typing import Annotated, Any
 
@@ -26,7 +27,7 @@ class SessionModel(BaseModel):
 
     id: Annotated[str, Field(alias='id')]
     max_age: Annotated[timedelta, Field(alias='maxAge')]
-    user_data: Annotated[dict[str, JsonSerializable], Field(alias='userData')]
+    user_data: Annotated[MutableMapping[str, JsonSerializable], Field(alias='userData')]
     max_error_score: Annotated[float, Field(alias='maxErrorScore')]
     error_score_decrement: Annotated[float, Field(alias='errorScoreDecrement')]
     created_at: Annotated[datetime, Field(alias='createdAt')]

--- a/src/crawlee/sessions/_session.py
+++ b/src/crawlee/sessions/_session.py
@@ -11,8 +11,10 @@ from crawlee._utils.docs import docs_group
 from crawlee.sessions._cookies import CookieParam, SessionCookies
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping, MutableMapping
     from http.cookiejar import CookieJar
 
+    from crawlee._types import JsonSerializable
     from crawlee.sessions._models import SessionModel
 
 logger = getLogger(__name__)
@@ -36,7 +38,7 @@ class Session:
         *,
         id: str | None = None,
         max_age: timedelta = timedelta(minutes=50),
-        user_data: dict | None = None,
+        user_data: Mapping[str, JsonSerializable] | None = None,
         max_error_score: float = 3.0,
         error_score_decrement: float = 0.5,
         created_at: datetime | None = None,
@@ -63,7 +65,7 @@ class Session:
         """
         self._id = id or crypto_random_object_id(length=10)
         self._max_age = max_age
-        self._user_data = user_data or {}
+        self._user_data: dict[str, JsonSerializable] = dict(user_data) if user_data is not None else {}
         self._max_error_score = max_error_score
         self._error_score_decrement = error_score_decrement
         self._created_at = created_at or datetime.now(timezone.utc)
@@ -117,7 +119,7 @@ class Session:
         return self._id
 
     @property
-    def user_data(self) -> dict:
+    def user_data(self) -> MutableMapping[str, JsonSerializable]:
         """Get the user data."""
         return self._user_data
 

--- a/src/crawlee/sessions/_session.py
+++ b/src/crawlee/sessions/_session.py
@@ -65,7 +65,7 @@ class Session:
         """
         self._id = id or crypto_random_object_id(length=10)
         self._max_age = max_age
-        self._user_data: dict[str, JsonSerializable] = dict(user_data) if user_data is not None else {}
+        self._user_data: MutableMapping[str, JsonSerializable] = dict(user_data) if user_data is not None else {}
         self._max_error_score = max_error_score
         self._error_score_decrement = error_score_decrement
         self._created_at = created_at or datetime.now(timezone.utc)

--- a/src/crawlee/storage_clients/_base/_dataset_client.py
+++ b/src/crawlee/storage_clients/_base/_dataset_client.py
@@ -12,12 +12,6 @@ if TYPE_CHECKING:
     from crawlee.storage_clients.models import DatasetItemsListPage, DatasetMetadata
 
 
-def _is_list_of_items(
-    data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable],
-) -> TypeIs[Sequence[Mapping[str, JsonSerializable]]]:
-    return isinstance(data, list)
-
-
 class DatasetClient(ABC):
     """An abstract class for dataset storage clients.
 

--- a/src/crawlee/storage_clients/_base/_dataset_client.py
+++ b/src/crawlee/storage_clients/_base/_dataset_client.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Mapping, Sequence
+    from collections.abc import AsyncIterator, Mapping
 
     from typing_extensions import TypeIs
 
@@ -95,7 +96,7 @@ class DatasetClient(ABC):
             yield {}
 
     @staticmethod
-    def _is_list_of_items(
+    def _is_sequence_of_items(
         data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable],
     ) -> TypeIs[Sequence[Mapping[str, JsonSerializable]]]:
-        return isinstance(data, list)
+        return isinstance(data, Sequence)

--- a/src/crawlee/storage_clients/_base/_dataset_client.py
+++ b/src/crawlee/storage_clients/_base/_dataset_client.py
@@ -4,10 +4,18 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
-    from typing import Any
+    from collections.abc import AsyncIterator, Mapping, Sequence
 
+    from typing_extensions import TypeIs
+
+    from crawlee._types import JsonSerializable
     from crawlee.storage_clients.models import DatasetItemsListPage, DatasetMetadata
+
+
+def _is_list_of_items(
+    data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable],
+) -> TypeIs[Sequence[Mapping[str, JsonSerializable]]]:
+    return isinstance(data, list)
 
 
 class DatasetClient(ABC):
@@ -42,7 +50,7 @@ class DatasetClient(ABC):
         """
 
     @abstractmethod
-    async def push_data(self, data: list[Any] | dict[str, Any]) -> None:
+    async def push_data(self, data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable]) -> None:
         """Push data to the dataset.
 
         The backend method for the `Dataset.push_data` call.
@@ -82,7 +90,7 @@ class DatasetClient(ABC):
         unwind: list[str] | None = None,
         skip_empty: bool = False,
         skip_hidden: bool = False,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncIterator[Mapping[str, JsonSerializable]]:
         """Iterate over the dataset items with filtering options.
 
         The backend method for the `Dataset.iterate_items` call.
@@ -91,3 +99,9 @@ class DatasetClient(ABC):
         raise NotImplementedError
         if False:
             yield {}
+
+    @staticmethod
+    def _is_list_of_items(
+        data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable],
+    ) -> TypeIs[Sequence[Mapping[str, JsonSerializable]]]:
+        return isinstance(data, list)

--- a/src/crawlee/storage_clients/_file_system/_dataset_client.py
+++ b/src/crawlee/storage_clients/_file_system/_dataset_client.py
@@ -225,7 +225,7 @@ class FileSystemDatasetClient(DatasetClient):
     async def push_data(self, data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable]) -> None:
         async with self._lock:
             new_item_count = self._metadata.item_count
-            if self._is_list_of_items(data):
+            if self._is_sequence_of_items(data):
                 for item in data:
                     new_item_count += 1
                     await self._push_item(item, new_item_count)
@@ -352,7 +352,7 @@ class FileSystemDatasetClient(DatasetClient):
         unwind: list[str] | None = None,
         skip_empty: bool = False,
         skip_hidden: bool = False,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncIterator[Mapping[str, JsonSerializable]]:
         # Check for unsupported arguments and log a warning if found.
         unsupported_args: dict[str, Any] = {
             'clean': clean,

--- a/src/crawlee/storage_clients/_file_system/_dataset_client.py
+++ b/src/crawlee/storage_clients/_file_system/_dataset_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import shutil
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from logging import getLogger
 from pathlib import Path
@@ -12,6 +13,7 @@ from pydantic import ValidationError
 from typing_extensions import Self, override
 
 from crawlee._consts import METADATA_FILENAME
+from crawlee._types import JsonSerializable
 from crawlee._utils.crypto import crypto_random_object_id
 from crawlee._utils.file import atomic_write, json_dumps
 from crawlee._utils.raise_if_too_many_kwargs import raise_if_too_many_kwargs
@@ -19,7 +21,7 @@ from crawlee.storage_clients._base import DatasetClient
 from crawlee.storage_clients.models import DatasetItemsListPage, DatasetMetadata
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Sequence
 
     from crawlee.configuration import Configuration
 
@@ -220,10 +222,10 @@ class FileSystemDatasetClient(DatasetClient):
             )
 
     @override
-    async def push_data(self, data: list[dict[str, Any]] | dict[str, Any]) -> None:
+    async def push_data(self, data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable]) -> None:
         async with self._lock:
             new_item_count = self._metadata.item_count
-            if isinstance(data, list):
+            if self._is_list_of_items(data):
                 for item in data:
                     new_item_count += 1
                     await self._push_item(item, new_item_count)
@@ -304,7 +306,7 @@ class FileSystemDatasetClient(DatasetClient):
             selected_files = selected_files[:limit]
 
         # Read and parse each data file.
-        items = list[dict[str, Any]]()
+        items = list[Mapping[str, JsonSerializable]]()
         for file_path in selected_files:
             try:
                 file_content = await asyncio.to_thread(file_path.read_text, encoding='utf-8')
@@ -441,7 +443,7 @@ class FileSystemDatasetClient(DatasetClient):
         data = await json_dumps(self._metadata.model_dump())
         await atomic_write(self.path_to_metadata, data)
 
-    async def _push_item(self, item: dict[str, Any], item_id: int) -> None:
+    async def _push_item(self, item: Mapping[str, JsonSerializable], item_id: int) -> None:
         """Push a single item to the dataset.
 
         This method writes the item as a JSON file with a zero-padded numeric filename

--- a/src/crawlee/storage_clients/_memory/_dataset_client.py
+++ b/src/crawlee/storage_clients/_memory/_dataset_client.py
@@ -120,7 +120,7 @@ class MemoryDatasetClient(DatasetClient):
         metadata = await self.get_metadata()
         new_item_count = metadata.item_count
 
-        if self._is_list_of_items(data):
+        if self._is_sequence_of_items(data):
             for item in data:
                 new_item_count += 1
                 await self._push_item(item)

--- a/src/crawlee/storage_clients/_memory/_dataset_client.py
+++ b/src/crawlee/storage_clients/_memory/_dataset_client.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from logging import getLogger
 from typing import TYPE_CHECKING, Any
 
 from typing_extensions import Self, override
 
+from crawlee._types import JsonSerializable
 from crawlee._utils.crypto import crypto_random_object_id
 from crawlee._utils.raise_if_too_many_kwargs import raise_if_too_many_kwargs
 from crawlee.storage_clients._base import DatasetClient
 from crawlee.storage_clients.models import DatasetItemsListPage, DatasetMetadata
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Sequence
+
 
 logger = getLogger(__name__)
 
@@ -41,7 +44,7 @@ class MemoryDatasetClient(DatasetClient):
         """
         self._metadata = metadata
 
-        self._records = list[dict[str, Any]]()
+        self._records = list[Mapping[str, JsonSerializable]]()
         """List to hold dataset items. Each item is a dictionary representing a record."""
 
     @override
@@ -113,11 +116,11 @@ class MemoryDatasetClient(DatasetClient):
         )
 
     @override
-    async def push_data(self, data: list[dict[str, Any]] | dict[str, Any]) -> None:
+    async def push_data(self, data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable]) -> None:
         metadata = await self.get_metadata()
         new_item_count = metadata.item_count
 
-        if isinstance(data, list):
+        if self._is_list_of_items(data):
             for item in data:
                 new_item_count += 1
                 await self._push_item(item)
@@ -203,7 +206,7 @@ class MemoryDatasetClient(DatasetClient):
         unwind: list[str] | None = None,
         skip_empty: bool = False,
         skip_hidden: bool = False,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncIterator[Mapping[str, JsonSerializable]]:
         # Check for unsupported arguments and log a warning if found
         unsupported_args: dict[str, Any] = {
             'clean': clean,
@@ -260,7 +263,7 @@ class MemoryDatasetClient(DatasetClient):
         if new_item_count is not None:
             self._metadata.item_count = new_item_count
 
-    async def _push_item(self, item: dict[str, Any]) -> None:
+    async def _push_item(self, item: Mapping[str, JsonSerializable]) -> None:
         """Push a single item to the dataset.
 
         Args:

--- a/src/crawlee/storage_clients/_redis/_dataset_client.py
+++ b/src/crawlee/storage_clients/_redis/_dataset_client.py
@@ -14,10 +14,12 @@ from ._client_mixin import MetadataUpdateParams, RedisClientMixin
 from ._utils import await_redis_response
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Mapping, Sequence
 
     from redis.asyncio import Redis
     from redis.asyncio.client import Pipeline
+
+    from crawlee._types import JsonSerializable
 
 logger = getLogger(__name__)
 
@@ -126,8 +128,8 @@ class RedisDatasetClient(DatasetClient, RedisClientMixin):
 
     @retry_on_error(RedisError)
     @override
-    async def push_data(self, data: list[dict[str, Any]] | dict[str, Any]) -> None:
-        if isinstance(data, dict):
+    async def push_data(self, data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable]) -> None:
+        if not self._is_list_of_items(data):
             data = [data]
 
         async with self._get_pipeline() as pipe:

--- a/src/crawlee/storage_clients/_redis/_dataset_client.py
+++ b/src/crawlee/storage_clients/_redis/_dataset_client.py
@@ -129,7 +129,7 @@ class RedisDatasetClient(DatasetClient, RedisClientMixin):
     @retry_on_error(RedisError)
     @override
     async def push_data(self, data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable]) -> None:
-        if not self._is_list_of_items(data):
+        if not self._is_sequence_of_items(data):
             data = [data]
 
         async with self._get_pipeline() as pipe:
@@ -239,7 +239,7 @@ class RedisDatasetClient(DatasetClient, RedisClientMixin):
         unwind: list[str] | None = None,
         skip_empty: bool = False,
         skip_hidden: bool = False,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncIterator[Mapping[str, JsonSerializable]]:
         """Iterate over dataset items one by one.
 
         This method yields items individually instead of loading all items at once,
@@ -303,7 +303,7 @@ class RedisDatasetClient(DatasetClient, RedisClientMixin):
                 if skip_empty and not item:
                     continue
 
-                yield cast('dict[str, Any]', item)
+                yield cast('Mapping[str, JsonSerializable]', item)
 
         async with self._get_pipeline() as pipe:
             await self._update_metadata(pipe, **_DatasetMetadataUpdateParams(update_accessed_at=True))

--- a/src/crawlee/storage_clients/_sql/_dataset_client.py
+++ b/src/crawlee/storage_clients/_sql/_dataset_client.py
@@ -17,11 +17,13 @@ from ._client_mixin import MetadataUpdateParams, SqlClientMixin
 from ._db_models import DatasetItemDb, DatasetMetadataBufferDb, DatasetMetadataDb
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Mapping, Sequence
 
     from sqlalchemy import Select
     from sqlalchemy.ext.asyncio import AsyncSession
     from typing_extensions import NotRequired
+
+    from crawlee._types import JsonSerializable
 
     from ._storage_client import SqlStorageClient
 
@@ -144,8 +146,8 @@ class SqlDatasetClient(DatasetClient, SqlClientMixin):
 
     @retry_on_error(SQLAlchemyError)
     @override
-    async def push_data(self, data: list[dict[str, Any]] | dict[str, Any]) -> None:
-        if not isinstance(data, list):
+    async def push_data(self, data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable]) -> None:
+        if not self._is_list_of_items(data):
             data = [data]
 
         db_items = [{'dataset_id': self._id, 'data': item} for item in data]

--- a/src/crawlee/storage_clients/_sql/_dataset_client.py
+++ b/src/crawlee/storage_clients/_sql/_dataset_client.py
@@ -147,7 +147,7 @@ class SqlDatasetClient(DatasetClient, SqlClientMixin):
     @retry_on_error(SQLAlchemyError)
     @override
     async def push_data(self, data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable]) -> None:
-        if not self._is_list_of_items(data):
+        if not self._is_sequence_of_items(data):
             data = [data]
 
         db_items = [{'dataset_id': self._id, 'data': item} for item in data]
@@ -219,7 +219,7 @@ class SqlDatasetClient(DatasetClient, SqlClientMixin):
         unwind: list[str] | None = None,
         skip_empty: bool = False,
         skip_hidden: bool = False,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncIterator[Mapping[str, JsonSerializable]]:
         stmt = self._prepare_get_stmt(
             offset=offset,
             limit=limit,

--- a/src/crawlee/storage_clients/_sql/_db_models.py
+++ b/src/crawlee/storage_clients/_sql/_db_models.py
@@ -189,7 +189,7 @@ class DatasetItemDb(Base):
     )
     """Foreign key to metadata dataset record."""
 
-    data: Mapped[list[dict[str, Any]] | dict[str, Any]] = mapped_column(JsonField, nullable=False)
+    data: Mapped[dict[str, Any]] = mapped_column(JsonField, nullable=False)
     """JSON serializable item data."""
 
     # Relationship back to parent dataset

--- a/src/crawlee/storage_clients/models.py
+++ b/src/crawlee/storage_clients/models.py
@@ -6,9 +6,12 @@ from typing import TYPE_CHECKING, Annotated, Any, Generic
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
 from typing_extensions import TypeVar
 
-from crawlee._types import HttpMethod
+from crawlee._types import HttpMethod, JsonSerializable
 from crawlee._utils.docs import docs_group
 from crawlee._utils.urls import validate_http_url
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
 
 KvsValueType = TypeVar('KvsValueType', default=Any)
 
@@ -129,7 +132,7 @@ class DatasetItemsListPage(BaseModel):
 
     # Workaround for Pydantic and type checkers when using Annotated with default_factory
     if TYPE_CHECKING:
-        items: list[dict] = []
+        items: Sequence[Mapping[str, JsonSerializable]] = []
         """The list of dataset items returned on this page."""
     else:
         items: Annotated[list[dict], Field(default_factory=list)]

--- a/src/crawlee/storages/_dataset.py
+++ b/src/crawlee/storages/_dataset.py
@@ -15,12 +15,12 @@ from ._key_value_store import KeyValueStore
 from ._utils import validate_storage_name
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Mapping, Sequence
     from typing import Any, Literal
 
     from typing_extensions import Unpack
 
-    from crawlee._types import ExportDataCsvKwargs, ExportDataJsonKwargs
+    from crawlee._types import ExportDataCsvKwargs, ExportDataJsonKwargs, JsonSerializable
     from crawlee.configuration import Configuration
     from crawlee.storage_clients import StorageClient
     from crawlee.storage_clients._base import DatasetClient
@@ -134,7 +134,7 @@ class Dataset(Storage):
     async def purge(self) -> None:
         await self._client.purge()
 
-    async def push_data(self, data: list[dict[str, Any]] | dict[str, Any]) -> None:
+    async def push_data(self, data: Sequence[Mapping[str, JsonSerializable]] | Mapping[str, JsonSerializable]) -> None:
         """Store an object or an array of objects to the dataset.
 
         The size of the data is limited by the receiving API and therefore `push_data()` will only
@@ -210,7 +210,7 @@ class Dataset(Storage):
         unwind: list[str] | None = None,
         skip_empty: bool = False,
         skip_hidden: bool = False,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncIterator[Mapping[str, JsonSerializable]]:
         """Iterate over items in the dataset according to specified filters and sorting.
 
         This method allows for asynchronously iterating through dataset items while applying various filters such as
@@ -258,7 +258,7 @@ class Dataset(Storage):
         unwind: list[str] | None = None,
         skip_empty: bool = False,
         skip_hidden: bool = False,
-    ) -> list[dict[str, Any]]:
+    ) -> list[Mapping[str, JsonSerializable]]:
         """Retrieve a list of all items from the dataset according to specified filters and sorting.
 
         This method collects all dataset items into a list while applying various filters such as

--- a/src/crawlee/storages/_key_value_store.py
+++ b/src/crawlee/storages/_key_value_store.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import MutableMapping  # noqa: TC003
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, overload
 
@@ -33,7 +33,7 @@ logger = getLogger(__name__)
 
 
 class AutosavedValue(RootModel):
-    root: dict[str, JsonSerializable]
+    root: MutableMapping[str, JsonSerializable]
 
 
 @docs_group('Storages')
@@ -262,8 +262,8 @@ class KeyValueStore(Storage):
     async def get_auto_saved_value(
         self,
         key: str,
-        default_value: dict[str, JsonSerializable] | None = None,
-    ) -> dict[str, JsonSerializable]:
+        default_value: MutableMapping[str, JsonSerializable] | None = None,
+    ) -> MutableMapping[str, JsonSerializable]:
         """Get a value from KVS that will be automatically saved on changes.
 
         Args:

--- a/uv.lock
+++ b/uv.lock
@@ -956,7 +956,7 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'sql-sqlite'", specifier = ">=2.0.0,<3.0.0" },
     { name = "tldextract", specifier = ">=5.1.0" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12.0" },
-    { name = "typing-extensions", specifier = ">=4.1.0" },
+    { name = "typing-extensions", specifier = ">=4.10.0" },
     { name = "wrapt", marker = "extra == 'otel'", specifier = ">=1.17.0" },
     { name = "yarl", specifier = ">=1.18.0" },
 ]


### PR DESCRIPTION
### Description

- Improved annotation for arguments that accept JSON data by replacing implicit `Any` with explicit `JsonSerializable` type for `push_data` and `user_data` parameters.

### Issues

- Closes: #1191