### PR TITLE
fix: Keep minutes segment in format_duration for sub-minute remainders

### DIFF
--- a/src/crawlee/_utils/time.py
+++ b/src/crawlee/_utils/time.py
@@ -112,7 +112,7 @@ def format_duration(duration: timedelta | None) -> str:
     seconds = remaining_seconds % _SECONDS_PER_MINUTE
 
     result = f'{hours}h'
-    if minutes > 0:
+    if minutes > 0 or seconds > 0:
         result += f' {minutes}min'
     if seconds > 0:
         result += f' {seconds:.1f}s'

--- a/tests/unit/_utils/test_time.py
+++ b/tests/unit/_utils/test_time.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from crawlee._utils.time import format_duration
+
+
+@pytest.mark.parametrize(
+    ('duration', 'expected'),
+    [
+        (None, 'None'),
+        (timedelta(seconds=0), '0s'),
+        (timedelta(microseconds=500), '500.0μs'),
+        (timedelta(milliseconds=500), '500.0ms'),
+        (timedelta(seconds=59.5), '59.50s'),
+        (timedelta(seconds=90), '1min 30.0s'),
+        (timedelta(minutes=2), '2min'),
+        (timedelta(hours=2), '2h'),
+        (timedelta(hours=2, minutes=1), '2h 1min'),
+        (timedelta(hours=2, minutes=1, seconds=30), '2h 1min 30.0s'),
+        # Hours with no full minutes but leftover seconds must keep the minutes
+        # segment, otherwise '1h 30.0s' misleadingly reads as 1h30m.
+        (timedelta(hours=1, seconds=30), '1h 0min 30.0s'),
+        (timedelta(hours=1, seconds=1), '1h 0min 1.0s'),
+    ],
+)
+def test_format_duration(duration: timedelta | None, expected: str) -> None:
+    assert format_duration(duration) == expected


### PR DESCRIPTION
### Description

`format_duration` (`src/crawlee/_utils/time.py`) drops the minutes segment for durations >= 1h that have zero full minutes but leftover seconds, because the minutes segment was appended only `if minutes > 0`. So a 1h0m30s duration rendered as `1h 30.0s`, which reads as 1h30m. The sub-hour branch is already consistent (`2min 30.0s`); only the hours branch was wrong.

This appends the minutes segment whenever any sub-hour remainder exists, so the case now renders `1h 0min 30.0s`. Seconds are still shown only when > 0, so durations with no remainder are unchanged (`2h`, `2h 1min`).

`format_duration` feeds the user-facing `FinalStatistics.to_table` rows (`crawler_runtime`, `request_total_duration`), so the visible impact is the displayed stats string. `to_dict` uses `total_seconds()`, not this string, so machine-readable output is untouched.

### Issues

- None. Self-identified correctness fix; no tracked issue.

### Testing

- Adds `tests/unit/_utils/test_time.py` (parametrized) covering the buggy hour edge (1h0m30s, 1h0m1s) plus neighbours (2h, 2h1m, 2h1m30s, sub-minute, sub-second, exact minute, 0s, None). `uv run pytest tests/unit/_utils/test_time.py` passes; reverting the one source line fails exactly the two hour-edge cases. `uv run poe lint` and `uv run poe type-check` are clean.

### Checklist

- [ ] CI passed
