### PR TITLE
test: Harden e2e templates test against transient apify-cli flakes

### DIFF
--- a/tests/e2e/project_template/test_static_crawlers_templates.py
+++ b/tests/e2e/project_template/test_static_crawlers_templates.py
@@ -47,6 +47,10 @@ from tests.e2e.project_template.utils import patch_crawlee_version_in_project
         pytest.param('poetry', marks=pytest.mark.poetry),
     ],
 )
+@pytest.mark.flaky(
+    reruns=3,
+    reason='`apify push` occasionally hangs against the Apify platform; retries cover transient CLI/network flakes.',
+)
 async def test_static_crawler_actor_at_apify(
     tmp_path: Path,
     crawlee_wheel_path: Path,
@@ -80,14 +84,21 @@ async def test_static_crawler_actor_at_apify(
     # Print apify version for debugging purposes in rare cases of CLI failures
     subprocess.run(['apify', '--version'], check=True)  # noqa: ASYNC221, S607
 
-    # Build actor using sequence of cli commands as the user would
+    # Build actor using sequence of cli commands as the user would.
     subprocess.run(  # noqa: ASYNC221, S603
         ['apify', 'login', '-t', os.environ['APIFY_TEST_USER_API_TOKEN']],  # noqa: S607
         capture_output=True,
         check=True,
         cwd=tmp_path / actor_name,
+        timeout=120,
     )
-    subprocess.run(['apify', 'init', '-y', actor_name], capture_output=True, check=True, cwd=tmp_path / actor_name)  # noqa: ASYNC221, S603, S607
+    subprocess.run(  # noqa: ASYNC221, S603
+        ['apify', 'init', '-y', actor_name],  # noqa: S607
+        capture_output=True,
+        check=True,
+        cwd=tmp_path / actor_name,
+        timeout=120,
+    )
 
     build_process = subprocess.run(  # noqa: ASYNC221
         ['apify', 'push'],  # noqa: S607
@@ -97,6 +108,7 @@ async def test_static_crawler_actor_at_apify(
         # Prevent git from walking up into the surrounding project's .git/ when running under
         # a basetemp inside the repo (see --basetemp in the e2e-templates-tests poe task).
         env={**os.environ, 'GIT_CEILING_DIRECTORIES': str(tmp_path)},
+        timeout=600,
     )
     # Get actor ID from build log
     actor_id_regexp = re.compile(r'https:\/\/console\.apify\.com\/actors\/(.*)#\/builds\/\d*\.\d*\.\d*')

--- a/tests/e2e/project_template/test_static_crawlers_templates.py
+++ b/tests/e2e/project_template/test_static_crawlers_templates.py
@@ -108,7 +108,7 @@ async def test_static_crawler_actor_at_apify(
         # Prevent git from walking up into the surrounding project's .git/ when running under
         # a basetemp inside the repo (see --basetemp in the e2e-templates-tests poe task).
         env={**os.environ, 'GIT_CEILING_DIRECTORIES': str(tmp_path)},
-        timeout=600,
+        timeout=120,
     )
     # Get actor ID from build log
     actor_id_regexp = re.compile(r'https:\/\/console\.apify\.com\/actors\/(.*)#\/builds\/\d*\.\d*\.\d*')

--- a/tests/unit/browsers/test_browser_pool.py
+++ b/tests/unit/browsers/test_browser_pool.py
@@ -74,7 +74,7 @@ async def test_multiple_plugins_new_page_creation(server_url: URL) -> None:
 
 
 @pytest.mark.flaky(
-    rerun=3,
+    reruns=3,
     reason='Test is flaky on Windows and MacOS, see https://github.com/apify/crawlee-python/issues/1660.',
 )
 async def test_new_page_with_each_plugin(server_url: URL) -> None:

--- a/tests/unit/browsers/test_stagehand_browser_controller.py
+++ b/tests/unit/browsers/test_stagehand_browser_controller.py
@@ -342,7 +342,7 @@ async def test_proxy_set_browserbase(
 
 
 @pytest.mark.flaky(
-    rerun=3,
+    reruns=3,
     reason='Test is flaky on Windows when Playwright hits net::ERR_NO_BUFFER_SPACE under xdist load.',
 )
 async def test_fingerprint_headers_set_on_new_page(controller: StagehandBrowserController, server_url: URL) -> None:

--- a/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
+++ b/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
@@ -238,7 +238,7 @@ async def test_adaptive_crawling_parsel(test_urls: list[str]) -> None:
 
 
 @pytest.mark.flaky(
-    rerun=3,
+    reruns=3,
     reason='Test is flaky on Windows when Playwright hits net::ERR_NO_BUFFER_SPACE and retries, '
     'causing the pre-nav hook to fire one extra time.',
 )
@@ -637,7 +637,7 @@ async def test_adaptive_playwright_crawler_default_predictor(test_urls: list[str
 
 
 @pytest.mark.flaky(
-    rerun=3,
+    reruns=3,
     reason='Test is flaky on Windows and MacOS, see https://github.com/apify/crawlee-python/issues/1650.',
 )
 async def test_adaptive_context_query_selector_beautiful_soup(test_urls: list[str]) -> None:
@@ -683,7 +683,7 @@ async def test_adaptive_context_query_selector_beautiful_soup(test_urls: list[st
 
 
 @pytest.mark.flaky(
-    rerun=3,
+    reruns=3,
     reason='Test is flaky on Windows and MacOS, see https://github.com/apify/crawlee-python/issues/1650.',
 )
 async def test_adaptive_context_query_selector_parsel(test_urls: list[str]) -> None:


### PR DESCRIPTION
## Summary

Today's [scheduled run](https://github.com/apify/crawlee-python/actions/runs/26136278735) had the `playwright_chrome+impit+pip` variant of `test_static_crawler_actor_at_apify` hang on `apify push` for the full 30-minute `pytest-timeout` window ([job log](https://github.com/apify/crawlee-python/actions/runs/26136278735/job/76872087287)). Yesterday it was a different combination — these are transient `apify-cli` / network flakes, not a code bug.

Two test-infrastructure fixes:

- **`@pytest.mark.flaky(reruns=3)`** on `test_static_crawler_actor_at_apify`, plus **`timeout=120`** on every `apify-cli` `subprocess.run` (`login`, `init`, `push`). A hung CLI now fails fast instead of burning the whole pytest-timeout window; the reruns absorb the transient.
- **Fix `rerun=` → `reruns=` kwarg typo** in five existing `@pytest.mark.flaky` decorators. `pytest-rerunfailures` reads `reruns` (plural) — the typo silently meant 1 retry instead of 3 for the affected unit tests.

The Stagehand `ECONNREFUSED` failures from the same scheduled run are a separate bug, fixed in #1906.