### PR TITLE
test: rebuild stagehand actor after registering OPENAI_API_KEY

### DIFF
--- a/tests/e2e/project_template/test_static_crawlers_templates.py
+++ b/tests/e2e/project_template/test_static_crawlers_templates.py
@@ -116,12 +116,14 @@ async def test_static_crawler_actor_at_apify(
         # Stagehand needs the model API key in `os.environ` at run time. Env vars are baked into the
         # build at build creation time, so registering the env var on the version after `apify push`
         # is not enough — we must trigger a fresh build for the env var to be included.
+        build_number: str | None = None
         if crawler_type == 'stagehand':
             env_vars = actor.version('0.0').env_vars()
             await env_vars.create(name='OPENAI_API_KEY', value=os.environ['OPENAI_API_KEY'], is_secret=True)
-            await actor.build(version_number='0.0', wait_for_finish=600)
+            rebuild = await actor.build(version_number='0.0', wait_for_finish=600)
+            build_number = rebuild['buildNumber']
 
-        started_run_data = await actor.start(memory_mbytes=8192)
+        started_run_data = await actor.start(memory_mbytes=8192, build=build_number)
         actor_run = client.run(started_run_data['id'])
 
         finished_run_data = await actor_run.wait_for_finish()

--- a/tests/e2e/project_template/test_static_crawlers_templates.py
+++ b/tests/e2e/project_template/test_static_crawlers_templates.py
@@ -113,11 +113,13 @@ async def test_static_crawler_actor_at_apify(
     try:
         assert build_process.returncode == 0
 
-        # Stagehand needs the model API key in `os.environ` at run time; register it as a secret env var
-        # on the deployed actor version so the platform injects it into the run.
+        # Stagehand needs the model API key in `os.environ` at run time. Env vars are baked into the
+        # build at build creation time, so registering the env var on the version after `apify push`
+        # is not enough — we must trigger a fresh build for the env var to be included.
         if crawler_type == 'stagehand':
             env_vars = actor.version('0.0').env_vars()
             await env_vars.create(name='OPENAI_API_KEY', value=os.environ['OPENAI_API_KEY'], is_secret=True)
+            await actor.build(version_number='0.0', wait_for_finish=600)
 
         started_run_data = await actor.start(memory_mbytes=8192)
         actor_run = client.run(started_run_data['id'])


### PR DESCRIPTION
## Summary

The scheduled stagehand e2e test fails with `ValueError: The OPENAI_API_KEY environment variable is not set.` at actor runtime ([example failing job](https://github.com/apify/crawlee-python/actions/runs/25984272849/job/76378624262)).

Root cause: Apify bakes a version's environment variables into the build at build-creation time. The recently added code registers `OPENAI_API_KEY` on version 0.0 *after* `apify push` has already produced the build, so the env var never reaches the running container ([Apify docs](https://docs.apify.com/platform/actors/development/programming-interface/environment-variables): *"Once you start a build, you cannot change its environment variables. To use different variables, you must create a new build."*).

## Fix

After creating the env var on the version, trigger a fresh build via `actor.build(version_number='0.0', wait_for_finish=600)`. `actor.start()` then runs the newer build, which has `OPENAI_API_KEY` baked in. The extra build only runs for the `stagehand` crawler type.