### PR TITLE
test: fix flaky Windows CI failures in statistics and browser-pool tests

### DIFF
--- a/tests/unit/browsers/test_browser_pool.py
+++ b/tests/unit/browsers/test_browser_pool.py
@@ -9,7 +9,6 @@ import pytest
 from crawlee.browsers import BrowserPool, PlaywrightBrowserPlugin
 from crawlee.browsers._browser_controller import BrowserController
 from crawlee.browsers._types import CrawleePage
-from tests.unit.utils import run_alone_on_mac
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -103,9 +102,11 @@ async def test_new_page_with_each_plugin(server_url: URL) -> None:
         assert browser_pool.total_pages_count == 2
 
 
-@run_alone_on_mac
+@pytest.mark.run_alone
 async def test_with_default_plugin_constructor(server_url: URL) -> None:
-    # Use a generous operation timeout so that Firefox has enough time to launch on slow Windows CI.
+    # Launching a real Firefox browser is resource-heavy and flakes under xdist parallelism (it can time out
+    # even with a generous operation timeout when several workers compete for the runner). Run it alone and
+    # keep a generous operation timeout so that Firefox has enough time to launch on slow CI.
     async with BrowserPool.with_default_plugin(
         headless=True, browser_type='firefox', operation_timeout=timedelta(seconds=60)
     ) as browser_pool:

--- a/tests/unit/crawlers/_basic/test_basic_crawler.py
+++ b/tests/unit/crawlers/_basic/test_basic_crawler.py
@@ -1993,9 +1993,10 @@ async def test_crawler_intermediate_statistics() -> None:
     async def handler(_: BasicCrawlingContext) -> None:
         await asyncio.sleep(check_time.total_seconds() * 5)
 
-    # Start crawler and wait until statistics are initialized.
+    # Start crawler and wait until statistics are initialized. Use a generous timeout so that crawler startup
+    # has enough time to reach the active state on slow CI runners under xdist load.
     crawler_task = asyncio.create_task(crawler.run(['https://a.placeholder.com']))
-    assert await poll_until_condition(lambda: crawler.statistics.active)
+    assert await poll_until_condition(lambda: crawler.statistics.active, timeout=30)
 
     # Wait some time and check that runtime is updated.
     await asyncio.sleep(check_time.total_seconds())


### PR DESCRIPTION
Two unit tests flaked on a master push build ([run](https://github.com/apify/crawlee-python/actions/runs/26953000755/job/79522749183), `windows-latest`, Python 3.10).

- **`test_crawler_intermediate_statistics`** — `poll_until_condition(lambda: crawler.statistics.active)` used the helper's default 5s ceiling. Under xdist load on a slow Windows runner, crawler startup didn't reach the active state in time, so the poll returned `False`. Pass a generous `timeout=30` (the happy path still returns in <1s, so there's no cost on green runs).
- **`test_with_default_plugin_constructor`** — launching a real Firefox browser timed out even with `operation_timeout=60s` while competing with other xdist workers on the constrained Windows runner. The existing `@run_alone_on_mac` only isolated macOS, so Windows still ran it in the parallel pool. Upgraded to `@pytest.mark.run_alone` so the heavy browser launch gets the full machine on every platform; the 60s timeout is kept.

Both flakes are Windows-resource-specific, so local Linux re-runs (10/10 and 5/5 green) confirm the fixes are valid but can't reproduce the original failure mode — CI re-verifies the Windows path.