### PR TITLE
build: limit sdist contents to source and metadata files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ dev = [
 packages = ["src/crawlee"]
 
 [tool.hatch.build.targets.sdist]
-include = [
+only-include = [
     "src/crawlee",
     "CHANGELOG.md",
     "CONTRIBUTING.md",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,16 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/crawlee"]
 
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/crawlee",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "README.md",
+    "pyproject.toml",
+]
+
 [tool.ruff]
 line-length = 120
 include = ["src/**/*.py", "tests/**/*.py", "docs/**/*.py", "website/**/*.py"]


### PR DESCRIPTION
## Summary

The latest beta release ([run 25675751322](https://github.com/apify/crawlee-python/actions/runs/25675751322/job/75373186335)) failed when uploading the sdist:

```
400 Bad Request — Project size too large. Limit for project 'crawlee' total size is 10 GB.
```

`pyproject.toml` only configured the wheel target, so hatchling's default sdist bundled the entire repo — including `website/` (42 MB of Docusaurus demo MP4s/GIFs and versioned docs). Each released sdist was ~24.7 MB instead of ~280 KB. Combined with the fact that a beta release is published on every src-touching commit to master, the cumulative storage quota on PyPI hit the 10 GB cap fast.

This PR adds an explicit `[tool.hatch.build.targets.sdist]` that ships only `src/crawlee` and standard metadata files (`LICENSE`, `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `pyproject.toml`). Verified locally: sdist drops from 24.7 MB → ~280 KB (~88×).

Tests are intentionally excluded — they need dev-only deps (playwright, fakeredis, proxy-py, apify-cli) that aren't installable from a plain sdist anyway.

## Note

PyPI's cap is cumulative across all uploaded files, so this PR doesn't unblock the pending beta on its own — we still need to request a [project size limit increase](https://docs.pypi.org/project-management/storage-limits#requesting-a-project-size-limit-increase). It just stops future releases from chewing through quota.