### PR TITLE
test: deflake Playwright navigation tests hitting ERR_NO_BUFFER_SPACE on Windows CI

### DIFF
--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -725,10 +725,9 @@ async def test_respect_robots_txt_with_problematic_links(server_url: URL) -> Non
     """Test checks the crawler behavior with links that may cause problems when attempting to retrieve robots.txt."""
     visit = mock.Mock()
     fail = mock.Mock()
-    crawler = PlaywrightCrawler(
-        respect_robots_txt_file=True,
-        max_request_retries=0,
-    )
+    # Keep default retries so a spurious `net::ERR_NO_BUFFER_SPACE` navigation failure (Windows/`xdist` on CI) recovers
+    # instead of aborting the crawl. `budplaceholder.com` still fails after its retries are exhausted.
+    crawler = PlaywrightCrawler(respect_robots_txt_file=True)
 
     @crawler.router.default_handler
     async def request_handler(context: PlaywrightCrawlingContext) -> None:
@@ -1044,10 +1043,9 @@ async def test_navigation_timeout_applies_to_hooks(server_url: URL) -> None:
 
 
 async def test_slow_navigation_does_not_count_toward_handler_timeout(server_url: URL) -> None:
-    crawler = PlaywrightCrawler(
-        request_handler_timeout=timedelta(seconds=0.5),
-        max_request_retries=0,
-    )
+    # Keep default retries so a spurious `net::ERR_NO_BUFFER_SPACE` navigation failure (Windows/`xdist` on CI) recovers
+    # instead of failing the run.
+    crawler = PlaywrightCrawler(request_handler_timeout=timedelta(seconds=0.5))
 
     request_handler = AsyncMock()
     crawler.router.default_handler(request_handler)

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -725,8 +725,6 @@ async def test_respect_robots_txt_with_problematic_links(server_url: URL) -> Non
     """Test checks the crawler behavior with links that may cause problems when attempting to retrieve robots.txt."""
     visit = mock.Mock()
     fail = mock.Mock()
-    # Keep default retries so a spurious `net::ERR_NO_BUFFER_SPACE` navigation failure (Windows/`xdist` on CI) recovers
-    # instead of aborting the crawl. `budplaceholder.com` still fails after its retries are exhausted.
     crawler = PlaywrightCrawler(respect_robots_txt_file=True)
 
     @crawler.router.default_handler
@@ -1043,8 +1041,6 @@ async def test_navigation_timeout_applies_to_hooks(server_url: URL) -> None:
 
 
 async def test_slow_navigation_does_not_count_toward_handler_timeout(server_url: URL) -> None:
-    # Keep default retries so a spurious `net::ERR_NO_BUFFER_SPACE` navigation failure (Windows/`xdist` on CI) recovers
-    # instead of failing the run.
     crawler = PlaywrightCrawler(request_handler_timeout=timedelta(seconds=0.5))
 
     request_handler = AsyncMock()


### PR DESCRIPTION
Two Playwright crawler tests set `max_request_retries=0` and assert that navigation **succeeds**. On the Windows CI runners under `pytest-xdist` load, Chromium navigation intermittently fails with `net::ERR_NO_BUFFER_SPACE` (socket-buffer exhaustion). With retries disabled, a single such spurious failure aborted the run and failed the assertions (this is what broke on the reported CI run).

Dropping `max_request_retries=0` (falling back to the default of 3) lets a spurious navigation failure recover on retry, matching how the neighbouring tests already survive. The assertions are unchanged and still meaningful:

- `test_respect_robots_txt_with_problematic_links` — `budplaceholder.com` still reaches the failed-request handler once its retries are exhausted.
- `test_slow_navigation_does_not_count_toward_handler_timeout` — a single successful attempt still yields the asserted counts.

The failure-asserting tests that intentionally rely on `max_request_retries=0` (`test_navigation_timeout_on_slow_page_load`, `test_navigation_timeout_applies_to_hooks`, and the adaptive static-timeout test) were left unchanged, since enabling retries there would change their semantics rather than help.
