### PR TITLE
test: Mark flaky Stagehand fingerprint headers test for retries on Windows

### DIFF
--- a/tests/unit/browsers/test_stagehand_browser_controller.py
+++ b/tests/unit/browsers/test_stagehand_browser_controller.py
@@ -341,6 +341,10 @@ async def test_proxy_set_browserbase(
     assert browserbase_proxy_options['proxies'][0]['password'] == 'pass'
 
 
+@pytest.mark.flaky(
+    rerun=3,
+    reason='Test is flaky on Windows when Playwright hits net::ERR_NO_BUFFER_SPACE under xdist load.',
+)
 async def test_fingerprint_headers_set_on_new_page(controller: StagehandBrowserController, server_url: URL) -> None:
     page = await controller.new_page()
 


### PR DESCRIPTION
## Summary

`tests/unit/browsers/test_stagehand_browser_controller.py::test_fingerprint_headers_set_on_new_page` occasionally fails on Windows runners with `playwright._impl._errors.Error: StagehandPage.goto: net::ERR_NO_BUFFER_SPACE` (see [this run](https://github.com/apify/crawlee-python/actions/runs/26033429603/job/76525135135)). This is the known Windows-only resource flake that already affects parallel Playwright tests under xdist load — the runner exhausts socket buffer space.

Following the same mitigation pattern already used in `test_adaptive_playwright_crawler.py:240`, the test is now marked `@pytest.mark.flaky(rerun=3, ...)` so transient `ERR_NO_BUFFER_SPACE` failures are retried instead of breaking CI.