### PR TITLE
fix(sessions): Preserve cookie expiry of 0 (Unix epoch) on serialization

### DIFF
--- a/src/crawlee/sessions/_cookies.py
+++ b/src/crawlee/sessions/_cookies.py
@@ -150,7 +150,7 @@ class SessionCookies:
             http_only=cookie.has_nonstandard_attr('HttpOnly'),
         )
 
-        if cookie.expires:
+        if cookie.expires is not None:
             cookie_dict['expires'] = cookie.expires
 
         if (same_site := cookie.get_nonstandard_attr('SameSite')) and self._is_valid_same_site(same_site):

--- a/tests/unit/sessions/test_cookies.py
+++ b/tests/unit/sessions/test_cookies.py
@@ -110,6 +110,20 @@ def test_get_cookies_as_dicts(session_cookies: SessionCookies, cookie_dict: Cook
     assert [cookie_dict] == test_session_cookies
 
 
+def test_convert_cookie_to_dict_preserves_epoch_expiry() -> None:
+    """Test that an explicit `expires=0` (the Unix epoch) is not dropped on conversion."""
+    session_cookies = SessionCookies()
+    session_cookies.set('test', 'value', expires=0)
+
+    cookie_dicts = session_cookies.get_cookies_as_dicts()
+    assert len(cookie_dicts) == 1
+    assert cookie_dicts[0]['expires'] == 0
+
+    browser_cookies = session_cookies.get_cookies_as_playwright_format()
+    assert len(browser_cookies) == 1
+    assert browser_cookies[0]['expires'] == 0
+
+
 def test_store_cookie(session_cookies: SessionCookies) -> None:
     """Test storing a Cookie object directly."""
     test_session_cookies = SessionCookies()


### PR DESCRIPTION
A cookie whose expiry is exactly `0` (the Unix epoch, `1970-01-01T00:00:00Z`) is silently dropped from the serialized cookie dict and turned into a session cookie.

- `SessionCookies._convert_cookie_to_dict` guards the `expires` field with a truthiness check, `if cookie.expires:`. The underlying `http.cookiejar.Cookie` does store `expires == 0`, but `0` is falsy, so the `expires` key is omitted from the resulting `CookieParam`.
- A `CookieParam` with no `expires` is, by the type's own contract, a session cookie (`expires` is documented "None for a session cookie"). So an explicit epoch expiry is converted into "no expiry" and the cookie's lifetime is lost.
- This dict is the serialization path used both by `Session.get_state` and by `get_cookies_as_playwright_format`, so the epoch expiry is lost in both.
- Fix: use `is not None` so the boundary value `0` is preserved. `None` remains the sole "no expiry" sentinel, so genuine session cookies are still dropped and every non-zero expiry is unchanged.

### Issues

- No existing GitHub issue. This is a self-identified correctness bug found while reviewing the session cookie serialization. Happy to open a tracking issue with the repro first if the maintainers prefer that.

### Testing

- Added `test_convert_cookie_to_dict_preserves_epoch_expiry` to `tests/unit/sessions/test_cookies.py`. It uses the public `SessionCookies` API (`set('test', 'value', expires=0)`) and asserts that `expires == 0` survives both `get_cookies_as_dicts()` and `get_cookies_as_playwright_format()`.
- Verified fail-first: the new test fails on `master` with `KeyError: 'expires'` and passes with the fix.
- `uv run pytest tests/unit/sessions/` -> 31 passed (offline), including the existing session persist/restore tests.
- `uv run poe lint` and `uv run poe type-check` both pass on the changed files.

### Checklist

- [ ] CI passed
