### PR TITLE
test: Bump apify-cli subprocess timeouts to 600s for heavier templates

### DIFF
--- a/tests/e2e/project_template/test_static_crawlers_templates.py
+++ b/tests/e2e/project_template/test_static_crawlers_templates.py
@@ -90,14 +90,14 @@ async def test_static_crawler_actor_at_apify(
         capture_output=True,
         check=True,
         cwd=tmp_path / actor_name,
-        timeout=120,
+        timeout=600,
     )
     subprocess.run(  # noqa: ASYNC221, S603
         ['apify', 'init', '-y', actor_name],  # noqa: S607
         capture_output=True,
         check=True,
         cwd=tmp_path / actor_name,
-        timeout=120,
+        timeout=600,
     )
 
     build_process = subprocess.run(  # noqa: ASYNC221
@@ -108,7 +108,7 @@ async def test_static_crawler_actor_at_apify(
         # Prevent git from walking up into the surrounding project's .git/ when running under
         # a basetemp inside the repo (see --basetemp in the e2e-templates-tests poe task).
         env={**os.environ, 'GIT_CEILING_DIRECTORIES': str(tmp_path)},
-        timeout=120,
+        timeout=600,
     )
     # Get actor ID from build log
     actor_id_regexp = re.compile(r'https:\/\/console\.apify\.com\/actors\/(.*)#\/builds\/\d*\.\d*\.\d*')


### PR DESCRIPTION
## Summary

The `poetry-curl-impersonate-adaptive-parsel` variant of `test_static_crawler_actor_at_apify` is failing every scheduled run with `subprocess.TimeoutExpired: Command '['apify', 'push']' timed out after 120 seconds` ([example failing job](https://github.com/apify/crawlee-python/actions/runs/26263684679/job/77302398558)). The job total (522s) matches 4 × 120s + setup, i.e. the timeout fires on every rerun — retries cannot absorb the wall.

**Root cause:** `apify push` waits server-side for the actor's Docker build to finish before returning. The captured stderr shows a ~550 MB base image mid-download when the timeout fires:

```
#6 sha256:a9e4a63… 99.61MB / 547.96MB 1.5s
```

So the CLI is not hung — the build is just genuinely slower than 120s for heavier templates (adaptive crawlers, playwright-based ones). The 120s timeout was added in #1905 with the reasoning that a hung CLI should fail fast, but that's a false dichotomy for builds that take 2–5 minutes.

## Fix

Bump the timeout on all three apify-cli `subprocess.run` calls (`login`, `init`, `push`) from 120s to 600s. The 1800s `pytest-timeout` per test still bounds a truly hung CLI, and `@pytest.mark.flaky(reruns=3)` still covers transient network/CLI flakes.