### PR TITLE
test: Give Apify builds more time in scheduled e2e templates test

### DIFF
--- a/tests/e2e/project_template/test_static_crawlers_templates.py
+++ b/tests/e2e/project_template/test_static_crawlers_templates.py
@@ -90,14 +90,14 @@ async def test_static_crawler_actor_at_apify(
         capture_output=True,
         check=True,
         cwd=tmp_path / actor_name,
-        timeout=120,
+        timeout=600,
     )
     subprocess.run(  # noqa: ASYNC221, S603
         ['apify', 'init', '-y', actor_name],  # noqa: S607
         capture_output=True,
         check=True,
         cwd=tmp_path / actor_name,
-        timeout=120,
+        timeout=600,
     )
 
     build_process = subprocess.run(  # noqa: ASYNC221
@@ -108,7 +108,7 @@ async def test_static_crawler_actor_at_apify(
         # Prevent git from walking up into the surrounding project's .git/ when running under
         # a basetemp inside the repo (see --basetemp in the e2e-templates-tests poe task).
         env={**os.environ, 'GIT_CEILING_DIRECTORIES': str(tmp_path)},
-        timeout=120,
+        timeout=600,
     )
     # Get actor ID from build log
     actor_id_regexp = re.compile(r'https:\/\/console\.apify\.com\/actors\/(.*)#\/builds\/\d*\.\d*\.\d*')

--- a/tests/e2e/project_template/test_static_crawlers_templates.py
+++ b/tests/e2e/project_template/test_static_crawlers_templates.py
@@ -132,8 +132,17 @@ async def test_static_crawler_actor_at_apify(
         if crawler_type == 'stagehand':
             env_vars = actor.version('0.0').env_vars()
             await env_vars.create(name='OPENAI_API_KEY', value=os.environ['OPENAI_API_KEY'], is_secret=True)
-            rebuild = await actor.build(version_number='0.0', wait_for_finish=600)
-            build_number = rebuild['buildNumber']
+            # `ActorClientAsync.build`'s `wait_for_finish` parameter is capped server-side at 60s,
+            # which is shorter than a stagehand build (playwright + browser deps). Trigger the build,
+            # then poll client-side via `BuildClientAsync.wait_for_finish` until it reaches a terminal
+            # status, and assert it succeeded before starting the run.
+            rebuild = await actor.build(version_number='0.0')
+            finished_build = await client.build(rebuild['id']).wait_for_finish(wait_secs=900)
+            assert finished_build is not None, 'Stagehand rebuild did not reach a terminal status within 900s.'
+            assert finished_build['status'] == 'SUCCEEDED', (
+                f'Stagehand rebuild did not succeed: status={finished_build["status"]!r}, build={finished_build}'
+            )
+            build_number = finished_build['buildNumber']
 
         started_run_data = await actor.start(memory_mbytes=8192, build=build_number)
         actor_run = client.run(started_run_data['id'])


### PR DESCRIPTION
## Summary

Two related scheduled e2e failures, both fixed by giving Apify builds more time to complete.

### 1. Stagehand rebuild: `wait_for_finish=600` was silently clipped to 60s

The scheduled stagehand tests have been failing on every run since [#1900](https://github.com/apify/crawlee-python/pull/1900) added the post-`env_vars.create` rebuild ([example](https://github.com/apify/crawlee-python/actions/runs/26263684679/job/77302398839)):

```
apify_client.errors.ApifyApiError: The build has not finished or was not successful.
```

`ActorClientAsync.build()`'s `wait_for_finish` parameter is clipped server-side to a max of 60s ("By default it is 0, the maximum value is 60"). A stagehand build (playwright + browser deps) does not finish in 60s, so `actor.build()` returned a still-`PROCESSING` build and `actor.start(build=build_number)` was rejected.

**Fix:** After triggering the rebuild, poll client-side via `client.build(<id>).wait_for_finish(wait_secs=900)` — which uses long-poll requests and actually waits up to the requested duration — then assert `status == 'SUCCEEDED'` before passing the build to `actor.start()`.

### 2. `apify push` 120s timeout was too tight for heavier templates

The `poetry-curl-impersonate-adaptive-parsel` variant times out on every rerun ([example](https://github.com/apify/crawlee-python/actions/runs/26263684679/job/77302398558)):

```
subprocess.TimeoutExpired: Command '['apify', 'push']' timed out after 120 seconds
```

`apify push` waits server-side for the Docker build to finish before returning. The captured stderr shows a ~550 MB base image mid-download when the timeout fires — the CLI isn't hung, the build is just legitimately slower than 120s for heavier templates. Job total (522s ≈ 4 × 120s) confirms every rerun hits the same wall, so retries don't help.

**Fix:** Bump all three apify-cli `subprocess.run` timeouts (`login`, `init`, `push`) from 120s to 600s. The 1800s `pytest-timeout` per test still bounds a truly hung CLI; `@pytest.mark.flaky(reruns=3)` still covers transient network/CLI flakes.