### PR TITLE
chore: align add_batch_of_requests docstring with its signature

### DIFF
--- a/src/crawlee/storage_clients/_base/_request_queue_client.py
+++ b/src/crawlee/storage_clients/_base/_request_queue_client.py
@@ -51,11 +51,6 @@ class RequestQueueClient(ABC):
             requests: The collection of requests to add to the queue.
             forefront: Whether to put the added requests at the beginning (True) or the end (False) of the queue.
                 When True, the requests will be processed sooner than previously added requests.
-            batch_size: The maximum number of requests to add in a single batch.
-            wait_time_between_batches: The time to wait between adding batches of requests.
-            wait_for_all_requests_to_be_added: If True, the method will wait until all requests are added
-                to the queue before returning.
-            wait_for_all_requests_to_be_added_timeout: The maximum time to wait for all requests to be added.
 
         Returns:
             A response object containing information about which requests were successfully


### PR DESCRIPTION

```markdown

The abstract `RequestQueueClient.add_batch_of_requests` has the signature
`(self, requests, *, forefront=False)`, but its `Args` section still documented
four parameters that are not part of it:

- `batch_size`
- `wait_time_between_batches`
- `wait_for_all_requests_to_be_added`
- `wait_for_all_requests_to_be_added_timeout`

These four are parameters of the higher-level `RequestQueue.add_requests` API
(`src/crawlee/storages/_request_queue.py`), not of the low-level storage-client
contract. They were left behind in the docstring when the storage client system
was reworked (the signature dropped them, the `Args` block did not).

This is the abstract contract that custom storage-client implementers read, so
the stale entries actively mislead anyone extending `RequestQueueClient`. This
change removes only those four descriptions and keeps `requests` and
`forefront`, so the documented `Args` now match the actual signature.

Docs-only change: no runtime behavior is affected.

### Issues

- No related open issue.

### Testing

Docs-only change, so there is nothing runtime to assert. Verified locally:

- `uv run poe lint` -> all checks passed (ruff format + check; Google docstrings).
- `uv run poe type-check` -> no new diagnostics from this change.

### Checklist

- [x] CI passed
```
