### PR TITLE
fix(templates): Pin playwright to base image version in `uv` Dockerfile template

### DIFF
--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
@@ -54,7 +54,7 @@ COPY pyproject.toml uv.lock ./
 RUN echo "Python version:" \
     && python --version \
     && echo "Installing dependencies:" \
-    && uv sync --frozen --no-install-project --no-editable -q --no-dev --inexact \
+    && uv sync --frozen --no-install-project --no-editable --quiet --no-dev --inexact \
     && PLAYWRIGHT_BASE_VERSION=$(cat /tmp/.base-playwright-version 2>/dev/null || echo "") \
     && if [ -n "$PLAYWRIGHT_BASE_VERSION" ]; then \
         echo "Pinning playwright to $PLAYWRIGHT_BASE_VERSION to match the browser binaries shipped in the base image" \

--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
@@ -41,11 +41,11 @@ RUN echo "Python version:" \
  && echo "All installed Python packages:" \
  && pip freeze
 # % elif cookiecutter.package_manager == 'uv'
-# Snapshot the base image's playwright version before COPY/uv sync so we can pin to it later
+COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /uvx /bin/
+
+# Snapshot the base image's playwright version before uv sync so we can pin to it later
 # and stay aligned with the browser binaries baked into /pw-browsers.
-RUN pip install -U pip setuptools \
-    && pip install 'uv<1' \
-    && (hash playwright 2>/dev/null && playwright --version | cut -d ' ' -f 2 > /tmp/.base-playwright-version || true)
+RUN hash playwright 2>/dev/null && playwright --version | cut -d ' ' -f 2 > /tmp/.base-playwright-version || true
 
 ENV UV_PROJECT_ENVIRONMENT="/usr/local"
 

--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
@@ -54,18 +54,11 @@ COPY pyproject.toml uv.lock ./
 RUN echo "Python version:" \
     && python --version \
     && echo "Installing dependencies:" \
+    && uv sync --frozen --no-install-project --no-editable -q --no-dev --inexact \
     && PLAYWRIGHT_BASE_VERSION=$(cat /tmp/.base-playwright-version 2>/dev/null || echo "") \
     && if [ -n "$PLAYWRIGHT_BASE_VERSION" ]; then \
-        echo "Playwright $PLAYWRIGHT_BASE_VERSION pre-installed in base image; excluding from uv sync" \
-        && uv sync --frozen --no-install-project --no-editable -q --no-dev --inexact --no-install-package playwright \
-        && CURRENT_PLAYWRIGHT_VERSION=$(playwright --version 2>/dev/null | cut -d ' ' -f 2) \
-        && if [ "$CURRENT_PLAYWRIGHT_VERSION" != "$PLAYWRIGHT_BASE_VERSION" ]; then \
-            echo "Pinning playwright back to $PLAYWRIGHT_BASE_VERSION (was $CURRENT_PLAYWRIGHT_VERSION) to match shipped browsers" \
-            && uv pip install --reinstall --no-deps "playwright==$PLAYWRIGHT_BASE_VERSION"; \
-        fi; \
-    else \
-        echo "Playwright not found in base image, installing all dependencies as resolved in the lockfile" \
-        && uv sync --frozen --no-install-project --no-editable -q --no-dev --inexact; \
+        echo "Pinning playwright to $PLAYWRIGHT_BASE_VERSION to match the browser binaries shipped in the base image" \
+        && uv pip install --reinstall --no-deps "playwright==$PLAYWRIGHT_BASE_VERSION"; \
     fi \
     && rm -f /tmp/.base-playwright-version \
     && echo "All installed Python packages:" \

--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
@@ -41,8 +41,11 @@ RUN echo "Python version:" \
  && echo "All installed Python packages:" \
  && pip freeze
 # % elif cookiecutter.package_manager == 'uv'
+# Snapshot the base image's playwright version before COPY/uv sync so we can pin to it later
+# and stay aligned with the browser binaries baked into /pw-browsers.
 RUN pip install -U pip setuptools \
-    && pip install 'uv<1'
+    && pip install 'uv<1' \
+    && (hash playwright 2>/dev/null && playwright --version | cut -d ' ' -f 2 > /tmp/.base-playwright-version || true)
 
 ENV UV_PROJECT_ENVIRONMENT="/usr/local"
 
