### PR TITLE
chore: fix typos in code comment and test docstring

### DIFF
--- a/src/crawlee/statistics/_models.py
+++ b/src/crawlee/statistics/_models.py
@@ -119,7 +119,7 @@ class StatisticsState(BaseModel):
 
     @crawler_runtime.setter
     def crawler_runtime(self, value: timedelta) -> None:
-        # Setter for backwards compatibility only, the crawler_runtime is now computed_field, and cant be set manually.
+        # Setter for backwards compatibility only, the crawler_runtime is now computed_field, and can't be set manually.
         # To be removed in v2 release https://github.com/apify/crawlee-python/issues/1567
         warnings.warn(
             f"Setting 'crawler_runtime' is deprecated and will be removed in a future version."

--- a/tests/unit/browsers/test_playwright_browser_controller.py
+++ b/tests/unit/browsers/test_playwright_browser_controller.py
@@ -156,7 +156,7 @@ async def test_max_open_pages_limit_error_on_concurrent_creation(controller: Pla
 
 
 async def test_browser_with_pre_existing_context(tmp_path: Path) -> None:
-    """Test that using `Browser` with pre-existing active context re-uses such context."""
+    """Test that using `Browser` with pre-existing active context reuses such context."""
     async with async_playwright() as pw:
         persistent_context = await pw.firefox.launch_persistent_context(
             user_data_dir=str(tmp_path),


### PR DESCRIPTION


Two one-word spelling corrections, no functional change:

- `src/crawlee/statistics/_models.py`: fix `cant` to `can't` in the
  `StatisticsState.crawler_runtime` setter comment.
- `tests/unit/browsers/test_playwright_browser_controller.py`: fix `re-uses` to
  `reuses` in the `test_browser_with_pre_existing_context` docstring, matching
  the spelling used everywhere else in the codebase.

### Testing

- `uv run poe lint` (ruff format check + ruff check): passes.
- `crate-ci/typos` and codespell over both files: clean.
- Comment/docstring-only changes, so no runtime behavior is affected and no test
  changes are needed.

### Checklist

- [ ] CI passed

<!-- Note for the human before opening: the template's "Issues -> Closes: #TODO"
line is intentionally omitted because there is no tracked issue for these typos
(the repo has no `good first issue` label and accepts typo-only PRs by
precedent). Keep it omitted, or drop a short "No related issue" note, rather than
leaving a `#TODO` placeholder. -->
