### PR TITLE
ci: bump apify/actions/pnpm-install to v1.3.1

### DIFF
--- a/.github/workflows/_checks.yaml
+++ b/.github/workflows/_checks.yaml
@@ -62,7 +62,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install pnpm and website dependencies
-        uses: apify/actions/pnpm-install@v1.3.0
+        uses: apify/actions/pnpm-install@v1.3.1
         with:
           working-directory: website
 
@@ -83,7 +83,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install pnpm and website dependencies
-        uses: apify/actions/pnpm-install@v1.3.0
+        uses: apify/actions/pnpm-install@v1.3.1
         with:
           working-directory: website
 

--- a/.github/workflows/manual_release_docs.yaml
+++ b/.github/workflows/manual_release_docs.yaml
@@ -73,7 +73,7 @@ jobs:
         run: uv run poe install-dev
 
       - name: Install pnpm and website dependencies
-        uses: apify/actions/pnpm-install@v1.3.0
+        uses: apify/actions/pnpm-install@v1.3.1
         with:
           working-directory: website
 

--- a/.github/workflows/manual_version_docs.yaml
+++ b/.github/workflows/manual_version_docs.yaml
@@ -72,7 +72,7 @@ jobs:
         run: uv run poe install-dev
 
       - name: Install pnpm and website dependencies
-        uses: apify/actions/pnpm-install@v1.3.0
+        uses: apify/actions/pnpm-install@v1.3.1
         with:
           working-directory: website
 


### PR DESCRIPTION
Bumps the pinned `apify/actions/pnpm-install` composite action to `v1.3.1`.

That release updates `actions/cache` to `v6.1.0`, so the action runs on the Node.js 24 runtime. It clears the "Node.js 20 is deprecated" warning that shows up on every CI run. For details, see apify/actions#29.
