### PR TITLE
fix(curl-impersonate): Avoid false already consumed error for buffered streams in `CurlImpersonateHttpClient`

### DIFF
--- a/src/crawlee/http_clients/_curl_impersonate.py
+++ b/src/crawlee/http_clients/_curl_impersonate.py
@@ -99,7 +99,14 @@ class _CurlImpersonateResponse:
         if not self._response.astream_task:
             raise RuntimeError('Cannot read stream, Response not obtained from `stream` method.')
 
-        if isinstance(self._response.astream_task, asyncio.Future) and self._response.astream_task.done():
+        # A finished transfer task only means the whole body arrived into the response queue. The stream is consumed
+        # once the queue has also been drained.
+        if (
+            isinstance(self._response.astream_task, asyncio.Future)
+            and self._response.astream_task.done()
+            and self._response.queue is not None
+            and self._response.queue.empty()
+        ):
             raise RuntimeError('Cannot read stream, it was already consumed.')
 
         async for chunk in self._response.aiter_content():

--- a/tests/unit/http_clients/test_http_clients.py
+++ b/tests/unit/http_clients/test_http_clients.py
@@ -15,6 +15,7 @@ from crawlee import Request
 from crawlee.errors import ProxyError
 from crawlee.http_clients import CurlImpersonateHttpClient, HttpClient, HttpxHttpClient, ImpitHttpClient
 from crawlee.statistics import Statistics
+from tests.unit.server import generate_file_content
 from tests.unit.server_endpoints import HELLO_WORLD
 
 if TYPE_CHECKING:
@@ -180,16 +181,19 @@ async def test_stream(http_client: HttpClient, server_url: URL) -> None:
 
 async def test_stream_read_after_transfer_finished(http_client: HttpClient, server_url: URL) -> None:
     """A small body can be fully buffered before `read_stream` is called. It must still be readable."""
+    file_size = 16
     content_body: bytes = b''
 
-    async with http_client.stream(str(server_url)) as response:
-        # Give the event loop time to finish the transfer before the body is consumed.
-        await asyncio.sleep(0.1)
+    small_file_url = str((server_url / 'file').update_query(size=file_size))
+
+    async with http_client.stream(small_file_url) as response:
+        # Guarantee at least one event-loop tick for the response to be buffered.
+        await asyncio.sleep(0)
 
         async for chunk in response.read_stream():
             content_body += chunk
 
-    assert content_body == HELLO_WORLD
+    assert content_body == generate_file_content(file_size)
 
 
 async def test_stream_with_empty_body(http_client: HttpClient, server_url: URL) -> None:

--- a/tests/unit/http_clients/test_http_clients.py
+++ b/tests/unit/http_clients/test_http_clients.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 import os
 import sys
@@ -175,6 +176,31 @@ async def test_stream(http_client: HttpClient, server_url: URL) -> None:
             content_body += chunk
 
     assert content_body == HELLO_WORLD
+
+
+async def test_stream_read_after_transfer_finished(http_client: HttpClient, server_url: URL) -> None:
+    """A small body can be fully buffered before `read_stream` is called. It must still be readable."""
+    content_body: bytes = b''
+
+    async with http_client.stream(str(server_url)) as response:
+        # Give the event loop time to finish the transfer before the body is consumed.
+        await asyncio.sleep(0.1)
+
+        async for chunk in response.read_stream():
+            content_body += chunk
+
+    assert content_body == HELLO_WORLD
+
+
+async def test_stream_with_empty_body(http_client: HttpClient, server_url: URL) -> None:
+    """A streamed response with an empty body must be readable and yield no chunks."""
+    content_body: bytes = b''
+    async with http_client.stream(str(server_url / 'status/200')) as response:
+        assert response.status_code == 200
+        async for chunk in response.read_stream():
+            content_body += chunk
+
+    assert content_body == b''
 
 
 async def test_stream_error_double_read_stream(http_client: HttpClient, server_url: URL) -> None:

--- a/tests/unit/server.py
+++ b/tests/unit/server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import gzip
+import hashlib
 import json
 import sys
 import threading
@@ -129,6 +130,7 @@ async def app(scope: dict[str, Any], receive: Receive, send: Send) -> None:
         'xml': hello_world_xml,
         'robots.txt': robots_txt,
         'get_compressed': get_compressed,
+        'file': file_endpoint,
         'slow': slow_response,
         'infinite_scroll': infinite_scroll_endpoint,
         'resource_loading_page': resource_loading_endpoint,
@@ -428,6 +430,50 @@ async def get_compressed(_scope: dict[str, Any], _receive: Receive, send: Send) 
         }
     )
     await send({'type': 'http.response.body', 'body': gzip.compress(HELLO_WORLD * 1000)})
+
+
+def generate_file_content(size: int) -> bytes:
+    """Generate deterministic binary content of the given size."""
+    content = bytearray()
+    counter = 0
+    while len(content) < size:
+        content += hashlib.sha256(str(counter).encode()).digest()
+        counter += 1
+    return bytes(content[:size])
+
+
+async def file_endpoint(scope: dict[str, Any], _receive: Receive, send: Send) -> None:
+    """Stream deterministic binary content in chunks to test file downloads."""
+    query_params = get_query_params(scope.get('query_string', b''))
+
+    size = int(query_params.get('size', '1024'))
+    chunk_size = int(query_params.get('chunk_size', '65536'))
+    throttle = float(query_params.get('throttle', '0'))
+    content_type = query_params.get('content_type', 'application/octet-stream')
+
+    content = generate_file_content(size)
+
+    await send(
+        {
+            'type': 'http.response.start',
+            'status': 200,
+            'headers': [
+                [b'content-type', content_type.encode()],
+                [b'content-length', str(len(content)).encode()],
+            ],
+        }
+    )
+
+    for offset in range(0, len(content), chunk_size):
+        if throttle and offset:
+            await asyncio.sleep(throttle)
+        await send(
+            {
+                'type': 'http.response.body',
+                'body': content[offset : offset + chunk_size],
+                'more_body': offset + chunk_size < len(content),
+            }
+        )
 
 
 async def slow_response(scope: dict[str, Any], _receive: Receive, send: Send) -> None:


### PR DESCRIPTION
### Description

- `curl_cffi` buffers a streamed response in a queue, so a small response body could be fully buffered before reading started. This caused a false `RuntimeError: Cannot read stream, it was already consumed.` from `read_stream`.

### Testing

- Added new regression tests for HTTP clients 
