### PR TITLE
fix(deps): raise tldextract floor to >=5.3.0 to avoid AttributeError on same-domain enqueue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "pydantic-settings>=2.12.0",
     "pydantic>=2.11.0",
     "pyee>=9.0.0",
-    "tldextract>=5.1.0",
+    "tldextract>=5.3.0",
     "typing-extensions>=4.10.0",
     "yarl>=1.18.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -981,7 +981,7 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'sql-postgres'", specifier = ">=2.0.0,<3.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'sql-sqlite'", specifier = ">=2.0.0,<3.0.0" },
     { name = "stagehand", marker = "extra == 'stagehand'", specifier = ">=3.19.5" },
-    { name = "tldextract", specifier = ">=5.1.0" },
+    { name = "tldextract", specifier = ">=5.3.0" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12.0" },
     { name = "typing-extensions", specifier = ">=4.10.0" },
     { name = "wrapt", marker = "extra == 'otel'", specifier = ">=1.17.0" },


### PR DESCRIPTION


`_domain_under_public_suffix` in `src/crawlee/_utils/urls.py` reads the
`top_domain_under_public_suffix` property of tldextract's `ExtractResult`:

```python
return _get_tld_extractor().extract_str(host).top_domain_under_public_suffix
```

That property was added in **tldextract 5.3.0** (2025-04-21), but the dependency
constraint in `pyproject.toml` is still `tldextract>=5.1.0`. Any environment that
resolves tldextract into the permitted `5.1.0`-`5.2.x` range therefore raises

```
AttributeError: 'ExtractResult' object has no attribute 'top_domain_under_public_suffix'
```

the first time registrable-domain matching runs, i.e. on the `same-domain`
enqueue strategy (`_matches_enqueue_strategy`). The bundled `uv.lock` pins a
newer tldextract, so CI always runs a version that has the property and never
exercises the older versions the metadata still allows.

This bumps the floor to `>=5.3.0` to match the code. `top_domain_under_public_suffix`
is the only tldextract result property used anywhere in `src/`, so 5.3.0 is
exactly the version that introduced the API the code relies on. It is a
metadata-only change; the currently resolved tldextract already satisfies the
new floor, so `uv.lock` needs no re-resolution beyond the mirrored specifier
line.

### Issues

- Not applicable (no existing issue).

### Testing

- `uv lock --check` passes (lockfile stays consistent with the new floor).
- `uv run pytest tests/unit/_utils/test_urls.py` -> 28 passed, including the
  `same-domain` parametrizations that exercise the property.
- `uv run poe lint` passes (ruff format check + ruff check).
- No new test: the change is pure dependency metadata and cannot be driven
  red->green against the resolved tldextract (which already has the property);
  the `same-domain` path is already covered by the existing URL filter tests.

### Checklist

- [ ] CI passed
