### PR TITLE
fix: Make adaptive-crawler extra importable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 [project.optional-dependencies]
 all = ["crawlee[adaptive-crawler,pydantic-ai,beautifulsoup,cli,curl-impersonate,httpx,parsel,playwright,otel,sql_sqlite,sql_postgres,sql_mysql,stagehand,redis]"]
 adaptive-crawler = [
+    "crawlee[beautifulsoup,parsel]",
     "jaro-winkler>=2.0.3",
     "playwright>=1.27.0",
     "scikit-learn>=1.6.0",

--- a/uv.lock
+++ b/uv.lock
@@ -794,8 +794,11 @@ dependencies = [
 [package.optional-dependencies]
 adaptive-crawler = [
     { name = "apify-fingerprint-datapoints" },
+    { name = "beautifulsoup4", extra = ["lxml"] },
     { name = "browserforge" },
+    { name = "html5lib" },
     { name = "jaro-winkler" },
+    { name = "parsel" },
     { name = "playwright" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -944,6 +947,7 @@ requires-dist = [
     { name = "colorama", specifier = ">=0.4.0" },
     { name = "cookiecutter", marker = "extra == 'cli'", specifier = ">=2.6.0" },
     { name = "crawlee", extras = ["adaptive-crawler", "pydantic-ai", "beautifulsoup", "cli", "curl-impersonate", "httpx", "parsel", "playwright", "otel", "sql-sqlite", "sql-postgres", "sql-mysql", "stagehand", "redis"], marker = "extra == 'all'" },
+    { name = "crawlee", extras = ["beautifulsoup", "parsel"], marker = "extra == 'adaptive-crawler'" },
     { name = "cryptography", marker = "extra == 'sql-mysql'", specifier = ">=46.0.5" },
     { name = "curl-cffi", marker = "extra == 'curl-impersonate'", specifier = ">=0.9.0" },
     { name = "html5lib", marker = "extra == 'beautifulsoup'", specifier = ">=1.0" },


### PR DESCRIPTION
## Problem

`pip install 'crawlee[adaptive-crawler]'` couldn't import `AdaptivePlaywrightCrawler`, because the module imports `bs4` and `parsel` at the top level while the extra didn't include them.

## Changes

The `adaptive-crawler` extra now pulls in `crawlee[beautifulsoup,parsel]`, using the same self-referencing pattern as the `all` extra.

## Verification

Installed only the `adaptive-crawler` extra into a clean venv, then imported `AdaptivePlaywrightCrawler` and constructed both the BeautifulSoup and Parsel static-parser factories.