### PR TITLE
ci: build release docs from the branch tip, not the dispatch ref

### DIFF
--- a/.github/workflows/manual_release_docs.yaml
+++ b/.github/workflows/manual_release_docs.yaml
@@ -3,9 +3,21 @@ name: Release docs
 on:
   # Runs when manually triggered from the GitHub UI.
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Commit SHA or ref to build the docs from. If empty, the triggering ref is used.
+        required: false
+        type: string
+        default: ""
 
   # Runs when invoked by another workflow.
   workflow_call:
+    inputs:
+      ref:
+        description: Commit SHA or ref to build the docs from. If empty, the triggering ref is used.
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -39,6 +51,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.ref }}
           token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
       - name: Set up Node

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -156,8 +156,9 @@ jobs:
       checks: read
     uses: ./.github/workflows/manual_release_docs.yaml
     with:
-      # Build from the versioned-docs commit produced by `version_docs` — it sits on top of the
-      # finalized changelog and includes the new version snapshot. Without this, the docs workflow's
-      # checkout defaults to the dispatch ref (pre-bump) and redeploys stale docs.
-      ref: ${{ needs.version_docs.outputs.commit_sha }}
+      # Build from the up-to-date branch tip, not the workflow-dispatch ref. The default checkout
+      # pins to the dispatch commit (pre-bump), which predates the changelog finalization and the
+      # version snapshot pushed earlier in this run — so the docs would be redeployed from stale
+      # content (e.g. the changelog stuck at "not yet released").
+      ref: ${{ github.ref_name }}
     secrets: inherit

--- a/.github/workflows/manual_release_stable.yaml
+++ b/.github/workflows/manual_release_stable.yaml
@@ -155,4 +155,9 @@ jobs:
       id-token: write
       checks: read
     uses: ./.github/workflows/manual_release_docs.yaml
+    with:
+      # Build from the versioned-docs commit produced by `version_docs` — it sits on top of the
+      # finalized changelog and includes the new version snapshot. Without this, the docs workflow's
+      # checkout defaults to the dispatch ref (pre-bump) and redeploys stale docs.
+      ref: ${{ needs.version_docs.outputs.commit_sha }}
     secrets: inherit

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -18,6 +18,10 @@ on:
         required: false
         type: string
         default: ""
+    outputs:
+      commit_sha:
+        description: Full SHA of the versioned-docs commit that was pushed (falls back to HEAD if nothing was committed).
+        value: ${{ jobs.version_docs.outputs.commit_sha }}
 
 concurrency:
   group: version-docs
@@ -37,6 +41,8 @@ jobs:
     permissions:
       contents: write
       checks: read
+    outputs:
+      commit_sha: ${{ steps.commit.outputs.commit_long_sha }}
 
     steps:
       # Gate manual dispatches on the `Checks` workflow already succeeding on this commit (run by `on_master.yaml`);
@@ -123,6 +129,7 @@ jobs:
           uv run pnpm exec docusaurus api:version "$MAJOR_MINOR_VERSION"
 
       - name: Commit and push versioned docs
+        id: commit
         uses: apify/actions/signed-commit@v1.2.0
         with:
           message: "docs: Version docs for v${{ steps.snapshot.outputs.version }} [skip ci]"

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -18,10 +18,6 @@ on:
         required: false
         type: string
         default: ""
-    outputs:
-      commit_sha:
-        description: Full SHA of the versioned-docs commit that was pushed (falls back to HEAD if nothing was committed).
-        value: ${{ jobs.version_docs.outputs.commit_sha }}
 
 concurrency:
   group: version-docs
@@ -41,8 +37,6 @@ jobs:
     permissions:
       contents: write
       checks: read
-    outputs:
-      commit_sha: ${{ steps.commit.outputs.commit_long_sha }}
 
     steps:
       # Gate manual dispatches on the `Checks` workflow already succeeding on this commit (run by `on_master.yaml`);
@@ -129,7 +123,6 @@ jobs:
           uv run pnpm exec docusaurus api:version "$MAJOR_MINOR_VERSION"
 
       - name: Commit and push versioned docs
-        id: commit
         uses: apify/actions/signed-commit@v1.2.0
         with:
           message: "docs: Version docs for v${{ steps.snapshot.outputs.version }} [skip ci]"


### PR DESCRIPTION
In the stable release, the `doc_release` job checked out the workflow-dispatch ref (the pre-bump commit), so the docs were redeployed from stale content. After the v1.7.2 release the changelog page stayed at `1.7.2 — not yet released` instead of the finalized dated entry, and the new version snapshot wasn't published.

The fix points the docs build at the up-to-date branch tip (`github.ref_name`) via a new optional `ref` input on `manual_release_docs.yaml`. By the time `doc_release` runs, the branch tip already carries the finalized changelog and the version snapshot pushed earlier in the run. Other entry points (on-master docs deploys, manual dispatches) are unaffected because `ref` defaults to the triggering ref.

The same approach is being applied to `apify-sdk-python` and `apify-client-python`, where the docs build additionally runs a theme-update step — checking out the branch tip (rather than threading a detached commit SHA) keeps that step's internal `git checkout master` working.

Note: this fix applies to the next release; the currently-deployed v1.7.2 docs still need a one-off manual `Release docs` run to refresh.