@@ -51,15 +54,20 @@ COPY pyproject.toml uv.lock ./
 RUN echo "Python version:" \
     && python --version \
     && echo "Installing dependencies:" \
-    # Check if playwright is already installed
-    && PLAYWRIGHT_INSTALLED=$(pip freeze | grep -q playwright && echo "true" || echo "false") \
-    && if [ "$PLAYWRIGHT_INSTALLED" = "true" ]; then \
-        echo "Playwright already installed, excluding from uv sync" \
-        && uv sync --frozen --no-install-project --no-editable -q --no-dev --inexact --no-install-package playwright; \
+    && PLAYWRIGHT_BASE_VERSION=$(cat /tmp/.base-playwright-version 2>/dev/null || echo "") \
+    && if [ -n "$PLAYWRIGHT_BASE_VERSION" ]; then \
+        echo "Playwright $PLAYWRIGHT_BASE_VERSION pre-installed in base image; excluding from uv sync" \
+        && uv sync --frozen --no-install-project --no-editable -q --no-dev --inexact --no-install-package playwright \
+        && CURRENT_PLAYWRIGHT_VERSION=$(playwright --version 2>/dev/null | cut -d ' ' -f 2) \
+        && if [ "$CURRENT_PLAYWRIGHT_VERSION" != "$PLAYWRIGHT_BASE_VERSION" ]; then \
+            echo "Pinning playwright back to $PLAYWRIGHT_BASE_VERSION (was $CURRENT_PLAYWRIGHT_VERSION) to match shipped browsers" \
+            && uv pip install --reinstall --no-deps "playwright==$PLAYWRIGHT_BASE_VERSION"; \
+        fi; \
     else \
-        echo "Playwright not found, installing all dependencies" \
+        echo "Playwright not found in base image, installing all dependencies as resolved in the lockfile" \
         && uv sync --frozen --no-install-project --no-editable -q --no-dev --inexact; \
     fi \
+    && rm -f /tmp/.base-playwright-version \
     && echo "All installed Python packages:" \
     && pip freeze
 # % elif cookiecutter.package_manager == 'pip'


### PR DESCRIPTION
## Summary

The `uv` package-manager branch of the actor Dockerfile template (`src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile`) doesn't pin Python `playwright` to the version pre-installed in the Apify base image. When the lockfile resolves to a different `playwright` version than the base image (currently 1.59.0 vs the base image's 1.60.0 + chromium-1223), the actor tries to launch a Chromium build that `/pw-browsers/` doesn't ship and fails with `Executable doesn't exist at /pw-browsers/chromium_headless_shell-1217/...`.

The pip and poetry branches solve this by sed-rewriting `playwright==X.Y.Z` to whatever `playwright --version` reports in the image. The uv branch's `--no-install-package playwright` was supposed to be the equivalent, but the test's `pip install crawlee --force-reinstall` (and any user step that touches playwright before the `uv sync` runs) defeats it.

This fix mirrors the pip/poetry intent for uv:

- **Snapshot** the base image's `playwright --version` in the early `pip install uv` layer, before `COPY pyproject.toml uv.lock ./` or any test-injected step can mutate it.
- After `uv sync ... --no-install-package playwright`, check if the env's playwright still matches; if it has drifted, force-reinstall with `uv pip install --reinstall --no-deps "playwright==<base-version>"`.
- Guard the reinstall behind a version check so the common case (no drift) skips the wheel download.

Resolves the 9 failing `uv`-variant scheduled e2e jobs in [run 26082797876](https://github.com/apify/crawlee-python/actions/runs/26082797876) (`playwright`, `adaptive_beautifulsoup`, `adaptive_parsel` × {httpx, curl_impersonate, impit}).

Verified against the live `apify/actor-python-playwright:3.13` image:
| Scenario | Before | After |
| --- | --- | --- |
| Real user, no drift | works, but `pip freeze \| grep playwright` check is brittle | guard short-circuits, no extra work |
| Test injection downgrades playwright to 1.59.0 | mismatched chromium → crash | reinstall pins to 1.60.0, browsers match |