### PR TITLE
chore: switch renovate lock file maintenance to a reviewed PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,7 @@
     "internalChecksFilter": "strict",
     "lockFileMaintenance": {
         "enabled": true,
-        "automerge": true,
-        "automergeType": "branch"
+        "minimumReleaseAge": "0 days"
     },
     "packageRules": [
         {


### PR DESCRIPTION
Lock file maintenance was effectively stuck. Renovate cannot yet pass an age constraint to `uv lock` (renovatebot/renovate#41654), so `minimumReleaseAge` only added a `renovate/stability-days` check that blocked the merge while `uv lock --upgrade` still resolved to the newest versions. Combined with branch automerge and strict internal checks, the branch was rebased and regenerated on every `master` change, so the check never cleared and the lockfile refresh never landed, leaving transitive dependencies frozen.

This drops `automerge`/`automergeType` and sets `minimumReleaseAge: "0 days"` on `lockFileMaintenance`, so the refresh opens a regular PR for review instead: the PR reliably appears (no stuck stability check) and the transitive bumps get a human/CI check before merge. The top-level `minimumReleaseAge` still gates direct dependency updates.
