### PR TITLE
fix: Remove extra sleep in `ImpitHttpClient.stream`

### DIFF
--- a/src/crawlee/http_clients/_impit.py
+++ b/src/crawlee/http_clients/_impit.py
@@ -220,11 +220,6 @@ class ImpitHttpClient(HttpClient):
         try:
             yield _ImpitResponse(response)
         finally:
-            # TODO: https://github.com/apify/impit/issues/242
-            # Quickly closing Response while reading the response body causes an error in the Rust generator in `impit`.
-            # With a short sleep and sync closing, the error does not occur.
-            # Replace with `response.aclose` when this is resolved in impit.
-            await asyncio.sleep(0.01)
             response.close()
 
     def _get_client(self, proxy_url: str | None, cookie_jar: CookieJar | None) -> AsyncClient:


### PR DESCRIPTION
### Description

- The error at https://github.com/apify/impit/issues/242 cannot be reproduced