### PR TITLE
chore(ci): modernize Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
-    "extends": ["config:base", ":semanticCommitTypeAll(chore)"],
+    "extends": ["config:recommended", ":semanticCommitTypeAll(chore)"],
     "ignorePaths": ["docs/**", "src/crawlee/project_template/**", "website/versioned_docs/**"],
-    "pinVersions": false,
+    "rangeStrategy": "replace",
     "separateMajorMinor": false,
     "dependencyDashboard": false,
     "semanticCommits": "enabled",
@@ -15,7 +15,7 @@
     },
     "packageRules": [
         {
-            "matchPaths": ["pyproject.toml"],
+            "matchFileNames": ["pyproject.toml"],
             "matchDepTypes": ["devDependencies"],
             "matchUpdateTypes": ["major", "minor"],
             "groupName": "major/minor dev dependencies",

--- a/renovate.json
+++ b/renovate.json
@@ -28,8 +28,8 @@
             "minimumReleaseAge": "0 days"
         },
         {
-          "matchUpdateTypes": ["lockFileMaintenance"],
-          "minimumReleaseAgeBehaviour": "timestamp-optional"
+            "matchUpdateTypes": ["lockFileMaintenance"],
+            "minimumReleaseAgeBehaviour": "timestamp-optional"
         }
     ],
     "schedule": ["* 0-5 * * 2-5"],


### PR DESCRIPTION
`renovate.json` uses three Renovate options that were renamed or removed in Renovate v36. Renovate still accepts them by running an internal config migration on every run, but because this config sets `dependencyDashboard: false` and does not enable `configMigration`, Renovate never opens a migration PR or surfaces a dashboard checkbox, so the legacy option names otherwise persist.

This updates them to the current names:

- `extends`: `config:base` -> `config:recommended` (the preset was renamed in v36).
- `pinVersions: false` -> `rangeStrategy: "replace"`. Renovate's config migration converts `pinVersions: false` into `rangeStrategy: "replace"`, so making it explicit matches the config Renovate already computes internally.
- `packageRules[].matchPaths` -> `matchFileNames` (`matchPaths` and `matchFiles` were merged into `matchFileNames` in v36).

These edits match what `renovate-config-validator` emits when it migrates the current config, so there is no behavior change, only the removal of deprecated option names.

### Issues

- N/A (config housekeeping; no related issue).

### Testing

Validated with Renovate's official config validator:

```bash
npx --package renovate -- renovate-config-validator --strict renovate.json
```

- Before: exit 1, `WARN: Config migration necessary`.
- After: exit 0, `INFO: Config validated successfully`.

No unit test applies because this is CI/tooling config; no in-repo workflow, pre-commit hook, or formatter touches `renovate.json`.

### Checklist

- [ ] CI passed
