### PR TITLE
test: Bump goto timeout in flaky `test_resource_management`

### DIFF
--- a/tests/unit/browsers/test_browser_pool.py
+++ b/tests/unit/browsers/test_browser_pool.py
@@ -143,7 +143,8 @@ async def test_resource_management(server_url: URL) -> None:
 
     async with BrowserPool([playwright_plugin]) as browser_pool:
         page = await browser_pool.new_page()
-        await page.page.goto(str(server_url))
+        # Use a generous navigation timeout to avoid flakes on slow Windows CI runners.
+        await page.page.goto(str(server_url), timeout=60_000)
         assert page.page.url == str(server_url)
         assert '<html' in await page.page.content()  # there is some HTML content
         assert browser_pool.total_pages_count == 1


### PR DESCRIPTION
## Summary

- `tests/unit/browsers/test_browser_pool.py::test_resource_management` has been failing intermittently on `windows-latest` + Python 3.14 with `playwright._impl._errors.TimeoutError: Page.goto: Timeout 30000ms exceeded`.
- Root cause: Playwright's default 30s navigation timeout is too short for a cold Windows + 3.14 CI runner; the local test server is fine, but Chromium's page load (waiting for `load`) overruns the default budget.
- Fix: Pass an explicit `timeout=60_000` to the single `page.goto(...)` call in this test.

Failure run for reference: https://github.com/apify/crawlee-python/actions/runs/26436864359/job/77821574408