### PR TITLE
docs: Adopt `@apify/docusaurus-plugin-typedoc-api` 5.1.7

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -23,7 +23,7 @@
         "preinstall": "npx only-allow pnpm"
     },
     "dependencies": {
-        "@apify/docusaurus-plugin-typedoc-api": "^5.1.0",
+        "@apify/docusaurus-plugin-typedoc-api": "^5.1.7",
         "@apify/utilities": "^2.8.0",
         "@docusaurus/core": "^3.9.2",
         "@docusaurus/faster": "^3.9.2",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@apify/docusaurus-plugin-typedoc-api':
-        specifier: ^5.1.0
-        version: 5.1.4(b5d850f32c50aa67ed4d2687a57dffc8)
+        specifier: ^5.1.7
+        version: 5.1.7(b5d850f32c50aa67ed4d2687a57dffc8)
       '@apify/utilities':
         specifier: ^2.8.0
         version: 2.26.1
@@ -237,8 +237,8 @@ packages:
   '@apify/consts@2.52.1':
     resolution: {integrity: sha512-Nhal8FiIgAw5ylVL4U2DAeJJyKow0bFObAX/og5BJjB9xJ2csQcyVAx4ChnO7XOaeRU8HbRn9u0QUGzPt5NNqA==}
 
-  '@apify/docusaurus-plugin-typedoc-api@5.1.4':
-    resolution: {integrity: sha512-/h960ua/DQnE8i7k2pXws+8gZojv7PCL4vPgAYjSqwiC3zB+Mqz/csHB3BK6rFRW+Exizo2TCtFoH8Syq0jQiQ==}
+  '@apify/docusaurus-plugin-typedoc-api@5.1.7':
+    resolution: {integrity: sha512-W70ZTzwDxcY1PUu6jRF+OfHG4zk3lgBsXjjMm9+2SS9tZH8Ajj/musVq/+4DQdFrWXBNvtq3vqkZnA4B1Idd3Q==}
     engines: {node: '>=16.12.0'}
     peerDependencies:
       '@docusaurus/core': ^3.8.1
@@ -2435,6 +2435,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -7154,6 +7155,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   value-equal@1.0.1:
@@ -7528,7 +7530,7 @@ snapshots:
 
   '@apify/consts@2.52.1': {}
 
-  '@apify/docusaurus-plugin-typedoc-api@5.1.4(b5d850f32c50aa67ed4d2687a57dffc8)':
+  '@apify/docusaurus-plugin-typedoc-api@5.1.7(b5d850f32c50aa67ed4d2687a57dffc8)':
     dependencies:
       '@docusaurus/core': 3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.24)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5))(@rspack/core@1.7.11)(@swc/core@1.15.24)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
       '@docusaurus/mdx-loader': 3.10.0(@swc/core@1.15.24)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)


### PR DESCRIPTION
## Summary

Bump `@apify/docusaurus-plugin-typedoc-api` from `^5.1.0` (resolved 5.1.4) to `^5.1.7` in `website/` to pick up the latest fixes and improvements from upstream.