### PR TITLE
ci: Grant `checks: read` to doc release job in on_master

### DIFF
--- a/.github/workflows/manual_release_docs.yaml
+++ b/.github/workflows/manual_release_docs.yaml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       # Gate manual dispatches on the `Checks` workflow already succeeding on this commit (run by `on_master.yaml`);
-      # skipped when called from another workflow. TODO: pin to a tag after apify/workflows#238 is merged.
+      # skipped when called from another workflow.
       - name: Wait for checks
         if: github.event_name == 'workflow_dispatch'
-        uses: apify/workflows/wait-for-checks@wait-for-checks-action
+        uses: apify/actions/wait-for-checks@v1.2.0
         with:
           ref: ${{ github.sha }}
           check-regexp: '^Checks'

--- a/.github/workflows/on_master.yaml
+++ b/.github/workflows/on_master.yaml
@@ -28,6 +28,7 @@ jobs:
       contents: write
       pages: write
       id-token: write
+      checks: read
     uses: ./.github/workflows/manual_release_docs.yaml
     secrets: inherit
 


### PR DESCRIPTION
## Summary

After merging #1913, `on_master.yaml` started failing with:

> The nested job 'release_docs' is requesting 'checks: read', but is only allowed 'checks: none'.

When a workflow is called via `uses:`, the caller's `permissions:` block must explicitly include every permission the called workflow requests. The `doc_release` job in `on_master.yaml` was missing `checks: read`, which `manual_release_docs.yaml` requests for its wait-for-checks step.

Also pins the wait-for-checks action in `manual_release_docs.yaml` to `apify/actions/wait-for-checks@v1.2.0` (the file slipped through the original PR — the other three release workflows already use the tagged version).