### PR TITLE
test: bound `serve_in_thread` teardown to prevent CI hangs

### DIFF
--- a/tests/unit/server.py
+++ b/tests/unit/server.py
@@ -541,7 +541,7 @@ class TestServer(Server):
 
 def serve_in_thread(server: TestServer) -> Iterator[TestServer]:
     """Run a server in a background thread and yield it."""
-    thread = threading.Thread(target=server.run)
+    thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
     try:
         while not server.started:
@@ -549,4 +549,9 @@ def serve_in_thread(server: TestServer) -> Iterator[TestServer]:
         yield server
     finally:
         server.should_exit = True
-        thread.join()
+        thread.join(timeout=10)
+        if thread.is_alive():
+            # Uvicorn occasionally ignores should_exit; force_exit aborts the
+            # asyncio loop so teardown cannot hang the suite indefinitely.
+            server.force_exit = True
+            thread.join(timeout=5)


### PR DESCRIPTION
The session-scoped `http_server` fixture's teardown in `tests/unit/server.py` called `thread.join()` with no timeout. When uvicorn occasionally fails to honor `should_exit` (it's stuck inside the asyncio loop's selector poll), the join blocks indefinitely — pytest-timeout eventually kills the run after 30 minutes, taking down the whole job.

The fix bounds the teardown:

1. `thread.join(timeout=10)` — wait for graceful shutdown.
2. If still alive, set `server.force_exit = True` and `thread.join(timeout=5)` — uvicorn's documented hard-exit path.
3. Mark the worker thread as `daemon=True` so an abandoned thread cannot keep the interpreter alive at process exit.

Observed failure: https://github.com/apify/crawlee-python/actions/runs/25720617454/job/75520659980