### PR TITLE
test: Deflake test_error_handler_can_access_page on Windows CI

### DIFF
--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -1238,8 +1238,18 @@ async def test_error_handler_can_access_page(server_url: URL) -> None:
 
     await crawler.run([str(server_url / 'hello-world')])
 
-    assert error_handler_calls == [HELLO_WORLD.decode(), HELLO_WORLD.decode()]
-    assert failed_handler_calls == [HELLO_WORLD.decode()]
+    # The error handler runs on each retry and the failed-request handler on the final failure, each recording the
+    # page content when it received a `PlaywrightCrawlingContext` or `None` otherwise. On CI (notably Windows under
+    # `xdist` load) navigation can spuriously fail with `net::ERR_NO_BUFFER_SPACE` before the page is created, so that
+    # attempt surfaces a `BasicCrawlingContext` recorded as `None`. Such attempts are environmental noise rather than
+    # the behavior under test, so assert on the attempts that actually reached the page: at least one must have, and
+    # every one that did must expose the page HTML.
+    page_error_calls = [content for content in error_handler_calls if content is not None]
+    page_failed_calls = [content for content in failed_handler_calls if content is not None]
+
+    assert page_error_calls, 'the error handler never received a PlaywrightCrawlingContext'
+    assert all(content == HELLO_WORLD.decode() for content in page_error_calls)
+    assert all(content == HELLO_WORLD.decode() for content in page_failed_calls)
 
 
 def test_import_error_handled() -> None:

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -1220,32 +1220,30 @@ async def test_error_handler_can_access_page(server_url: URL) -> None:
     request_handler = mock.AsyncMock(side_effect=RuntimeError('Intentional crash'))
     crawler.router.default_handler(request_handler)
 
-    error_handler_calls: list[str | None] = []
+    error_handler_calls: list[str] = []
 
     @crawler.error_handler
     async def error_handler(context: BasicCrawlingContext | PlaywrightCrawlingContext, _error: Exception) -> None:
-        error_handler_calls.append(
-            await context.page.content() if isinstance(context, PlaywrightCrawlingContext) else None
-        )
+        if isinstance(context, PlaywrightCrawlingContext):
+            error_handler_calls.append(await context.page.content())
 
-    failed_handler_calls: list[str | None] = []
+    failed_handler_calls: list[str] = []
 
     @crawler.failed_request_handler
     async def failed_handler(context: BasicCrawlingContext | PlaywrightCrawlingContext, _error: Exception) -> None:
-        failed_handler_calls.append(
-            await context.page.content() if isinstance(context, PlaywrightCrawlingContext) else None
-        )
+        if isinstance(context, PlaywrightCrawlingContext):
+            failed_handler_calls.append(await context.page.content())
 
     await crawler.run([str(server_url / 'hello-world')])
 
-    # On Windows CI, navigation can spuriously fail with `net::ERR_NO_BUFFER_SPACE`, giving an error-handler call
-    # with a non-Playwright context (`None`). Ignore those and require page-reaching attempts to see the page HTML.
-    page_error_calls = [content for content in error_handler_calls if content is not None]
-    page_failed_calls = [content for content in failed_handler_calls if content is not None]
-
-    assert page_error_calls, 'the error handler never received a PlaywrightCrawlingContext'
-    assert all(content == HELLO_WORLD.decode() for content in page_error_calls)
-    assert all(content == HELLO_WORLD.decode() for content in page_failed_calls)
+    # The error handler runs on each retry and the failed-request handler on the final failure. Each records the page
+    # content only when it received a `PlaywrightCrawlingContext`. On CI (notably Windows under `xdist` load) navigation
+    # can spuriously fail with `net::ERR_NO_BUFFER_SPACE` before the page is created, yielding a `BasicCrawlingContext`
+    # that never reached the page. Such attempts are environmental noise rather than the behavior under test, so assert
+    # only on the attempts that actually reached the page: at least one must have, and every one that did exposes it.
+    assert error_handler_calls, 'the error handler never received a PlaywrightCrawlingContext'
+    assert all(content == HELLO_WORLD.decode() for content in error_handler_calls)
+    assert all(content == HELLO_WORLD.decode() for content in failed_handler_calls)
 
 
 def test_import_error_handled() -> None:

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -1238,12 +1238,8 @@ async def test_error_handler_can_access_page(server_url: URL) -> None:
 
     await crawler.run([str(server_url / 'hello-world')])
 
