### PR TITLE
fix(sitemap): Prevent sitemap parser from leaking metadata between <url> entries

### DIFF
--- a/src/crawlee/_utils/sitemap.py
+++ b/src/crawlee/_utils/sitemap.py
@@ -127,8 +127,9 @@ class _XMLSaxSitemapHandler(ContentHandler):
 
             self._current_tag = None
 
-        if name == 'url' and 'loc' in self._current_url:
-            self.items.append({'type': 'url', **self._current_url})
+        if name == 'url':
+            if 'loc' in self._current_url:
+                self.items.append({'type': 'url', **self._current_url})
             self._current_url = {}
 
 

--- a/tests/unit/_utils/test_sitemap.py
+++ b/tests/unit/_utils/test_sitemap.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock
+from xml.sax.expatreader import ExpatParser
 
 import pytest
 from yarl import URL
@@ -410,6 +411,22 @@ def test_xml_handler_resets_current_tag_on_end_element() -> None:
     # Stray text between elements must not be buffered.
     handler.characters('   stray text   ')
     assert handler._buffer == 'https://example.com/'
+
+
+def test_xml_handler_discards_metadata_from_url_without_loc() -> None:
+    """A <url> block with metadata but no <loc> must not leak its metadata into the next <url>."""
+    handler = _XMLSaxSitemapHandler()
+    parser = ExpatParser()
+    parser.setContentHandler(handler)
+    parser.feed(
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+        '<url><lastmod>2005-01-01</lastmod><priority>0.1</priority><changefreq>daily</changefreq></url>'
+        '<url><loc>https://example.com/real-page</loc></url>'
+        '</urlset>'
+    )
+
+    assert handler.items == [{'type': 'url', 'loc': 'https://example.com/real-page'}]
 
 
 async def test_txt_parser_flush_clears_buffer() -> None:


### PR DESCRIPTION
### Description

The XML sitemap parser leaks per-entry metadata from a malformed `<url>` block into the next entry.

- In `_XMLSaxSitemapHandler.endElement` (`src/crawlee/_utils/sitemap.py`), the emit **and** the reset of `self._current_url` were both gated behind `if name == 'url' and 'loc' in self._current_url:`.
- `_current_url` accumulates `lastmod` / `priority` / `changefreq` as those child tags close. When a `<url>` block has metadata children but no (or an empty) `<loc>`, the closing `</url>` did **not** reset `_current_url`, so its stale metadata carried over and attached to the next parsed `<url>`.
- Fix: reset `_current_url` on **every** closing `</url>`, while still only emitting an item when a `loc` is present. This discards a locless block's metadata instead of leaking it, and leaves well-formed sitemaps unchanged.

```diff
-        if name == 'url' and 'loc' in self._current_url:
-            self.items.append({'type': 'url', **self._current_url})
+        if name == 'url':
+            if 'loc' in self._current_url:
+                self.items.append({'type': 'url', **self._current_url})
             self._current_url = {}
```

### Issues

- No existing GitHub issue. This is a self-identified correctness bug found while reviewing the sitemap parser. Happy to open a tracking issue with the repro first if you'd prefer that.

### Testing

- Added `test_xml_handler_discards_metadata_from_url_without_loc` to `tests/unit/_utils/test_sitemap.py`. It drives the real `ExpatParser` + `_XMLSaxSitemapHandler` path (the same path `_XmlSitemapParser` uses in production), feeds a locless metadata `<url>` followed by a real `<url><loc>...</loc></url>`, and asserts the output is a single clean item with no leaked `lastmod` / `priority` / `changefreq`.
- Verified fail-first: the new test fails on `master` (the metadata leaks) and passes with the fix.
- `uv run pytest tests/unit/_utils/test_sitemap.py tests/unit/request_loaders/test_sitemap_request_loader.py` -> 101 passed. The request-loader suite exercises the same parser path.
- `uv run poe lint` (ruff check + format) and `uv run poe type-check` (ty) both pass on the changed files.

### Checklist

- [ ] CI passed
