### PR TITLE
fix(memory-storage): Avoid duplicate processed requests in memory request queue client

### DIFF
--- a/src/crawlee/storage_clients/_memory/_request_queue_client.py
+++ b/src/crawlee/storage_clients/_memory/_request_queue_client.py
@@ -190,14 +190,6 @@ class MemoryRequestQueueClient(RequestQueueClient):
                     # Add updated request back to queue.
                     self._pending_requests.appendleft(request)
 
-                processed_requests.append(
-                    ProcessedRequest(
-                        unique_key=request.unique_key,
-                        was_already_present=True,
-                        was_already_handled=False,
-                    )
-                )
-
             # Add the new request to the queue.
             else:
                 if forefront:

--- a/tests/unit/storage_clients/_memory/test_memory_rq_client.py
+++ b/tests/unit/storage_clients/_memory/test_memory_rq_client.py
@@ -43,6 +43,23 @@ async def test_memory_specific_purge_behavior() -> None:
     assert await rq_client2.is_empty() is True
 
 
+async def test_add_existing_pending_request_returns_single_processed_request(
+    rq_client: MemoryRequestQueueClient,
+) -> None:
+    """Test that re-adding a pending (not handled) request yields exactly one `ProcessedRequest` entry."""
+    request = Request.from_url('https://example.com')
+    await rq_client.add_batch_of_requests([request])
+
+    # Re-add the same request while it is still pending (not handled, not in progress).
+    response = await rq_client.add_batch_of_requests([request])
+
+    assert len(response.processed_requests) == 1
+    processed_request = response.processed_requests[0]
+    assert processed_request.unique_key == request.unique_key
+    assert processed_request.was_already_present is True
+    assert processed_request.was_already_handled is False
+
+
 async def test_memory_metadata_updates(rq_client: MemoryRequestQueueClient) -> None:
     """Test that metadata timestamps are updated correctly in memory storage."""
     # Record initial timestamps


### PR DESCRIPTION
## Description

- `MemoryRequestQueueClient.add_batch_of_requests` appended a `ProcessedRequest` twice for requests that were already present in the queue but not yet handled — once in the `was_already_present` branch and again at the unconditional append after the if/else block, which that branch did not skip.
- This violated the contract that `AddRequestsResponse.processed_requests` contains exactly one entry per input request and inflated results for any caller iterating the list.
- Removed the inner append so the shared append at the end handles both branches, matching the structure of the file system client. Added a regression test.