-    # The error handler runs on each retry and the failed-request handler on the final failure, each recording the
-    # page content when it received a `PlaywrightCrawlingContext` or `None` otherwise. On CI (notably Windows under
-    # `xdist` load) navigation can spuriously fail with `net::ERR_NO_BUFFER_SPACE` before the page is created, so that
-    # attempt surfaces a `BasicCrawlingContext` recorded as `None`. Such attempts are environmental noise rather than
-    # the behavior under test, so assert on the attempts that actually reached the page: at least one must have, and
-    # every one that did must expose the page HTML.
+    # On Windows CI, navigation can spuriously fail with `net::ERR_NO_BUFFER_SPACE`, giving an error-handler call
+    # with a non-Playwright context (`None`). Ignore those and require page-reaching attempts to see the page HTML.
     page_error_calls = [content for content in error_handler_calls if content is not None]
     page_failed_calls = [content for content in failed_handler_calls if content is not None]
 

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -1236,14 +1236,16 @@ async def test_error_handler_can_access_page(server_url: URL) -> None:
 
     await crawler.run([str(server_url / 'hello-world')])
 
-    # The error handler runs on each retry and the failed-request handler on the final failure. Each records the page
-    # content only when it received a `PlaywrightCrawlingContext`. On CI (notably Windows under `xdist` load) navigation
-    # can spuriously fail with `net::ERR_NO_BUFFER_SPACE` before the page is created, yielding a `BasicCrawlingContext`
-    # that never reached the page. Such attempts are environmental noise rather than the behavior under test, so assert
-    # only on the attempts that actually reached the page: at least one must have, and every one that did exposes it.
-    assert error_handler_calls, 'the error handler never received a PlaywrightCrawlingContext'
-    assert all(content == HELLO_WORLD.decode() for content in error_handler_calls)
-    assert all(content == HELLO_WORLD.decode() for content in failed_handler_calls)
+    # Each handler records page content only when it received a `PlaywrightCrawlingContext`. On CI (notably Windows
+    # under `xdist` load) navigation can spuriously fail with `net::ERR_NO_BUFFER_SPACE` before the page is created,
+    # yielding a `BasicCrawlingContext` that never reached the page.
+    #
+    # The error handler runs on every retry, so at least one attempt must have reached the page, and every attempt that
+    # did must expose its HTML.
+    assert set(error_handler_calls) == {HELLO_WORLD.decode()}
+    # The failed-request handler runs only on the final attempt, which may itself be a non-navigated one, so an empty
+    # result is legitimate here. Any content it did record must still be the page HTML.
+    assert set(failed_handler_calls) <= {HELLO_WORLD.decode()}
 
 
 def test_import_error_handled() -> None:


### PR DESCRIPTION
`test_error_handler_can_access_page` fails intermittently on the Windows CI runner ([example run](https://github.com/apify/crawlee-python/actions/runs/28652457948/job/84973524931)). Under `xdist` load, Playwright's `Page.goto` occasionally fails with `net::ERR_NO_BUFFER_SPACE` before the page is navigated. That attempt's error handler then receives a `BasicCrawlingContext` (recorded as `None`) instead of a `PlaywrightCrawlingContext`, so the exact-list assertion `[HELLO_WORLD, HELLO_WORLD]` breaks with `[None, HELLO_WORLD]`.

The crawler behaves correctly here (it retries, and a non-navigated attempt legitimately yields a basic context), so this is a test flake, not a product bug. The same `net::ERR_NO_BUFFER_SPACE` failure is already documented for three sibling tests (`test_resource_management`, `test_adaptive_crawling_pre_nav_change_to_context`, `test_stagehand_browser_controller`), which handle it with `@pytest.mark.flaky(reruns=3)`.

Rather than retry, this makes the assertion robust to spurious pre-navigation failures: it ignores attempts that never reached the page (`None`) and asserts that at least one attempt did, and that every attempt that did exposes the page HTML. Removes the test's sensitivity to the flake deterministically while preserving what it verifies (that the error handler can read the page). No product code changes.
