### PR TITLE
docs: add Invisible Firefox stealth browser example

### DIFF
--- a/docs/guides/avoid_blocking.mdx
+++ b/docs/guides/avoid_blocking.mdx
@@ -11,6 +11,7 @@ import RunnableCodeBlock from '@site/src/components/RunnableCodeBlock';
 import PlaywrightDefaultFingerprintGenerator from '!!raw-loader!roa-loader!./code_examples/avoid_blocking/playwright_with_fingerprint_generator.py';
 import PlaywrightWithCamoufox from '!!raw-loader!roa-loader!../examples/code_examples/playwright_crawler_with_camoufox.py';
 import PlaywrightWithCloakBrowser from '!!raw-loader!roa-loader!./code_examples/avoid_blocking/playwright_with_cloakbrowser.py';
+import PlaywrightWithInvisibleFirefox from '!!raw-loader!roa-loader!./code_examples/avoid_blocking/playwright_with_invisible_firefox.py';
 
 import PlaywrightDefaultFingerprintGeneratorWithArgs from '!!raw-loader!./code_examples/avoid_blocking/default_fingerprint_generator_with_args.py';
 
@@ -48,6 +49,14 @@ For sites with aggressive anti-bot protection, [CloakBrowser](https://github.com
 
 <RunnableCodeBlock className="language-python" language="python">
     {PlaywrightWithCloakBrowser}
+</RunnableCodeBlock>
+
+## Using Invisible Firefox
+
+For sites that flag Chromium UA by default, the Firefox-side equivalent of the CloakBrowser approach is [invisible_playwright](https://github.com/feder-cr/invisible_playwright), which drives a patched Firefox 150 binary with fingerprints modified at the C++ source code level (no JavaScript shims). Install it separately with `pip install invisible_playwright`. The example below mirrors the CloakBrowser pattern: the plugin calls `ensure_binary()` to download and cache the patched Firefox on first run, then launches it via the standard Playwright Firefox interface with the stealth prefs applied.
+
+<RunnableCodeBlock className="language-python" language="python">
+    {PlaywrightWithInvisibleFirefox}
 </RunnableCodeBlock>
 
 **Related links**

--- a/docs/guides/code_examples/avoid_blocking/playwright_with_invisible_firefox.py
+++ b/docs/guides/code_examples/avoid_blocking/playwright_with_invisible_firefox.py
@@ -1,0 +1,80 @@
+import asyncio
+
+# invisible_playwright is an external package. Install it separately.
+from invisible_playwright import generate_profile, translate_profile_to_prefs
+from invisible_playwright.download import ensure_binary
+from typing_extensions import override
+
+from crawlee.browsers import (
+    BrowserPool,
+    PlaywrightBrowserController,
+    PlaywrightBrowserPlugin,
+)
+from crawlee.crawlers import PlaywrightCrawler, PlaywrightCrawlingContext
+
+
+class InvisibleFirefoxPlugin(PlaywrightBrowserPlugin):
+    """Example browser plugin that uses invisible_playwright's patched Firefox 150,
+    but otherwise keeps the functionality of PlaywrightBrowserPlugin.
+    """
+
+    @override
+    async def new_browser(self) -> PlaywrightBrowserController:
+        if not self._playwright:
+            raise RuntimeError('Playwright browser plugin is not initialized.')
+
+        binary_path = ensure_binary()
+        profile = generate_profile()
+        stealth_prefs = translate_profile_to_prefs(profile)
+
+        # Merge invisible_firefox stealth prefs with any user-provided launch options.
+        launch_options = dict(self._browser_launch_options)
+        launch_options.pop('executable_path', None)
+        existing_prefs = dict(launch_options.pop('firefox_user_prefs', {}) or {})
+        launch_options['firefox_user_prefs'] = {**existing_prefs, **stealth_prefs}
+
+        return PlaywrightBrowserController(
+            browser=await self._playwright.firefox.launch(
+                executable_path=str(binary_path),
+                **launch_options,
+            ),
+            max_open_pages_per_browser=1,
+            # invisible_firefox handles fingerprints at the binary level.
+            header_generator=None,
+        )
+
+
+async def main() -> None:
+    crawler = PlaywrightCrawler(
+        # Limit the crawl to max requests. Remove or increase it for crawling all links.
+        max_requests_per_crawl=10,
+        # Custom browser pool. Gives users full control over browsers used by the crawler.
+        browser_pool=BrowserPool(plugins=[InvisibleFirefoxPlugin()]),
+    )
+
+    # Define the default request handler, which will be called for every request.
+    @crawler.router.default_handler
+    async def request_handler(context: PlaywrightCrawlingContext) -> None:
+        context.log.info(f'Processing {context.request.url} ...')
+
+        # Extract some data from the page using Playwright's API.
+        posts = await context.page.query_selector_all('.athing')
+        for post in posts:
+            # Get the HTML elements for the title and rank within each post.
+            title_element = await post.query_selector('.title a')
+
+            # Extract the data we want from the elements.
+            title = await title_element.inner_text() if title_element else None
+
+        # Push the extracted data to the default dataset.
+        await context.push_data({'title': title})
+
+        # Find a link to the next page and enqueue it if it exists.
+        await context.enqueue_links(selector='.morelink')
+
+    # Run the crawler with the initial list of URLs.
+    await crawler.run(['https://news.ycombinator.com/'])
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/website/versioned_docs/version-1.7/guides/avoid_blocking.mdx
+++ b/website/versioned_docs/version-1.7/guides/avoid_blocking.mdx
@@ -11,6 +11,7 @@ import RunnableCodeBlock from '@site/src/components/RunnableCodeBlock';
 import PlaywrightDefaultFingerprintGenerator from '!!raw-loader!roa-loader!./code_examples/avoid_blocking/playwright_with_fingerprint_generator.py';
 import PlaywrightWithCamoufox from '!!raw-loader!roa-loader!../examples/code_examples/playwright_crawler_with_camoufox.py';
 import PlaywrightWithCloakBrowser from '!!raw-loader!roa-loader!./code_examples/avoid_blocking/playwright_with_cloakbrowser.py';
+import PlaywrightWithInvisibleFirefox from '!!raw-loader!roa-loader!./code_examples/avoid_blocking/playwright_with_invisible_firefox.py';
 
 import PlaywrightDefaultFingerprintGeneratorWithArgs from '!!raw-loader!./code_examples/avoid_blocking/default_fingerprint_generator_with_args.py';
 
@@ -48,6 +49,14 @@ For sites with aggressive anti-bot protection, [CloakBrowser](https://github.com
 
 <RunnableCodeBlock className="language-python" language="python">
     {PlaywrightWithCloakBrowser}
+</RunnableCodeBlock>
+
+## Using Invisible Firefox
+
+For sites that flag Chromium UA by default, the Firefox-side equivalent of the CloakBrowser approach is [invisible_playwright](https://github.com/feder-cr/invisible_playwright), which drives a patched Firefox 150 binary with fingerprints modified at the C++ source code level (no JavaScript shims). Install it separately with `pip install invisible_playwright`. The example below mirrors the CloakBrowser pattern: the plugin calls `ensure_binary()` to download and cache the patched Firefox on first run, then launches it via the standard Playwright Firefox interface with the stealth prefs applied.
+
+<RunnableCodeBlock className="language-python" language="python">
+    {PlaywrightWithInvisibleFirefox}
 </RunnableCodeBlock>
 
 **Related links**

--- a/website/versioned_docs/version-1.7/guides/code_examples/avoid_blocking/playwright_with_invisible_firefox.py
+++ b/website/versioned_docs/version-1.7/guides/code_examples/avoid_blocking/playwright_with_invisible_firefox.py
@@ -1,0 +1,80 @@
+import asyncio
+
+# invisible_playwright is an external package. Install it separately.
+from invisible_playwright import generate_profile, translate_profile_to_prefs
+from invisible_playwright.download import ensure_binary
+from typing_extensions import override
+
+from crawlee.browsers import (
+    BrowserPool,
+    PlaywrightBrowserController,
+    PlaywrightBrowserPlugin,
+)
+from crawlee.crawlers import PlaywrightCrawler, PlaywrightCrawlingContext
+
+
+class InvisibleFirefoxPlugin(PlaywrightBrowserPlugin):
+    """Example browser plugin that uses invisible_playwright's patched Firefox 150,
+    but otherwise keeps the functionality of PlaywrightBrowserPlugin.
+    """
+
+    @override
+    async def new_browser(self) -> PlaywrightBrowserController:
+        if not self._playwright:
+            raise RuntimeError('Playwright browser plugin is not initialized.')
+
+        binary_path = ensure_binary()
+        profile = generate_profile()
+        stealth_prefs = translate_profile_to_prefs(profile)
+
+        # Merge invisible_firefox stealth prefs with any user-provided launch options.
+        launch_options = dict(self._browser_launch_options)
+        launch_options.pop('executable_path', None)
+        existing_prefs = dict(launch_options.pop('firefox_user_prefs', {}) or {})
+        launch_options['firefox_user_prefs'] = {**existing_prefs, **stealth_prefs}
+
+        return PlaywrightBrowserController(
+            browser=await self._playwright.firefox.launch(
+                executable_path=str(binary_path),
+                **launch_options,
+            ),
+            max_open_pages_per_browser=1,
+            # invisible_firefox handles fingerprints at the binary level.
+            header_generator=None,
+        )
+
+
+async def main() -> None:
+    crawler = PlaywrightCrawler(
+        # Limit the crawl to max requests. Remove or increase it for crawling all links.
+        max_requests_per_crawl=10,
+        # Custom browser pool. Gives users full control over browsers used by the crawler.
+        browser_pool=BrowserPool(plugins=[InvisibleFirefoxPlugin()]),
+    )
+
+    # Define the default request handler, which will be called for every request.
+    @crawler.router.default_handler
+    async def request_handler(context: PlaywrightCrawlingContext) -> None:
+        context.log.info(f'Processing {context.request.url} ...')
+
+        # Extract some data from the page using Playwright's API.
+        posts = await context.page.query_selector_all('.athing')
+        for post in posts:
+            # Get the HTML elements for the title and rank within each post.
+            title_element = await post.query_selector('.title a')
+
+            # Extract the data we want from the elements.
+            title = await title_element.inner_text() if title_element else None
+
+        # Push the extracted data to the default dataset.
+        await context.push_data({'title': title})
+
+        # Find a link to the next page and enqueue it if it exists.
+        await context.enqueue_links(selector='.morelink')
+
+    # Run the crawler with the initial list of URLs.
+    await crawler.run(['https://news.ycombinator.com/'])
+
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
opening as draft to check interest first.

this mirrors the CloakBrowser example added in PR #1794 (merged 2026-03-31) for the Firefox side. PR #1794 covers the Chromium-side path; some target sites flag Chromium UA by default and the same approach makes sense on the Firefox side.

invisible_playwright (feder-cr/invisible_playwright) drives a patched Firefox 150 binary (feder-cr/invisible_firefox, MPL-2, same license as Firefox upstream, fingerprint patches at the C++ source code level so no JS shims to detect). it follows the same `pip install` + `ensure_binary()` + `PlaywrightBrowserPlugin` subclass pattern as CloakBrowser, so the integration shape is identical.

file structure exactly mirrors PR #1794:
- one new example file under `docs/guides/code_examples/avoid_blocking/`
- one new section in `docs/guides/avoid_blocking.mdx`
- the same versioned mirror under `website/versioned_docs/version-1.7/`

issues against the backend route to feder-cr/invisible_playwright, not here. tracking discussion: #1920

if not in scope i'll close without noise.