### PR TITLE
test: Mark `test_resource_management` flaky on Windows

### DIFF
--- a/tests/unit/browsers/test_browser_pool.py
+++ b/tests/unit/browsers/test_browser_pool.py
@@ -138,6 +138,10 @@ async def test_new_page_with_invalid_plugin() -> None:
             await browser_pool.new_page(browser_plugin=plugin_2)
 
 
+@pytest.mark.flaky(
+    reruns=3,
+    reason='Test is flaky on Windows when Playwright hits net::ERR_NO_BUFFER_SPACE under xdist load.',
+)
 async def test_resource_management(server_url: URL) -> None:
     playwright_plugin = PlaywrightBrowserPlugin(browser_type='chromium')
 


### PR DESCRIPTION
### Description

`tests/unit/browsers/test_browser_pool.py::test_resource_management` failed on master CI (Windows, Python 3.10) with `playwright._impl._errors.Error: Page.goto: net::ERR_NO_BUFFER_SPACE` — see [run 26453810483](https://github.com/apify/crawlee-python/actions/runs/26453810483/job/77881886837).

The previous fix (#1916) bumped the `goto` timeout to 60s, but the failure is not a slow response — it's a hard kernel-level socket buffer exhaustion on Windows when many xdist workers simultaneously launch Chromium and open sockets. A larger timeout cannot help.

Mark the test with `@pytest.mark.flaky(reruns=3)` to match the existing project precedent for this exact failure mode (see `test_stagehand_browser_controller.py` and `test_adaptive_playwright_crawler.py`).