### PR TITLE
fix(configuration): Reject out-of-range max_used_cpu_ratio and max_used_memory_ratio

### DIFF
--- a/src/crawlee/configuration.py
+++ b/src/crawlee/configuration.py
@@ -117,7 +117,9 @@ class Configuration(BaseSettings):
             validation_alias=AliasChoices(
                 'apify_max_used_cpu_ratio',
                 'crawlee_max_used_cpu_ratio',
-            )
+            ),
+            gt=0.0,
+            le=1.0,
         ),
     ] = 0.95
     """The maximum CPU usage ratio. If the CPU usage exceeds this value, the system is considered overloaded.
@@ -129,7 +131,9 @@ class Configuration(BaseSettings):
             validation_alias=AliasChoices(
                 'apify_max_used_memory_ratio',
                 'crawlee_max_used_memory_ratio',
-            )
+            ),
+            gt=0.0,
+            le=1.0,
         ),
     ] = 0.9
     """The maximum memory usage ratio. If the memory usage exceeds this ratio, it is considered overloaded.

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
 from anyio import Path as AnyioPath
+from pydantic import ValidationError
 
 from crawlee import service_locator
 from crawlee.configuration import Configuration
@@ -15,6 +17,28 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from yarl import URL
+
+
+@pytest.mark.parametrize('invalid_value', [-0.1, 0.0, 1.5])
+def test_configuration_rejects_out_of_range_max_used_cpu_ratio(invalid_value: float) -> None:
+    with pytest.raises(ValidationError):
+        Configuration(max_used_cpu_ratio=invalid_value)
+
+
+@pytest.mark.parametrize('invalid_value', [-0.1, 0.0, 1.5])
+def test_configuration_rejects_out_of_range_max_used_memory_ratio(invalid_value: float) -> None:
+    with pytest.raises(ValidationError):
+        Configuration(max_used_memory_ratio=invalid_value)
+
+
+@pytest.mark.parametrize('valid_value', [0.1, 0.9, 1.0])
+def test_configuration_accepts_in_range_max_used_cpu_ratio(valid_value: float) -> None:
+    assert Configuration(max_used_cpu_ratio=valid_value).max_used_cpu_ratio == valid_value
+
+
+@pytest.mark.parametrize('valid_value', [0.1, 0.9, 1.0])
+def test_configuration_accepts_in_range_max_used_memory_ratio(valid_value: float) -> None:
+    assert Configuration(max_used_memory_ratio=valid_value).max_used_memory_ratio == valid_value
 
 
 def test_global_configuration_works() -> None:


### PR DESCRIPTION


`Configuration.available_memory_ratio` is constrained with `Field(gt=0.0, le=1.0)`, but the two sibling ratio settings `max_used_cpu_ratio` (default `0.95`) and `max_used_memory_ratio` (default `0.9`) had no numeric bounds. As a result, out-of-range values were accepted silently, including values supplied through the `CRAWLEE_MAX_USED_*_RATIO` / `APIFY_MAX_USED_*_RATIO` environment variables.

These ratios feed the `Snapshotter` overload thresholds, which gate on `used_ratio > max_used_*_ratio` (`src/crawlee/_autoscaling/_types.py`). An out-of-range value degrades autoscaling:

- a ratio greater than `1.0` makes the overload threshold unreachable, so CPU/memory back-pressure never triggers (the pool keeps scaling up instead of throttling);
- a ratio of zero or below reports the system as always overloaded, so the autoscaler stalls.

This change adds matching `gt=0.0, le=1.0` bounds to both fields, mirroring `available_memory_ratio` (and the existing `Ratio` pydantic type in `_autoscaling/_types.py`, which uses the same constraint). Invalid values are now rejected at configuration time with a `ValidationError` rather than silently degrading autoscaling at runtime. A ratio of exactly `1.0` remains valid; `0.0` and negative values are rejected, consistent with `available_memory_ratio`.

Note: this rejects values that were previously accepted. Those values were always meaningless for the overload logic, so the practical effect is turning a silent misconfiguration into an explicit, early error.

### Issues

- No related open issue; this is a self-identified consistency/validation fix.

### Testing

- Added parametrized unit tests in `tests/unit/test_configuration.py`: both fields reject `-0.1`, `0.0`, `1.5` (raise `ValidationError`) and accept `0.1`, `0.9`, `1.0`.
- `uv run pytest tests/unit/test_configuration.py` passes (17 tests, 12 new).
- `uv run pytest tests/unit/_autoscaling/` passes (31 tests; no consumer regression).
- Reverting only the source bounds while keeping the new tests makes the reject cases fail ("DID NOT RAISE"), confirming the tests exercise the fix.
- `uv run poe lint` (ruff check + format) clean on both files.
- `uv run poe type-check` (ty) reports no new diagnostics attributable to the change.

### Checklist

- [ ] CI passed
