### PR TITLE
fix(fingerprint): keep the original error as the cause when generation fails

### DIFF
--- a/src/crawlee/fingerprint_suite/_browserforge_adapter.py
+++ b/src/crawlee/fingerprint_suite/_browserforge_adapter.py
@@ -230,13 +230,13 @@ class BrowserforgeFingerprintGenerator(FingerprintGenerator):
         # During test runs around 10 % flakiness was detected.
         # Max attempt set to 10 as (0.1)^10 is considered sufficiently low probability.
         max_attempts = 10
-        for attempt in range(max_attempts):
+        last_error: ValueError | None = None
+        for _attempt in range(max_attempts):
             try:
                 return self._generator.generate(**self._options)
-            except ValueError:  # noqa:PERF203
-                if attempt == max_attempts:
-                    raise
-        raise RuntimeError('Failed to generate fingerprint.')
+            except ValueError as exc:  # noqa:PERF203
+                last_error = exc
+        raise RuntimeError('Failed to generate fingerprint.') from last_error
 
 
 class BrowserforgeHeaderGenerator:

--- a/tests/unit/fingerprint_suite/test_adapters.py
+++ b/tests/unit/fingerprint_suite/test_adapters.py
@@ -8,7 +8,10 @@ from crawlee.fingerprint_suite import (
     HeaderGeneratorOptions,
     ScreenOptions,
 )
-from crawlee.fingerprint_suite._browserforge_adapter import PatchedHeaderGenerator
+from crawlee.fingerprint_suite._browserforge_adapter import (
+    BrowserforgeFingerprintGenerator,
+    PatchedHeaderGenerator,
+)
 from crawlee.fingerprint_suite._consts import BROWSER_TYPE_HEADER_KEYWORD
 
 
@@ -85,3 +88,27 @@ def test_patched_header_generator_generate(browser: Iterable[str | Browser]) -> 
     """Test that PatchedHeaderGenerator works with all the possible types correctly."""
     header = PatchedHeaderGenerator().generate(browser=browser)
     assert any(keyword in header['User-Agent'] for keyword in BROWSER_TYPE_HEADER_KEYWORD['firefox'])
+
+
+def test_fingerprint_generator_preserves_error_on_persistent_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that a persistently failing fingerprint generation preserves the original error.
+
+    `browserforge` is flaky and raises `ValueError` when the constraints cannot be satisfied. After exhausting all
+    retries, `generate` must raise a `RuntimeError` that chains the last `ValueError` so its context is not lost.
+    """
+    generator = BrowserforgeFingerprintGenerator()
+    attempts = 0
+
+    def always_fail(**_kwargs: object) -> None:
+        nonlocal attempts
+        attempts += 1
+        raise ValueError('screen constraints are too strict')
+
+    monkeypatch.setattr(generator._generator, 'generate', always_fail)
+
+    with pytest.raises(RuntimeError, match=r'Failed to generate fingerprint') as exc_info:
+        generator.generate()
+
+    assert attempts == 10
+    assert isinstance(exc_info.value.__cause__, ValueError)
+    assert str(exc_info.value.__cause__) == 'screen constraints are too strict'


### PR DESCRIPTION

`BrowserforgeFingerprintGenerator.generate` retries `browserforge` fingerprint
generation (which is known to be flaky and raises `ValueError` when the screen
or header constraints cannot be satisfied) inside `for attempt in range(max_attempts)`
with an `if attempt == max_attempts: raise` guard:

```python
max_attempts = 10
for attempt in range(max_attempts):
    try:
        return self._generator.generate(**self._options)
    except ValueError:  # noqa:PERF203
        if attempt == max_attempts:
            raise
raise RuntimeError('Failed to generate fingerprint.')
```

`range(10)` yields `0..9`, so `attempt == max_attempts` (`== 10`) is never true
and the inner `raise` is dead code. On persistent failure the loop falls through
to a bare `RuntimeError('Failed to generate fingerprint.')` whose `__cause__` and
`__context__` are both `None`, so the original `ValueError` (which carries the
real reason the constraints could not be satisfied) is discarded and the failure
is hard to diagnose.

This drops the dead guard and chains the last `ValueError` through the final
`RuntimeError` via `raise ... from`, so the diagnostic context is preserved. The
retry count (10) and the raised `RuntimeError` type and message are unchanged;
the only behavior change is that the exception now has a `__cause__`.

This also makes the method consistent with its sibling
`PatchedHeaderGenerator.generate` in the same module, which already loops
`for _attempt in range(max_attempts)` and raises `RuntimeError` only after the
loop, with no in-loop guard.

### Issues

- No existing issue; this was found while reading the fingerprint suite. The
  behavior was introduced in #829.

### Testing

- Added `test_fingerprint_generator_preserves_error_on_persistent_failure` in
  `tests/unit/fingerprint_suite/test_adapters.py`: it monkeypatches the
  underlying generator to always raise `ValueError`, then asserts that
  `generate()` raises `RuntimeError` after exactly 10 attempts and that
  `__cause__` is the original `ValueError`. It fails on the current code (the
  `RuntimeError`'s `__cause__` is `None`) and passes with this change.
- `uv run pytest tests/unit/fingerprint_suite/ -q` -> 17 passed, no regressions.
- `uv run poe lint` and `uv run poe type-check` are clean for the changed files.

### Checklist

- [ ] CI passed
