### PR TITLE
fix(docs): remove broken static DocSearch version filter

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -414,9 +414,6 @@ module.exports = {
                 apiKey: '878493fcd7001e3c179b6db6796a999b', // search only (public) API key
                 indexName: 'crawlee_python',
                 placeholder: 'Search documentation',
-                algoliaOptions: {
-                    facetFilters: ['version:VERSION'],
-                },
                 translations: {
                     button: {
                         buttonText: 'Search documentation...',


### PR DESCRIPTION
## Summary
- remove the static version filter from the Python docs DocSearch config
- allow the crawler docs search index to return results again instead of filtering everything out

Fixes #2020.

## Testing
- verified the patch is limited to website/docusaurus.config.js`n- no local docs build was run in this environment