### PR TITLE
ci: Add package pre-publish check

### DIFF
--- a/.github/workflows/_check_package.yaml
+++ b/.github/workflows/_check_package.yaml
@@ -27,7 +27,7 @@ jobs:
         run: uv run poe build
 
       - name: Verify built package
-        uses: apify/actions/python-package-check@main
+        uses: apify/actions/python-package-check@v1.1.0
         with:
           package_name: crawlee
           dist_dir: dist

--- a/.github/workflows/_check_package.yaml
+++ b/.github/workflows/_check_package.yaml
@@ -27,10 +27,9 @@ jobs:
         run: uv run poe build
 
       - name: Verify built package
-        uses: apify/workflows/python-package-check@main
+        uses: apify/actions/python-package-check@feat/python-package-check-action
         with:
           package_name: crawlee
-          src_package_dir: src/crawlee
           dist_dir: dist
           python_version: "3.14"
           extras: all

--- a/.github/workflows/_check_package.yaml
+++ b/.github/workflows/_check_package.yaml
@@ -1,0 +1,47 @@
+name: Package check
+
+on:
+  # Runs when manually triggered from the GitHub UI.
+  workflow_dispatch:
+
+  # Runs when invoked by another workflow.
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  package_check:
+    name: Package check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up uv package manager
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          python-version: "3.14"
+
+      - name: Build sdist and wheel
+        run: uv run poe build
+
+      - name: Verify built package
+        uses: apify/workflows/python-package-check@main
+        with:
+          package_name: crawlee
+          src_package_dir: src/crawlee
+          dist_dir: dist
+          python_version: "3.14"
+          extras: all
+          smoke_code: |
+            from crawlee.crawlers import (
+                HttpCrawler, BeautifulSoupCrawler, ParselCrawler,
+                PlaywrightCrawler, AdaptivePlaywrightCrawler,
+            )
+            from crawlee.storages import Dataset, KeyValueStore, RequestQueue
+            from crawlee.http_clients import HttpxHttpClient, ImpitHttpClient
+            from crawlee import Request
+            HttpCrawler()
+            BeautifulSoupCrawler()
+            ParselCrawler()

--- a/.github/workflows/_check_package.yaml
+++ b/.github/workflows/_check_package.yaml
@@ -27,7 +27,7 @@ jobs:
         run: uv run poe build
 
       - name: Verify built package
-        uses: apify/actions/python-package-check@feat/python-package-check-action
+        uses: apify/actions/python-package-check@main
         with:
           package_name: crawlee
           dist_dir: dist

--- a/.github/workflows/manual_release_beta.yaml
+++ b/.github/workflows/manual_release_beta.yaml
@@ -61,7 +61,7 @@ jobs:
           ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
 
       - name: Verify built package
-        uses: apify/actions/python-package-check@feat/python-package-check-action
+        uses: apify/actions/python-package-check@main
         with:
           package_name: crawlee
           dist_dir: dist

--- a/.github/workflows/manual_release_beta.yaml
+++ b/.github/workflows/manual_release_beta.yaml
@@ -61,10 +61,9 @@ jobs:
           ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
 
       - name: Verify built package
-        uses: apify/workflows/python-package-check@main
+        uses: apify/actions/python-package-check@feat/python-package-check-action
         with:
           package_name: crawlee
-          src_package_dir: src/crawlee
           dist_dir: dist
           python_version: "3.14"
           extras: all

--- a/.github/workflows/manual_release_beta.yaml
+++ b/.github/workflows/manual_release_beta.yaml
@@ -61,7 +61,7 @@ jobs:
           ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
 
       - name: Verify built package
-        uses: apify/actions/python-package-check@main
+        uses: apify/actions/python-package-check@v1.1.0
         with:
           package_name: crawlee
           dist_dir: dist

--- a/.github/workflows/manual_release_beta.yaml
+++ b/.github/workflows/manual_release_beta.yaml
@@ -60,6 +60,26 @@ jobs:
           version_number: ${{ needs.release_prepare.outputs.version_number }}
           ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
 
+      - name: Verify built package
+        uses: apify/workflows/python-package-check@main
+        with:
+          package_name: crawlee
+          src_package_dir: src/crawlee
+          dist_dir: dist
+          python_version: "3.14"
+          extras: all
+          smoke_code: |
+            from crawlee.crawlers import (
+                HttpCrawler, BeautifulSoupCrawler, ParselCrawler,
+                PlaywrightCrawler, AdaptivePlaywrightCrawler,
+            )
+            from crawlee.storages import Dataset, KeyValueStore, RequestQueue
+            from crawlee.http_clients import HttpxHttpClient, ImpitHttpClient
+            from crawlee import Request
+            HttpCrawler()
+            BeautifulSoupCrawler()
+            ParselCrawler()
+
       # Publish the package to PyPI using PyPA official GitHub action with OIDC authentication.
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -97,6 +97,27 @@ jobs:
           is_prerelease: ""
           version_number: ${{ needs.release_prepare.outputs.version_number }}
           ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
+
+      - name: Verify built package
+        uses: apify/workflows/python-package-check@main
+        with:
+          package_name: crawlee
+          src_package_dir: src/crawlee
+          dist_dir: dist
+          python_version: "3.14"
+          extras: all
+          smoke_code: |
+            from crawlee.crawlers import (
+                HttpCrawler, BeautifulSoupCrawler, ParselCrawler,
+                PlaywrightCrawler, AdaptivePlaywrightCrawler,
+            )
+            from crawlee.storages import Dataset, KeyValueStore, RequestQueue
+            from crawlee.http_clients import HttpxHttpClient, ImpitHttpClient
+            from crawlee import Request
+            HttpCrawler()
+            BeautifulSoupCrawler()
+            ParselCrawler()
+
       # Publish the package to PyPI using PyPA official GitHub action with OIDC authentication.
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -99,10 +99,9 @@ jobs:
           ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
 
       - name: Verify built package
