### PR TITLE
fix: preserve case-sensitive URL parts

### DIFF
--- a/src/crawlee/_utils/requests.py
+++ b/src/crawlee/_utils/requests.py
@@ -20,7 +20,7 @@ def normalize_url(url: str, *, keep_url_fragment: bool = False) -> str:
     converting the scheme and netloc to lower case, stripping unwanted tracking parameters
     (specifically those beginning with 'utm_'), sorting the remaining query parameters alphabetically,
     and optionally retaining the URL fragment. The goal is to ensure that URLs that are functionally
-    identical but differ in trivial ways (such as parameter order or casing) are treated as the same.
+    identical but differ in trivial ways (such as parameter order or scheme/host casing) are treated as the same.
 
     Args:
         url: The URL to be normalized.
@@ -44,7 +44,7 @@ def normalize_url(url: str, *, keep_url_fragment: bool = False) -> str:
         yarl_new_url.path.removesuffix('/'), keep_query=True, keep_fragment=keep_url_fragment
     )
 
-    return str(yarl_new_url).lower()
+    return str(yarl_new_url)
 
 
 def compute_unique_key(

--- a/tests/unit/_utils/test_requests.py
+++ b/tests/unit/_utils/test_requests.py
@@ -15,7 +15,9 @@ from crawlee._utils.requests import compute_unique_key, normalize_url
             'http://example.com/?another_key=another_value&key=value',
             False,
         ),
-        ('HTTPS://EXAMPLE.COM/?KEY=VALUE', 'https://example.com/?key=value', False),
+        ('HTTPS://EXAMPLE.COM/?KEY=VALUE', 'https://example.com/?KEY=VALUE', False),
+        ('HTTPS://EXAMPLE.COM/Product/ABC?token=SeCrEt', 'https://example.com/Product/ABC?token=SeCrEt', False),
+        ('HTTP://EXAMPLE.COM/Path#Frag', 'http://example.com/Path#Frag', True),
         ('', '', False),
         ('http://example.com/#fragment', 'http://example.com/#fragment', True),
         ('http://example.com/#fragment', 'http://example.com', False),
@@ -26,6 +28,8 @@ from crawlee._utils.requests import compute_unique_key, normalize_url
         'remove_utm_params',
         'retain_sort_non_utm_params',
         'convert_scheme_netloc_to_lowercase',
+        'preserve_path_query_case',
+        'preserve_fragment_case',
         'handle_empty_url',
         'retain_fragment',
         'remove_fragment',
@@ -36,6 +40,19 @@ from crawlee._utils.requests import compute_unique_key, normalize_url
 def test_normalize_url(url: str, expected_output: str, *, keep_url_fragment: bool) -> None:
     output = normalize_url(url, keep_url_fragment=keep_url_fragment)
     assert output == expected_output
+
+
+@pytest.mark.parametrize(
+    ('first_url', 'second_url'),
+    [
+        ('https://example.com/Product/ABC', 'https://example.com/product/abc'),
+        ('https://example.com/?token=SeCrEt', 'https://example.com/?token=secret'),
+        ('https://example.com/?Token=secret', 'https://example.com/?token=secret'),
+    ],
+    ids=['path_key', 'query_value_key', 'query_name_key'],
+)
+def test_compute_unique_key_preserves_case_sensitive_path_and_query(first_url: str, second_url: str) -> None:
+    assert compute_unique_key(first_url) != compute_unique_key(second_url)
 
 
 def test_compute_unique_key_basic() -> None:


### PR DESCRIPTION
### Description

- Preserve path, query-name, query-value, and fragment casing in `normalize_url` while still relying on `yarl` to canonicalize scheme/host casing.
- Update the normalization docstring so it no longer implies all URL casing is trivial.
- Add regressions showing default unique keys no longer collide for case-distinct paths or query components.

### Issues

- Closes: #2008

### Testing

- `uv run pytest tests/unit/_utils/test_requests.py -q`
- `uv run poe lint`
- `uv run poe type-check`
- `git diff --check`

I also attempted `uv run poe unit-tests`. After installing Playwright browsers, the suite reached `2152 passed, 6 skipped` but still failed in `tests/unit/browsers/test_stagehand_browser_plugin.py` because the local environment lacks the Stagehand SEA binary (`stagehand-linux-arm64`). That failure appears unrelated to this URL normalization change.

### Checklist

- [x] CI passed
