### PR TITLE
fix(redis): Return all items from Redis dataset `get_data` with `desc=True` and `limit=None`

### DIFF
--- a/src/crawlee/storage_clients/_redis/_dataset_client.py
+++ b/src/crawlee/storage_clients/_redis/_dataset_client.py
@@ -185,6 +185,8 @@ class RedisDatasetClient(DatasetClient, RedisClientMixin):
         match (desc, offset, limit):
             case (True, 0, int()):
                 json_path += f'[-{limit}:]'
+            case (True, 0, None):
+                json_path += '[:]'
             case (True, int(), None):
                 json_path += f'[:-{offset}]'
             case (True, int(), int()):

--- a/tests/unit/storage_clients/_redis/test_redis_dataset_client.py
+++ b/tests/unit/storage_clients/_redis/test_redis_dataset_client.py
@@ -148,6 +148,17 @@ async def test_metadata_record_updates(dataset_client: RedisDatasetClient) -> No
     assert metadata.accessed_at > accessed_after_get
 
 
+async def test_get_data_descending_with_unlimited_limit(dataset_client: RedisDatasetClient) -> None:
+    """Test that get_data with desc=True and limit=None returns all items in reverse order."""
+    items = [{'id': 1}, {'id': 2}, {'id': 3}]
+    await dataset_client.push_data(items)
+
+    result = await dataset_client.get_data(desc=True, limit=None)
+
+    assert result.count == 3
+    assert result.items == [{'id': 3}, {'id': 2}, {'id': 1}]
+
+
 async def test_error_handling_on_push_failure(dataset_client: RedisDatasetClient) -> None:
     """Test that push_data properly handles Redis errors and retries."""
     mock_pipe = MagicMock()

--- a/tests/unit/storage_clients/_redis/test_redis_dataset_client.py
+++ b/tests/unit/storage_clients/_redis/test_redis_dataset_client.py
@@ -148,17 +148,6 @@ async def test_metadata_record_updates(dataset_client: RedisDatasetClient) -> No
     assert metadata.accessed_at > accessed_after_get
 
 
-async def test_get_data_descending_with_unlimited_limit(dataset_client: RedisDatasetClient) -> None:
-    """Test that get_data with desc=True and limit=None returns all items in reverse order."""
-    items = [{'id': 1}, {'id': 2}, {'id': 3}]
-    await dataset_client.push_data(items)
-
-    result = await dataset_client.get_data(desc=True, limit=None)
-
-    assert result.count == 3
-    assert result.items == [{'id': 3}, {'id': 2}, {'id': 1}]
-
-
 async def test_error_handling_on_push_failure(dataset_client: RedisDatasetClient) -> None:
     """Test that push_data properly handles Redis errors and retries."""
     mock_pipe = MagicMock()

--- a/tests/unit/storages/test_dataset.py
+++ b/tests/unit/storages/test_dataset.py
@@ -235,6 +235,17 @@ async def test_get_data_descending_order(dataset: Dataset) -> None:
     assert result.items[-1]['id'] == 1
 
 
+async def test_get_data_descending_with_unlimited_limit(dataset: Dataset) -> None:
+    """Test that get_data with desc=True and limit=None returns all items in reverse order."""
+    items = [{'id': i} for i in range(1, 4)]  # 3 items
+    await dataset.push_data(items)
+
+    result = await dataset.get_data(desc=True, limit=None)
+
+    assert result.count == 3
+    assert result.items == [{'id': 3}, {'id': 2}, {'id': 1}]
+
+
 async def test_get_data_skip_empty(dataset: Dataset) -> None:
     """Test getting data with skip_empty option filters out empty items."""
     # Add some items including an empty one


### PR DESCRIPTION
## Description

`RedisDatasetClient.get_data` called with `desc=True, offset=0, limit=None` fell through to the generic descending match arm and built the Redis JSON path `$[:-0]`. Slice semantics treat `-0` as `0`, so the path evaluated to an empty array and a non-empty dataset silently returned zero items, while the symmetric ascending call correctly returned everything.

This adds an explicit `case (True, 0, None)` arm producing `$[:]` (all items, reversed afterwards by the existing `desc` handling), plus a regression test.