### PR TITLE
feat: provide Request instances in skipped request callbacks

### DIFF
--- a/docs/examples/code_examples/respect_robots_on_skipped_request.py
+++ b/docs/examples/code_examples/respect_robots_on_skipped_request.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from crawlee import SkippedReason
+from crawlee import Request, SkippedReason
 from crawlee.crawlers import (
     BeautifulSoupCrawler,
     BeautifulSoupCrawlingContext,
@@ -18,7 +18,9 @@ async def main() -> None:
     # highlight-start
     # This handler is called when a request is skipped
     @crawler.on_skipped_request
-    async def skipped_request_handler(url: str, reason: SkippedReason) -> None:
+    async def skipped_request_handler(request: Request, reason: SkippedReason) -> None:
+        url = request.url
+
         # Check if the request was skipped due to robots.txt rules
         if reason == 'robots_txt':
             crawler.log.info(f'Skipped {url} due to robots.txt rules.')

--- a/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
+++ b/src/crawlee/crawlers/_abstract_http/_abstract_http_crawler.py
@@ -206,6 +206,18 @@ class AbstractHttpCrawler(
             **kwargs: Unpack[EnqueueLinksKwargs],
         ) -> list[Request]:
             requests = list[Request]()
+            skipped = list[Request]()
+
+            def create_request(request_options: RequestOptions) -> Request | None:
+                try:
+                    return Request.from_url(**request_options)
+                except ValidationError as exc:
+                    context.log.debug(
+                        f'Skipping URL "{request_options["url"]}" due to invalid format: {exc}. '
+                        'This may be caused by a malformed URL or unsupported URL scheme. '
+                        'Please ensure the URL is correct and retry.'
+                    )
+                    return None
 
             base_user_data = user_data or {}
 
@@ -226,11 +238,19 @@ class AbstractHttpCrawler(
                 else context.request.loaded_url or context.request.url
             )
             links_iterator = to_absolute_url_iterator(base_url, links_iterator, logger=context.log)
+            skipped_iterator = iter([])
 
             if robots_txt_file:
-                skipped, links_iterator = partition(robots_txt_file.is_allowed, links_iterator)
-            else:
-                skipped = iter([])
+                skipped_iterator, links_iterator = partition(robots_txt_file.is_allowed, links_iterator)
+
+            for url in skipped_iterator:
+                request_options = RequestOptions(
+                    url=url, user_data={**base_user_data}, label=label, enqueue_strategy=strategy
+                )
+                request = create_request(request_options)
+
+                if request is not None:
+                    skipped.append(request)
 
             for url in self._enqueue_links_filter_iterator(links_iterator, context.request.url, **kwargs):
                 request_options = RequestOptions(
@@ -244,17 +264,10 @@ class AbstractHttpCrawler(
                     if transform_request_options != 'unchanged':
                         request_options = transform_request_options
 
-                try:
-                    request = Request.from_url(**request_options)
-                except ValidationError as exc:
-                    context.log.debug(
-                        f'Skipping URL "{url}" due to invalid format: {exc}. '
-                        'This may be caused by a malformed URL or unsupported URL scheme. '
-                        'Please ensure the URL is correct and retry.'
-                    )
-                    continue
+                request = create_request(request_options)
 
-                requests.append(request)
+                if request is not None:
+                    requests.append(request)
 
             skipped_tasks = [
                 asyncio.create_task(self._handle_skipped_request(request, 'robots_txt')) for request in skipped

--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -110,7 +110,7 @@ T = TypeVar('T')
 
 ErrorHandler = Callable[[TCrawlingContext, Exception], Awaitable[Request | None]]
 FailedRequestHandler = Callable[[TCrawlingContext, Exception], Awaitable[None]]
-SkippedRequestCallback = Callable[[str, SkippedReason], Awaitable[None]]
+SkippedRequestCallback = Callable[[Request, SkippedReason], Awaitable[None]]
 
 
 class _BasicCrawlerOptions(TypedDict):
@@ -1210,17 +1210,15 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
                 raise UserDefinedErrorHandlerError('Exception thrown in user-defined failed request handler') from e
 
     async def _handle_skipped_request(
-        self, request: Request | str, reason: SkippedReason, *, need_mark: bool = False
+        self, request: Request, reason: SkippedReason, *, need_mark: bool = False
     ) -> None:
         if need_mark and isinstance(request, Request):
             request.state = RequestState.SKIPPED
             await self._mark_request_as_handled(request)
 
-        url = request.url if isinstance(request, Request) else request
-
         if self._on_skipped_request:
             try:
-                await self._on_skipped_request(url, reason)
+                await self._on_skipped_request(request, reason)
             except Exception as e:
                 raise UserDefinedErrorHandlerError('Exception thrown in user-defined skipped request callback') from e
 

--- a/src/crawlee/crawlers/_playwright/_playwright_crawler.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_crawler.py
@@ -459,6 +459,18 @@ class PlaywrightCrawler(
             The `PlaywrightCrawler` implementation of the `ExtractLinksFunction` function.
             """
             requests = list[Request]()
+            skipped = list[Request]()
+
+            def create_request(request_options: RequestOptions) -> Request | None:
+                try:
+                    return Request.from_url(**request_options)
+                except ValidationError as exc:
+                    context.log.debug(
+                        f'Skipping URL "{request_options["url"]}" due to invalid format: {exc}. '
+                        'This may be caused by a malformed URL or unsupported URL scheme. '
+                        'Please ensure the URL is correct and retry.'
+                    )
+                    return None
 
             base_user_data = user_data or {}
 
@@ -478,10 +490,19 @@ class PlaywrightCrawler(
 
             links_iterator = to_absolute_url_iterator(base_url, links_iterator, logger=context.log)
 
+            skipped_iterator = iter([])
+
             if robots_txt_file:
-                skipped, links_iterator = partition(robots_txt_file.is_allowed, links_iterator)
-            else:
-                skipped = iter([])
+                skipped_iterator, links_iterator = partition(robots_txt_file.is_allowed, links_iterator)
+
+            for url in skipped_iterator:
+                request_options = RequestOptions(
+                    url=url, user_data={**base_user_data}, label=label, enqueue_strategy=strategy
+                )
+                request = create_request(request_options)
+
+                if request is not None:
+                    skipped.append(request)
 
             for url in self._enqueue_links_filter_iterator(links_iterator, context.request.url, **kwargs):
                 request_options = RequestOptions(
@@ -495,17 +516,10 @@ class PlaywrightCrawler(
                     if transform_request_options != 'unchanged':
                         request_options = transform_request_options
 
-                try:
-                    request = Request.from_url(**request_options)
-                except ValidationError as exc:
-                    context.log.debug(
-                        f'Skipping URL "{url}" due to invalid format: {exc}. '
-                        'This may be caused by a malformed URL or unsupported URL scheme. '
-                        'Please ensure the URL is correct and retry.'
-                    )
-                    continue
+                request = create_request(request_options)
 
-                requests.append(request)
+                if request is not None:
+                    requests.append(request)
 
             skipped_tasks = [
                 asyncio.create_task(self._handle_skipped_request(request, 'robots_txt')) for request in skipped

--- a/tests/unit/crawlers/_beautifulsoup/test_beautifulsoup_crawler.py
+++ b/tests/unit/crawlers/_beautifulsoup/test_beautifulsoup_crawler.py
@@ -246,18 +246,22 @@ async def test_on_skipped_request(server_url: URL, http_client: HttpClient) -> N
         await context.enqueue_links()
 
     @crawler.on_skipped_request
-    async def skipped_hook(url: str, _reason: SkippedReason) -> None:
-        skip(url)
+    async def skipped_hook(request: Request, _reason: SkippedReason) -> None:
+        skip(request)
 
     await crawler.run([str(server_url / 'start_enqueue')])
 
-    expected_skip_calls = [
-        mock.call(str(server_url / 'page_1')),
-        mock.call(str(server_url / 'page_2')),
-        mock.call(str(server_url / 'page_3')),
-        mock.call(str(server_url / 'page_4')),
-    ]
-    skip.assert_has_calls(expected_skip_calls, any_order=True)
+    expected_skip_urls = {
+        str(server_url / 'page_1'),
+        str(server_url / 'page_2'),
+        str(server_url / 'page_3'),
+        str(server_url / 'page_4'),
+    }
+
+    requests = [call.args[0] for call in skip.call_args_list]
+
+    all(isinstance(request, Request) for request in requests)
+    assert {request.url for request in requests} == expected_skip_urls
 
 
 async def test_extract_links(server_url: URL, http_client: HttpClient) -> None:

--- a/tests/unit/crawlers/_parsel/test_parsel_crawler.py
+++ b/tests/unit/crawlers/_parsel/test_parsel_crawler.py
@@ -330,18 +330,22 @@ async def test_on_skipped_request(server_url: URL, http_client: HttpClient) -> N
         await context.enqueue_links()
 
     @crawler.on_skipped_request
-    async def skipped_hook(url: str, _reason: SkippedReason) -> None:
-        skip(url)
+    async def skipped_hook(request: Request, _reason: SkippedReason) -> None:
+        skip(request)
 
     await crawler.run([str(server_url / 'start_enqueue')])
 
-    expected_skip_calls = [
-        mock.call(str(server_url / 'page_1')),
-        mock.call(str(server_url / 'page_2')),
-        mock.call(str(server_url / 'page_3')),
-        mock.call(str(server_url / 'page_4')),
-    ]
-    skip.assert_has_calls(expected_skip_calls, any_order=True)
+    expected_skip_urls = {
+        str(server_url / 'page_1'),
+        str(server_url / 'page_2'),
+        str(server_url / 'page_3'),
+        str(server_url / 'page_4'),
+    }
+
+    requests = [call.args[0] for call in skip.call_args_list]
+
+    all(isinstance(request, Request) for request in requests)
+    assert {request.url for request in requests} == expected_skip_urls
 
 
 async def test_extract_links(server_url: URL, http_client: HttpClient) -> None:

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -765,18 +765,22 @@ async def test_on_skipped_request(server_url: URL) -> None:
         await context.enqueue_links()
 
     @crawler.on_skipped_request
-    async def skipped_hook(url: str, _reason: SkippedReason) -> None:
-        skip(url)
+    async def skipped_hook(request: Request, _reason: SkippedReason) -> None:
+        skip(request)
 
     await crawler.run([str(server_url / 'start_enqueue')])
 
-    expected_skip_calls = [
-        mock.call(str(server_url / 'page_1')),
-        mock.call(str(server_url / 'page_2')),
-        mock.call(str(server_url / 'page_3')),
-        mock.call(str(server_url / 'page_4')),
-    ]
-    skip.assert_has_calls(expected_skip_calls, any_order=True)
+    expected_skip_urls = {
+        str(server_url / 'page_1'),
+        str(server_url / 'page_2'),
+        str(server_url / 'page_3'),
+        str(server_url / 'page_4'),
+    }
+
+    requests = [call.args[0] for call in skip.call_args_list]
+
+    all(isinstance(request, Request) for request in requests)
+    assert {request.url for request in requests} == expected_skip_urls
 
 
 async def test_send_request(server_url: URL) -> None:


### PR DESCRIPTION
### Description

<!-- The purpose of the PR, list of the changes, ... -->

This PR changes the skipped request handler to receive a `Request` object instead of only the URL `str`.

Skipped URLs are now converted into `Request` objects before the callback is invoked. This ensures that request metadata remains available for skipped requests, including `request.user_data` and other request attributes.


### Issues

<!-- If applicable, reference any related GitHub issues -->
- N/A

### Testing

<!-- Describe the testing process for these changes -->

- Added/updated unit tests for skipped request handlers.
- Verified that skipped request handlers receive the original Request object.
- Ran uv run poe check-code.

### Checklist

- [x] CI passed



### Future improvements

While working on this change, I noticed that many parts of the internal processing pipeline operate on `str | Request` unions.

A possible future improvement could be to standardize on `Request` objects internally and only accept `str | Request` at the public API boundary. URLs could then be wrapped into `Request` instances immediately, allowing the rest of the codebase to operate exclusively on `Request` objects.

This could simplify typing, reduce repeated union handling, and make request metadata consistently available throughout the pipeline. However, such a change would require broader refactoring and additional testing, so it is outside the scope of this PR.