### PR TITLE
fix: Reset private state correctly in sitemap parsers

### DIFF
--- a/src/crawlee/_utils/sitemap.py
+++ b/src/crawlee/_utils/sitemap.py
@@ -122,7 +122,7 @@ class _XMLSaxSitemapHandler(ContentHandler):
             elif name == 'changefreq' and text in VALID_CHANGE_FREQS:
                 self._current_url['changefreq'] = text
 
-            self.current_tag = None
+            self._current_tag = None
 
         if name == 'url' and 'loc' in self._current_url:
             self.items.append({'type': 'url', **self._current_url})
@@ -156,7 +156,7 @@ class _TxtSitemapParser:
             url = self._buffer.strip()
             if url:
                 yield {'type': 'url', 'loc': url}
-            self.buffer = ''
+            self._buffer = ''
 
     def close(self) -> None:
         """Clean up resources."""

--- a/tests/unit/_utils/test_sitemap.py
+++ b/tests/unit/_utils/test_sitemap.py
@@ -6,7 +6,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 from yarl import URL
 
-from crawlee._utils.sitemap import Sitemap, SitemapUrl, discover_valid_sitemaps, parse_sitemap
+from crawlee._utils.sitemap import (
+    Sitemap,
+    SitemapUrl,
+    _TxtSitemapParser,
+    _XMLSaxSitemapHandler,
+    discover_valid_sitemaps,
+    parse_sitemap,
+)
 from crawlee.http_clients._base import HttpClient, HttpResponse
 
 BASIC_SITEMAP = """
@@ -337,6 +344,32 @@ async def test_discover_sitemaps_multiple_domains() -> None:
         'http://domain-a.com/sitemap.xml',
         'http://domain-b.com/sitemap.xml',
     }
+
+
+def test_xml_handler_resets_current_tag_on_end_element() -> None:
+    """Closing a tracked tag resets the handler's current tag so stray text between elements is ignored."""
+    handler = _XMLSaxSitemapHandler()
+    handler.startElement('urlset', MagicMock())
+    handler.startElement('url', MagicMock())
+    handler.startElement('loc', MagicMock())
+    handler.characters('https://example.com/')
+    handler.endElement('loc')
+
+    assert handler._current_tag is None
+
+    # Stray text between elements must not be buffered.
+    handler.characters('   stray text   ')
+    assert handler._buffer == 'https://example.com/'
+
+
+async def test_txt_parser_flush_clears_buffer() -> None:
+    """Feeding more data after flush() must not concatenate the previously flushed URL."""
+    parser = _TxtSitemapParser()
+    items = [item async for item in parser.process_chunk('https://a.com/\nhttps://b.com/')]
+    items += [item async for item in parser.flush()]
+    items += [item async for item in parser.process_chunk('https://c.com/\n')]
+
+    assert [item['loc'] for item in items] == ['https://a.com/', 'https://b.com/', 'https://c.com/']
 
 
 async def test_discover_sitemap_url_without_host_skipped() -> None:


### PR DESCRIPTION
## Description

Fixes two attribute-name typos in `src/crawlee/_utils/sitemap.py` where the underscore prefix was missing on assignment, so each statement silently created a new public attribute instead of resetting the intended private state:

- `_XMLSaxSitemapHandler.endElement` set `self.current_tag = None` instead of `self._current_tag = None`. The handler therefore never left the "inside a tracked tag" state, so stray text between elements kept being appended to the buffer and a duplicate close tag could re-process stale buffer contents.
- `_TxtSitemapParser.flush` set `self.buffer = ''` instead of `self._buffer = ''`. Reusing the parser after `flush()` concatenated the leftover URL with the next chunk, yielding corrupted URLs like `https://b.com/https://c.com/`.

Both fixes add the missing underscore. Regression tests cover the state reset in the XML handler and the buffer corruption in the TXT parser.