### PR TITLE
docs: Remove stale client_class arg from SqlClientMixin docstring

### DIFF
--- a/src/crawlee/storage_clients/_sql/_client_mixin.py
+++ b/src/crawlee/storage_clients/_sql/_client_mixin.py
@@ -152,7 +152,6 @@ class SqlClientMixin(ABC):
             name: The name of the storage for named (global scope) storages.
             alias: The alias of the storage for unnamed (run scope) storages.
             storage_client: SQL storage client instance.
-            client_class: Concrete client class to instantiate.
             metadata_model: Pydantic model for metadata validation.
             extra_metadata_fields: Storage-specific metadata fields.
         """


### PR DESCRIPTION


`SqlClientMixin._safely_open` (`src/crawlee/storage_clients/_sql/_client_mixin.py`)
had a Google-style Args block that documented a `client_class` parameter which is
not part of the method signature. The method's keyword-only parameters are `id`,
`name`, `alias`, `storage_client`, `metadata_model`, and `extra_metadata_fields`,
so the `client_class` line was stale documentation for an argument that does not
exist.

This removes that single line so the documented arguments match the actual
signature, consistent with the sibling `_open` method whose Args block already
matches its signature. No code behavior changes.

### Issues

- None. Self-identified documentation fix; no tracked issue.

### Testing

- Docstring-only change, so no runtime test is added (matches how comparable
  doc fixes are handled here).
- `uv run poe lint` (ruff format check + ruff check): clean.
- `uv run poe type-check` (ty): no new diagnostics from this change; the only
  diagnostics are pre-existing `unresolved-import` warnings for the optional,
  uninstalled `pydantic_ai` dependency, and none reference the touched file.
- `uv run pytest tests/unit/storage_clients/_sql/`: 34 passed (these exercise the
  `_safely_open` open paths for dataset / KVS / request-queue / storage clients).

### Checklist

- [ ] CI passed
