### PR TITLE
chore: Fix sitemap_urls description in SitemapRequestLoader

### DIFF
--- a/src/crawlee/request_loaders/_sitemap_request_loader.py
+++ b/src/crawlee/request_loaders/_sitemap_request_loader.py
@@ -122,7 +122,7 @@ class SitemapRequestLoader(RequestLoader):
         """Initialize the sitemap request loader.
 
         Args:
-            sitemap_urls: Configuration options for the loader.
+            sitemap_urls: List of sitemap URLs to fetch and parse for request URLs.
             proxy_info: Optional proxy to use for fetching sitemaps.
             include: List of glob or regex patterns to include URLs.
             exclude: List of glob or regex patterns to exclude URLs.


### PR DESCRIPTION


The `sitemap_urls` parameter of `SitemapRequestLoader.__init__` is documented as
"Configuration options for the loader.", a copy-paste placeholder that does not
describe the argument. `sitemap_urls: list[str]` is the list of sitemap URLs the
loader fetches and parses for request URLs.

This corrects the one-line docstring to match the class docstring ("The loader
fetches and parses sitemaps in the background"), the internal state field
("Queue of sitemap URLs that need to be fetched and processed"), and every docs
example (all pass a list such as `sitemap_urls=['https://crawlee.dev/sitemap.xml']`).

```diff
-            sitemap_urls: Configuration options for the loader.
+            sitemap_urls: List of sitemap URLs to fetch and parse for request URLs.
```

Docs-only change; no source or behavior change.

### Issues

- No related issue.

### Testing

- Documentation-only change, so no runtime behavior to test.
- `uv run poe lint` passes (ruff format check + ruff check).
- `uv run poe type-check` (ty) reports no new diagnostics; the changed file is
  unaffected.

### Checklist

- [ ] CI passed

---

## Notes for the ship step (not part of the PR)

- `gh pr create --repo apify/crawlee-python --base master \
    --head anxkhn:docs/fix-sitemap-urls-param-description \
    --title "docs: fix sitemap_urls parameter description in SitemapRequestLoader" \
    --body-file <clean body>`
- The "Issues" line intentionally does not use "Closes: #NNN": this is a
  self-identified docstring fix with no tracking issue (the repo has no
  `good first issue` label and issues are maintainer-assigned).
- No DCO sign-off and no CLA are required by this repo.
