### PR TITLE
ci: retry `gh api` in scheduled-tests Slack notification

### DIFF
--- a/.github/workflows/on_schedule_tests.yaml
+++ b/.github/workflows/on_schedule_tests.yaml
@@ -91,9 +91,24 @@ jobs:
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           HEADING: ':red_circle: Scheduled e2e tests failed'
         run: |
-          failed_jobs=$(gh api \
-            "repos/${REPO}/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}/jobs?per_page=100" \
-            --jq '[.jobs[] | select(.conclusion == "failure") | "• \(.name)"] | join("\n")')
+          # Retry the API call to tolerate transient 5xx from GitHub.
+          max_attempts=5
+          fetched=0
+          for attempt in $(seq 1 "${max_attempts}"); do
+            if failed_jobs=$(gh api \
+              "repos/${REPO}/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}/jobs?per_page=100" \
+              --jq '[.jobs[] | select(.conclusion == "failure") | "• \(.name)"] | join("\n")'); then
+              fetched=1
+              break
+            fi
+            if [[ "${attempt}" -lt "${max_attempts}" ]]; then
+              sleep "$((attempt * 5))"
+            fi
+          done
+          if [[ "${fetched}" -eq 0 ]]; then
+            echo "Failed to fetch job list after ${max_attempts} attempts; sending notification without it." >&2
+            failed_jobs="(unable to fetch job list — see workflow run)"
+          fi
           jq -n \
             --arg repo "${REPO}" \
             --arg url "${WORKFLOW_URL}" \


### PR DESCRIPTION
The `Build Slack payload` step aborted on a transient HTTP 502 from `gh api`, so no Slack notification was sent. Retry the call (up to 5 attempts, linear backoff) and fall back to a placeholder message on persistent failure.

Failing run: https://github.com/apify/crawlee-python/actions/runs/25905726146/job/76143180252