### PR TITLE
fix(memory-storage): Apply skip_empty after pagination in MemoryDatasetClient.get_data

### DIFF
--- a/src/crawlee/storage_clients/_memory/_dataset_client.py
+++ b/src/crawlee/storage_clients/_memory/_dataset_client.py
@@ -171,16 +171,16 @@ class MemoryDatasetClient(DatasetClient):
         total = len(self._records)
         items = self._records.copy()
 
-        # Apply skip_empty filter if requested
-        if skip_empty:
-            items = [item for item in items if item]
-
         # Apply sorting
         if desc:
             items = list(reversed(items))
 
         # Apply pagination
         sliced_items = items[offset : (offset + limit) if limit is not None else total]
+
+        # Apply skip_empty filter if requested
+        if skip_empty:
+            sliced_items = [item for item in sliced_items if item]
 
         await self._update_metadata(update_accessed_at=True)
 


### PR DESCRIPTION
`MemoryDatasetClient.get_data` applied the `skip_empty` filter *before* the `offset`/`limit` slice, while `FileSystemDatasetClient.get_data` and `MemoryDatasetClient.iterate_items` both paginate first and then drop empty items. As a result, `get_data(skip_empty=True, offset=N, limit=M)` returned a different set of items depending on the storage backend, and disagreed with `iterate_items` on the same memory client.

This change reorders the operations in `MemoryDatasetClient.get_data` to apply the `desc` reversal, then the `offset`/`limit` slice, and only then filter out empty items — matching the other implementations. The returned `count`/`total`/`offset` pagination math is now also internally consistent when `skip_empty=True`.