### PR TITLE
fix(request): Do not mutate caller user_data or write empty __crawlee in from_url

### DIFF
--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -310,8 +310,8 @@ class Request(BaseModel):
         if always_enqueue:
             unique_key = f'{crypto_random_object_id()}|{unique_key}'
 
-        user_data_dict = kwargs.pop('user_data', {}) or {}
-        crawlee_data_dict = user_data_dict.get('__crawlee', {})
+        user_data_dict = dict(kwargs.pop('user_data', {}) or {})
+        crawlee_data_dict = dict(user_data_dict.get('__crawlee') or {})
 
         if max_retries is not None:
             crawlee_data_dict['maxRetries'] = max_retries
@@ -321,7 +321,7 @@ class Request(BaseModel):
 
         crawlee_data = CrawleeRequestData(**crawlee_data_dict)
 
-        if crawlee_data:
+        if crawlee_data != CrawleeRequestData():
             user_data_dict['__crawlee'] = crawlee_data
 
         request = cls(

--- a/src/crawlee/_request.py
+++ b/src/crawlee/_request.py
@@ -319,10 +319,8 @@ class Request(BaseModel):
         if enqueue_strategy is not None:
             crawlee_data_dict['enqueueStrategy'] = enqueue_strategy
 
-        crawlee_data = CrawleeRequestData(**crawlee_data_dict)
-
-        if crawlee_data != CrawleeRequestData():
-            user_data_dict['__crawlee'] = crawlee_data
+        if crawlee_data_dict:
+            user_data_dict['__crawlee'] = CrawleeRequestData(**crawlee_data_dict)
 
         request = cls(
             url=url,

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -4,33 +4,34 @@ from crawlee import Request
 
 
 def test_from_url_does_not_mutate_caller_user_data() -> None:
+    """Verify `from_url` leaves the caller's `user_data` dict and its nested `__crawlee` block untouched."""
     user_data = {'__crawlee': {'crawlDepth': 2}}
     original_crawlee_data = user_data['__crawlee']
 
     Request.from_url('https://example.com', user_data=user_data, enqueue_strategy='same-domain')
 
-    # The caller's dict and its nested `__crawlee` block must be left untouched.
     assert user_data['__crawlee'] is original_crawlee_data
     assert user_data['__crawlee'] == {'crawlDepth': 2}
 
 
 def test_from_url_can_reuse_same_user_data_dict() -> None:
+    """Verify the same `user_data` dict object can be passed to `from_url` twice without raising."""
     user_data = {'__crawlee': {'crawlDepth': 2}}
 
-    # Passing the same dict object twice used to raise because the first call replaced the
-    # nested `__crawlee` value with a model that does not support item assignment.
+    # The first call used to replace the nested `__crawlee` value with a model that rejects item assignment.
     Request.from_url('https://example.com', user_data=user_data, enqueue_strategy='same-domain')
     Request.from_url('https://example.com', user_data=user_data, enqueue_strategy='same-domain')
 
 
 def test_from_url_omits_crawlee_data_when_empty() -> None:
+    """Verify `from_url` does not write a `__crawlee` block when no crawlee-specific options are supplied."""
     request = Request.from_url('https://example.com')
 
-    # No crawlee-specific options were supplied, so `__crawlee` must not be written to `user_data`.
     assert '__crawlee' not in request.model_dump()['user_data']
 
 
 def test_from_url_keeps_crawlee_data_when_supplied() -> None:
+    """Verify `from_url` serializes supplied `max_retries` and `enqueue_strategy` into the `__crawlee` block."""
     request = Request.from_url('https://example.com', max_retries=3, enqueue_strategy='same-hostname')
 
     assert request.model_dump()['user_data']['__crawlee'] == {

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from crawlee import Request
+
+
+def test_from_url_does_not_mutate_caller_user_data() -> None:
+    user_data = {'__crawlee': {'crawlDepth': 2}}
+    original_crawlee_data = user_data['__crawlee']
+
+    Request.from_url('https://example.com', user_data=user_data, enqueue_strategy='same-domain')
+
+    # The caller's dict and its nested `__crawlee` block must be left untouched.
+    assert user_data['__crawlee'] is original_crawlee_data
+    assert user_data['__crawlee'] == {'crawlDepth': 2}
+
+
+def test_from_url_can_reuse_same_user_data_dict() -> None:
+    user_data = {'__crawlee': {'crawlDepth': 2}}
+
+    # Passing the same dict object twice used to raise because the first call replaced the
+    # nested `__crawlee` value with a model that does not support item assignment.
+    Request.from_url('https://example.com', user_data=user_data, enqueue_strategy='same-domain')
+    Request.from_url('https://example.com', user_data=user_data, enqueue_strategy='same-domain')
+
+
+def test_from_url_omits_crawlee_data_when_empty() -> None:
+    request = Request.from_url('https://example.com')
+
+    # No crawlee-specific options were supplied, so `__crawlee` must not be written to `user_data`.
+    assert '__crawlee' not in request.model_dump()['user_data']
+
+
+def test_from_url_keeps_crawlee_data_when_supplied() -> None:
+    request = Request.from_url('https://example.com', max_retries=3, enqueue_strategy='same-hostname')
+
+    assert request.model_dump()['user_data']['__crawlee'] == {
+        'maxRetries': 3,
+        'enqueueStrategy': 'same-hostname',
+    }
+    assert request.max_retries == 3
+    assert request.enqueue_strategy == 'same-hostname'


### PR DESCRIPTION


`Request.from_url` mutates the caller's `user_data` dict in place, and it always
writes an empty `__crawlee` block even when no crawlee options are supplied. Both
were introduced by #1603.

- It took a live reference to the caller's nested block
  (`crawlee_data_dict = user_data_dict.get('__crawlee', {})`), then mutated it in
  place (`crawlee_data_dict['maxRetries' | 'enqueueStrategy'] = ...`) and replaced
  the `__crawlee` key on the caller's dict with a `CrawleeRequestData` model.
  Reusing a `user_data` dict therefore leaks `enqueueStrategy` / `maxRetries` into
  the caller's nested dict, and passing the **same** dict object twice raises
  `TypeError: 'CrawleeRequestData' object does not support item assignment` on the
  second call (the key is no longer a plain dict). The framework's own
  `enqueue_links` dodges the crash by building a fresh outer dict per link
  (`{**base_user_data}`), but the shared nested `__crawlee` dict still accumulates
  `enqueueStrategy` across links.
- The `if crawlee_data:` guard, meant to skip writing `__crawlee` when there is no
  crawlee data, is always true because an empty pydantic model is truthy
  (`bool(CrawleeRequestData()) is True`). So `Request.from_url('https://example.com')`
  writes `user_data = {'__crawlee': {}}` instead of leaving `user_data` empty.

Fix: copy both the outer `user_data` dict and the nested `__crawlee` block before
mutating them, and compare against `CrawleeRequestData()` so the write is skipped
when empty.

```diff
-        user_data_dict = kwargs.pop('user_data', {}) or {}
-        crawlee_data_dict = user_data_dict.get('__crawlee', {})
+        user_data_dict = dict(kwargs.pop('user_data', {}) or {})
+        crawlee_data_dict = dict(user_data_dict.get('__crawlee') or {})

         if max_retries is not None:
             crawlee_data_dict['maxRetries'] = max_retries
@@
         crawlee_data = CrawleeRequestData(**crawlee_data_dict)

-        if crawlee_data:
+        if crawlee_data != CrawleeRequestData():
             user_data_dict['__crawlee'] = crawlee_data
```

### Issues

- No existing GitHub issue. This is a self-identified correctness bug found while
  reviewing `Request.from_url`. Happy to open a tracking issue with the repro
  first if you'd prefer that.

### Testing

- Added `tests/unit/test_request.py` with four tests:
  - `test_from_url_does_not_mutate_caller_user_data`: the caller's dict and its
    nested `__crawlee` block are left untouched (same object, unchanged value).
  - `test_from_url_can_reuse_same_user_data_dict`: calling `from_url` twice with
    the same `user_data` object no longer raises `TypeError`.
  - `test_from_url_omits_crawlee_data_when_empty`: a bare `from_url` does not write
    `__crawlee` into `user_data`.
  - `test_from_url_keeps_crawlee_data_when_supplied`: the positive round-trip,
    `max_retries` / `enqueue_strategy` are still serialized into `__crawlee` and
    reflected on the request.
- Verified fail-first: reverting only `src/crawlee/_request.py` (keeping the new
  tests) fails 3 of the 4 tests, each on its targeted defect; all 4 pass with the
  fix.
- `uv run pytest tests/unit/test_request.py` -> 4 passed.
- Regression: `uv run pytest tests/unit/crawlers/_basic/test_basic_crawler.py
  tests/unit/storages/test_request_queue.py tests/unit/test_router.py` and the
  `enqueue_strategy` / `max_retries` cases -> all pass.
- `uv run poe lint` (ruff format + check) passes on the changed files.

### Checklist

- [ ] CI passed
