### PR TITLE
test: Assert RequestList persists the expected request contents

### DIFF
--- a/tests/unit/request_loaders/test_request_list.py
+++ b/tests/unit/request_loaders/test_request_list.py
@@ -76,6 +76,7 @@ async def test_persist_requests_key_with_sync_iterable() -> None:
     kvs = await KeyValueStore.open()
     persisted_data = await kvs.get_value(persist_key)
     assert persisted_data is not None
+    assert [request['url'] for request in persisted_data['requests']] == urls
 
 
 async def test_persist_requests_key_with_empty_iterator() -> None:
@@ -93,6 +94,7 @@ async def test_persist_requests_key_with_empty_iterator() -> None:
     kvs = await KeyValueStore.open()
     persisted_data = await kvs.get_value(persist_key)
     assert persisted_data is not None
+    assert persisted_data['requests'] == []
 
 
 async def test_requests_restoration_without_state() -> None:
@@ -268,3 +270,4 @@ async def test_handle_invalid_url_with_persistence() -> None:
     kvs = await KeyValueStore.open()
     persisted_data = await kvs.get_value(persist_key)
     assert persisted_data is not None
+    assert [request['url'] for request in persisted_data['requests']] == ['https://valid.placeholder.com']


### PR DESCRIPTION


Three of the `RequestList` persistence tests in
`tests/unit/request_loaders/test_request_list.py` build a persisted value in the
key-value store and then only assert `persisted_data is not None`. Each of their
docstrings/comments claims to verify the actual persisted request set, but the
contents were never checked, so a regression that persisted the wrong URLs, an
empty list where data was expected, or a malformed structure would still pass.

This adds one content assertion per test on top of the existing null check:

- `test_persist_requests_key_with_sync_iterable`: the persisted URLs equal the
  three input URLs (docstring: "persists request data").
- `test_persist_requests_key_with_empty_iterator`: `persisted_data['requests']`
  equals `[]` (comment: "empty requests were persisted").
- `test_handle_invalid_url_with_persistence`: the persisted URLs are exactly
  `['https://valid.placeholder.com']`, so the invalid URL is excluded (comment:
  "the valid URL was persisted and the invalid one was not").

The existing `assert persisted_data is not None` lines are kept: they narrow the
type before the new subscripting.

No production code changes; this only strengthens existing assertions.

### Issues

- No related open issue. Self-identified test gap.

### Testing

- `uv run pytest tests/unit/request_loaders/test_request_list.py -v` -> 11 passed.
- `uv run poe lint` (ruff format check + ruff check) -> clean on the changed file.
- `uv run poe type-check` -> no new diagnostics from this change.
- Confirmed each new assertion is load-bearing: temporarily changing an expected
  value makes exactly that test fail, and reverting restores green.

### Checklist

- [ ] CI passed
