### PR TITLE
ci: Grant `checks: read` to remaining reusable-workflow callers

### DIFF
--- a/.github/workflows/manual_release_beta.yaml
+++ b/.github/workflows/manual_release_beta.yaml
@@ -104,5 +104,6 @@ jobs:
       contents: write
       pages: write
       id-token: write
+      checks: read
     uses: ./.github/workflows/manual_release_docs.yaml
     secrets: inherit

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -138,6 +138,7 @@ jobs:
     needs: [release_prepare, changelog_update, pypi_publish]
     permissions:
       contents: write
+      checks: read
     uses: ./.github/workflows/manual_version_docs.yaml
     with:
       # Pass the bumped version explicitly — the job's checkout uses the dispatch ref (pre-bump),
@@ -152,5 +153,6 @@ jobs:
       contents: write
       pages: write
       id-token: write
+      checks: read
     uses: ./.github/workflows/manual_release_docs.yaml
     secrets: inherit


### PR DESCRIPTION
## Summary

Same kind of permission error as #1914, but in the remaining callers — trying to dispatch the beta release surfaced this on `manual_release_beta.yaml`:

> The nested job 'release_docs' is requesting 'checks: read', but is only allowed 'checks: none'.

A reusable workflow is capped at the permissions the calling job declares. Both `manual_release_docs.yaml` and `manual_version_docs.yaml` request `checks: read` for their (conditional) wait-for-checks step, so every caller must grant it. This PR adds `checks: read` to the three remaining callers:

- `manual_release_beta.yaml` → `doc_release_post_publish`
- `manual_release_stable.yaml` → `version_docs`
- `manual_release_stable.yaml` → `doc_release`

I audited the rest: `_checks.yaml` only needs `contents: read` (the default), so its callers in `on_master.yaml` and `on_pull_request.yaml` are fine.