### PR TITLE
fix(sitemap): ignore sitemap URLs with an empty <loc>

### DIFF
--- a/src/crawlee/_utils/sitemap.py
+++ b/src/crawlee/_utils/sitemap.py
@@ -111,7 +111,7 @@ class _XMLSaxSitemapHandler(ContentHandler):
             if name == 'loc':
                 if self._root_tag_name == 'sitemapindex':
                     self._items.append({'type': 'sitemap_url', 'url': text})
-                else:
+                elif text:
                     self._current_url['loc'] = text
 
             elif name == 'lastmod' and text:

--- a/tests/unit/_utils/test_sitemap.py
+++ b/tests/unit/_utils/test_sitemap.py
@@ -429,6 +429,22 @@ def test_xml_handler_discards_metadata_from_url_without_loc() -> None:
     assert handler.items == [{'type': 'url', 'loc': 'https://example.com/real-page'}]
 
 
+def test_xml_handler_discards_url_with_empty_loc() -> None:
+    """A <url> block with an empty <loc></loc> must be discarded instead of emitting an empty-string URL."""
+    handler = _XMLSaxSitemapHandler()
+    parser = ExpatParser()
+    parser.setContentHandler(handler)
+    parser.feed(
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+        '<url><loc></loc><priority>0.5</priority></url>'
+        '<url><loc>https://example.com/real-page</loc></url>'
+        '</urlset>'
+    )
+
+    assert handler.items == [{'type': 'url', 'loc': 'https://example.com/real-page'}]
+
+
 async def test_txt_parser_flush_clears_buffer() -> None:
     """Feeding more data after flush() must not concatenate the previously flushed URL."""
     parser = _TxtSitemapParser()


### PR DESCRIPTION


`_XMLSaxSitemapHandler` (the streaming XML sitemap parser in
`src/crawlee/_utils/sitemap.py`) emitted a bogus empty-string URL when a
`<urlset>` contained a `<url>` with an empty `<loc></loc>`.

Two things combined to let this through:

- In `endElement`, the `loc` branch stored `text` on `self._current_url['loc']`
  unconditionally, even when `text` was an empty string.
- The `</url>` handler decides whether to emit an entry with
  `if 'loc' in self._current_url:`, which tests key presence, not a non-empty
  value.

So `<url><loc></loc><priority>0.5</priority></url>` produced
`{'type': 'url', 'loc': '', 'priority': 0.5}`, and
`Sitemap.from_xml_string(...).urls` returned `['']`.

This is inconsistent with the sibling metadata branches in the same method,
which all already guard on truthy text (`lastmod` and `priority` use
`and text`; `changefreq` uses `and text in VALID_CHANGE_FREQS`).

The fix guards the `loc` branch the same way, changing `else:` to `elif text:`
so an empty `<loc>` never sets the key and the `<url>` entry is discarded. The
`sitemapindex` path (which uses the raw `loc` text as a nested sitemap URL) is
untouched, and valid `<loc>` values behave exactly as before.

### Issues

- No existing issue; found while reading the sitemap parser.

### Testing

- Added `test_xml_handler_discards_url_with_empty_loc` in
  `tests/unit/_utils/test_sitemap.py`, mirroring the existing
  `test_xml_handler_discards_metadata_from_url_without_loc` (same `ExpatParser`
  driver and assertion style). It feeds a `<url>` with an empty `<loc></loc>`
  followed by a valid `<url>`, and asserts only the valid entry is emitted.
  Verified red before the fix (an empty-string URL leaks) and green after.
- `uv run pytest tests/unit/_utils/test_sitemap.py` -> 57 passed.
- `uv run poe lint` and `uv run poe type-check` clean on the changed files.

### Checklist

- [ ] CI passed
