### PR TITLE
test: rerun flaky test_http_2 on transient HTTP/2 connection termination

### DIFF
--- a/tests/unit/http_clients/test_http_clients.py
+++ b/tests/unit/http_clients/test_http_clients.py
@@ -42,6 +42,12 @@ async def test_http_1(http_client: HttpClient, server_url: URL) -> None:
     assert response.http_version == 'HTTP/1.1'
 
 
+@pytest.mark.flaky(
+    reruns=3,
+    reason='`https://apify.com/` occasionally terminates the HTTP/2 connection with a GOAWAY '
+    '(RemoteProtocolError / ConnectionTerminated); an external transient condition where a fresh '
+    'rerun reconnects and negotiates HTTP/2 cleanly.',
+)
 @pytest.mark.parametrize(
     'custom_http_client',
     [


### PR DESCRIPTION
`test_http_2` sends a real request to `https://apify.com/` to verify HTTP/2 negotiation across the three HTTP clients (`curl`, `httpx`, `impit`). Occasionally the server/CDN gracefully terminates the HTTP/2 connection with a GOAWAY frame (`error_code:0`), which `httpx`/`httpcore` surface as `RemoteProtocolError: <ConnectionTerminated ...>` without retrying. Crawlee's `send_request` just re-raises the transport error, so the test fails intermittently in CI (seen on macos-latest / 3.11 — [run 29007732402](https://github.com/apify/crawlee-python/actions/runs/29007732402/job/86083355443)).

The flakiness is external — we don't control apify.com's connection lifecycle — and the test's purpose is to exercise real HTTP/2 negotiation, so it can't be mocked and the local test server is plain HTTP/1.1. Following the project's documented flaky-test policy (`tests/unit/README.md`), the test is marked `@pytest.mark.flaky(reruns=3)`. A fresh rerun reconnects and negotiates HTTP/2 cleanly, while a genuine HTTP/2 regression would still fail every attempt.