-        uses: apify/workflows/python-package-check@main
+        uses: apify/actions/python-package-check@feat/python-package-check-action
         with:
           package_name: crawlee
-          src_package_dir: src/crawlee
           dist_dir: dist
           python_version: "3.14"
           extras: all

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -99,7 +99,7 @@ jobs:
           ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
 
       - name: Verify built package
-        uses: apify/actions/python-package-check@feat/python-package-check-action
+        uses: apify/actions/python-package-check@main
         with:
           package_name: crawlee
           dist_dir: dist

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -99,7 +99,7 @@ jobs:
           ref: ${{ needs.changelog_update.outputs.changelog_commitish }}
 
       - name: Verify built package
-        uses: apify/actions/python-package-check@main
+        uses: apify/actions/python-package-check@v1.1.0
         with:
           package_name: crawlee
           dist_dir: dist

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -27,24 +27,38 @@ jobs:
 
   package_check:
     name: Package check
-    uses: apify/workflows/.github/workflows/python_package_check.yaml@main
-    with:
-      package_name: crawlee
-      src_package_dir: src/crawlee
-      dist_dir: dist
-      python_version: "3.14"
-      extras: all
-      smoke_code: |
-        from crawlee.crawlers import (
-            HttpCrawler, BeautifulSoupCrawler, ParselCrawler,
-            PlaywrightCrawler, AdaptivePlaywrightCrawler,
-        )
-        from crawlee.storages import Dataset, KeyValueStore, RequestQueue
-        from crawlee.http_clients import HttpxHttpClient, ImpitHttpClient
-        from crawlee import Request
-        HttpCrawler()
-        BeautifulSoupCrawler()
-        ParselCrawler()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up uv package manager
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          python-version: "3.14"
+
+      - name: Build sdist and wheel
+        run: uv run poe build
+
+      - name: Verify built package
+        uses: apify/workflows/python-package-check@main
+        with:
+          package_name: crawlee
+          src_package_dir: src/crawlee
+          dist_dir: dist
+          python_version: "3.14"
+          extras: all
+          smoke_code: |
+            from crawlee.crawlers import (
+                HttpCrawler, BeautifulSoupCrawler, ParselCrawler,
+                PlaywrightCrawler, AdaptivePlaywrightCrawler,
+            )
+            from crawlee.storages import Dataset, KeyValueStore, RequestQueue
+            from crawlee.http_clients import HttpxHttpClient, ImpitHttpClient
+            from crawlee import Request
+            HttpCrawler()
+            BeautifulSoupCrawler()
+            ParselCrawler()
 
   tests:
     name: Tests

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -25,6 +25,27 @@ jobs:
     name: Code checks
     uses: ./.github/workflows/_check_code.yaml
 
+  package_check:
+    name: Package check
+    uses: apify/workflows/.github/workflows/python_package_check.yaml@main
+    with:
+      package_name: crawlee
+      src_package_dir: src/crawlee
+      dist_dir: dist
+      python_version: "3.14"
+      extras: all
+      smoke_code: |
+        from crawlee.crawlers import (
+            HttpCrawler, BeautifulSoupCrawler, ParselCrawler,
+            PlaywrightCrawler, AdaptivePlaywrightCrawler,
+        )
+        from crawlee.storages import Dataset, KeyValueStore, RequestQueue
+        from crawlee.http_clients import HttpxHttpClient, ImpitHttpClient
+        from crawlee import Request
+        HttpCrawler()
+        BeautifulSoupCrawler()
+        ParselCrawler()
+
   tests:
     name: Tests
     uses: ./.github/workflows/_tests.yaml

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -27,38 +27,7 @@ jobs:
 
   package_check:
     name: Package check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Set up uv package manager
-        uses: astral-sh/setup-uv@v8.1.0
-        with:
-          python-version: "3.14"
-
-      - name: Build sdist and wheel
-        run: uv run poe build
-
-      - name: Verify built package
-        uses: apify/workflows/python-package-check@main
-        with:
-          package_name: crawlee
-          src_package_dir: src/crawlee
-          dist_dir: dist
-          python_version: "3.14"
-          extras: all
-          smoke_code: |
-            from crawlee.crawlers import (
-                HttpCrawler, BeautifulSoupCrawler, ParselCrawler,
-                PlaywrightCrawler, AdaptivePlaywrightCrawler,
-            )
-            from crawlee.storages import Dataset, KeyValueStore, RequestQueue
-            from crawlee.http_clients import HttpxHttpClient, ImpitHttpClient
-            from crawlee import Request
-            HttpCrawler()
-            BeautifulSoupCrawler()
-            ParselCrawler()
+    uses: ./.github/workflows/_check_package.yaml
 
   tests:
     name: Tests


### PR DESCRIPTION
## Summary

Adds an end-to-end check that the built sdist and wheel install cleanly, expose the expected sources and data files (`py.typed`, `project_template/**`, `_redis/lua_scripts/*.lua`), and pass an import + `crawlee create` smoke test — guarding against the silent failure mode behind #1890.

Wired into every PR via a new reusable `_check_package.yaml`, and into both stable and beta release workflows so the exact artifact about to hit PyPI is verified first.