### PR TITLE
fix(templates): Install pinned playwright into system env in uv Dockerfile

### DIFF
--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
@@ -58,7 +58,7 @@ RUN echo "Python version:" \
     && PLAYWRIGHT_BASE_VERSION=$(cat /tmp/.base-playwright-version 2>/dev/null || echo "") \
     && if [ -n "$PLAYWRIGHT_BASE_VERSION" ]; then \
         echo "Pinning playwright to $PLAYWRIGHT_BASE_VERSION to match the browser binaries shipped in the base image" \
-        && uv pip install --reinstall --no-deps "playwright==$PLAYWRIGHT_BASE_VERSION"; \
+        && uv pip install --system --reinstall --no-deps "playwright==$PLAYWRIGHT_BASE_VERSION"; \
     fi \
     && rm -f /tmp/.base-playwright-version \
     && echo "All installed Python packages:" \


### PR DESCRIPTION
Since #1904 the `uv` Dockerfile branch uses a standalone uv binary and pins playwright via `uv pip install`. But `UV_PROJECT_ENVIRONMENT` is ignored by `uv pip`, so with no venv and no `--system` it fails with `No virtual environment found` — breaking all Playwright-based `uv` e2e jobs ([run 26485871617](https://github.com/apify/crawlee-python/actions/runs/26485871617)).

Adding `--system` installs the pin into `/usr/local`, the same env `uv sync` populates. Verified with a real `docker build`.