### PR TITLE
fix(cli): pin typer<0.26 to keep CLI choice options working

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,14 @@ adaptive-crawler = [
 ]
 pydantic-ai = ["pydantic-ai-slim[openai]>=2.1.0", "parsel>=1.10.0", "lxml[html_clean]>=5.2.0"]
 beautifulsoup = ["beautifulsoup4[lxml]>=4.12.0", "html5lib>=1.0"]
-cli = ["cookiecutter>=2.6.0", "inquirer>=3.3.0", "rich>=13.9.0", "typer>=0.12.0"]
+cli = [
+    "cookiecutter>=2.6.0",
+    "inquirer>=3.3.0",
+    "rich>=13.9.0",
+    # Pinned below 0.26, which breaks our `click.Choice` CLI options.
+    # See https://github.com/apify/crawlee-python/issues/2063.
+    "typer>=0.12.0,<0.26",
+]
 curl-impersonate = ["curl-cffi>=0.9.0"]
 httpx = ["httpx[brotli,http2,zstd]>=0.27.0", "apify_fingerprint_datapoints>=0.0.2", "browserforge>=1.2.3"]
 parsel = ["parsel>=1.10.0"]

--- a/src/crawlee/_cli.py
+++ b/src/crawlee/_cli.py
@@ -135,20 +135,20 @@ def create(
         '--crawler-type',
         '--template',
         show_default=False,
-        click_type=Choice(crawler_choices),  # ty: ignore[invalid-argument-type]
+        click_type=Choice(crawler_choices),
         help='The library that will be used for crawling in your crawler. If none is given, you will be prompted.',
     ),
     http_client: str | None = typer.Option(
         None,
         show_default=False,
-        click_type=Choice(http_client_choices),  # ty: ignore[invalid-argument-type]
+        click_type=Choice(http_client_choices),
         help='The library that will be used to make HTTP requests in your crawler. '
         'If none is given, you will be prompted.',
     ),
     package_manager: str | None = typer.Option(
         default=None,
         show_default=False,
-        click_type=Choice(package_manager_choices),  # ty: ignore[invalid-argument-type]
+        click_type=Choice(package_manager_choices),
         help='Package manager to be used in the new project. If none is given, you will be prompted.',
     ),
     start_url: str | None = typer.Option(

--- a/uv.lock
+++ b/uv.lock
@@ -977,7 +977,7 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'sql-sqlite'", specifier = ">=2.0.0,<3.0.0" },
     { name = "stagehand", marker = "extra == 'stagehand'", specifier = ">=3.19.5" },
     { name = "tldextract", specifier = ">=5.3.0" },
-    { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12.0" },
+    { name = "typer", marker = "extra == 'cli'", specifier = ">=0.12.0,<0.26" },
     { name = "typing-extensions", specifier = ">=4.10.0" },
     { name = "wrapt", marker = "extra == 'otel'", specifier = ">=1.17.0" },
     { name = "yarl", specifier = ">=1.18.0" },
@@ -4562,17 +4562,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.26.8"
+version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "click" },
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
typer 0.26 vendored click into a private `typer._click` module, so the `click.Choice` we pass to `typer.Option(click_type=...)` in `_cli.py` becomes a foreign `ParamType`. That fails `ty` and, worse, makes an invalid CLI choice raise an uncaught `click.BadParameter` (full traceback, exit code 1) instead of a clean usage error (exit code 2).

This pins `typer<0.26` in the `cli` extra so the CLI keeps working, and removes the now-unnecessary `# ty: ignore` comments that #2062 had added. The full migration to typer 0.26's choice handling is tracked in #2063.
