### PR TITLE
test: mark test_infinite_scroll_on_dynamic_page as flaky

### DIFF
--- a/tests/unit/crawlers/_playwright/test_utils.py
+++ b/tests/unit/crawlers/_playwright/test_utils.py
@@ -1,9 +1,14 @@
+import pytest
 from playwright.async_api import async_playwright
 from yarl import URL
 
 from crawlee.crawlers._playwright._utils import block_requests, infinite_scroll
 
 
+@pytest.mark.flaky(
+    reruns=3,
+    reason='Test is flaky on Windows when Playwright hits net::ERR_NO_BUFFER_SPACE under xdist load.',
+)
 async def test_infinite_scroll_on_dynamic_page(server_url: URL) -> None:
     """Checks that infinite_scroll loads all items on a page with infinite scrolling."""
     async with async_playwright() as p:


### PR DESCRIPTION
`test_infinite_scroll_on_dynamic_page` intermittently fails on the `windows-latest` unit-test job. Under `pytest-xdist` load the Windows runner transiently runs out of socket buffer space (`WSAENOBUFS`), so `page.goto` to the local test server fails with `net::ERR_NO_BUFFER_SPACE`. The failure happens during navigation setup, before `infinite_scroll` (the code under test) ever runs, so it's an environmental flake rather than a product or test-logic defect.

This mirrors the repo's established convention for the same signature (`test_browser_pool.py`, `test_stagehand_browser_controller.py`, `test_adaptive_playwright_crawler.py`): mark the test with `@pytest.mark.flaky(reruns=3, reason=...)`. The test's assertions stay deterministic given a successful navigation, so a real regression still fails all attempts; the reruns only absorb transient connection failures.

Failing run: https://github.com/apify/crawlee-python/actions/runs/29315899194/job/87029744185