### PR TITLE
fix: include `sql_mysql` in the `all` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-all = ["crawlee[adaptive-crawler,beautifulsoup,cli,curl-impersonate,httpx,parsel,playwright,otel,sql_sqlite,sql_postgres,stagehand,redis]"]
+all = ["crawlee[adaptive-crawler,beautifulsoup,cli,curl-impersonate,httpx,parsel,playwright,otel,sql_sqlite,sql_postgres,sql_mysql,stagehand,redis]"]
 adaptive-crawler = [
     "jaro-winkler>=2.0.3",
     "playwright>=1.27.0",

--- a/uv.lock
+++ b/uv.lock
@@ -801,12 +801,14 @@ adaptive-crawler = [
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 all = [
+    { name = "aiomysql" },
     { name = "aiosqlite" },
     { name = "apify-fingerprint-datapoints" },
     { name = "asyncpg" },
     { name = "beautifulsoup4", extra = ["lxml"] },
     { name = "browserforge" },
     { name = "cookiecutter" },
+    { name = "cryptography" },
     { name = "curl-cffi" },
     { name = "html5lib" },
     { name = "httpx", extra = ["brotli", "http2", "zstd"] },
@@ -934,7 +936,7 @@ requires-dist = [
     { name = "cachetools", specifier = ">=5.5.0" },
     { name = "colorama", specifier = ">=0.4.0" },
     { name = "cookiecutter", marker = "extra == 'cli'", specifier = ">=2.6.0" },
-    { name = "crawlee", extras = ["adaptive-crawler", "beautifulsoup", "cli", "curl-impersonate", "httpx", "parsel", "playwright", "otel", "sql-sqlite", "sql-postgres", "stagehand", "redis"], marker = "extra == 'all'" },
+    { name = "crawlee", extras = ["adaptive-crawler", "beautifulsoup", "cli", "curl-impersonate", "httpx", "parsel", "playwright", "otel", "sql-sqlite", "sql-postgres", "sql-mysql", "stagehand", "redis"], marker = "extra == 'all'" },
     { name = "cryptography", marker = "extra == 'sql-mysql'", specifier = ">=46.0.5" },
     { name = "curl-cffi", marker = "extra == 'curl-impersonate'", specifier = ">=0.9.0" },
     { name = "html5lib", marker = "extra == 'beautifulsoup'", specifier = ">=1.0" },


### PR DESCRIPTION
## Summary

The `all` meta-extra was missing `sql_mysql`, so installing `crawlee[all]` did not pull in the MySQL storage client dependencies (`aiomysql`, `cryptography`). This adds it alongside the other SQL extras.