### PR TITLE
test: Assert HttpOnly is unset on a minimal cookie

### DIFF
--- a/tests/unit/sessions/test_cookies.py
+++ b/tests/unit/sessions/test_cookies.py
@@ -40,7 +40,7 @@ def test_set_basic_cookie() -> None:
     assert cookie.value == 'value'
     assert cookie.path == '/'
     assert not cookie.secure
-    assert not cookie.has_nonstandard_attr('httpOnpy')
+    assert not cookie.has_nonstandard_attr('HttpOnly')
 
 
 def test_set_cookie_with_all_attributes(session_cookies: SessionCookies, cookie_dict: CookieParam) -> None:


### PR DESCRIPTION


`test_set_basic_cookie` meant to check that a minimal cookie leaves `HttpOnly`
unset, but the assertion looked up the wrong attribute key:

```python
assert not cookie.has_nonstandard_attr('httpOnpy')
```

`'httpOnpy'` is a typo (`l` -> `p`) for `'HttpOnly'`. Cookies never carry the
misspelled key, so `has_nonstandard_attr('httpOnpy')` is always `False` and
`assert not False` passed unconditionally. The assertion therefore validated
nothing: a regression that wrongly set `HttpOnly` on a minimal cookie would not be
caught.

This corrects the key to `'HttpOnly'`, which is how the flag is actually stored and
read in `src/crawlee/sessions/_cookies.py` (`rest={'HttpOnly': ''}` when
`http_only` is set, read back via `cookie.has_nonstandard_attr('HttpOnly')`), and
matches the sibling assertion in `test_set_cookie_with_all_attributes`. The check
now genuinely asserts the minimal-cookie default.

```diff
-    assert not cookie.has_nonstandard_attr('httpOnpy')
+    assert not cookie.has_nonstandard_attr('HttpOnly')
```

### Issues

- No related issue. Self-identified while reading the session-cookie tests.

### Testing

- `uv run pytest tests/unit/sessions/test_cookies.py` - passes (8 passed).
- `uv run pytest tests/unit/sessions/` - passes (30 passed).
- `uv run poe lint` - passes.
- `uv run poe type-check` - no new diagnostics from this change.
- Verified the assertion now has teeth: temporarily forcing the source to always
  set `HttpOnly` on minimal cookies makes the corrected assertion fail (red),
  whereas the old `httpOnpy` assertion still passed. On unmodified source it passes
  (green).

### Checklist

- [ ] CI passed
