### PR TITLE
test: fix flaky test_runs_concurrently by asserting peak concurrency instead of wall time

### DIFF
--- a/tests/unit/_autoscaling/test_autoscaled_pool.py
+++ b/tests/unit/_autoscaling/test_autoscaled_pool.py
@@ -37,10 +37,15 @@ def future(value: T, /) -> Awaitable[T]:
 @pytest.mark.run_alone
 async def test_runs_concurrently(system_status: SystemStatus | Mock) -> None:
     done_count = 0
+    running_count = 0
+    max_running_count = 0
 
     async def run() -> None:
+        nonlocal done_count, running_count, max_running_count
+        running_count += 1
+        max_running_count = max(max_running_count, running_count)
         await asyncio.sleep(0.1)
-        nonlocal done_count
+        running_count -= 1
         done_count += 1
 
     pool = AutoscaledPool(
@@ -54,12 +59,12 @@ async def test_runs_concurrently(system_status: SystemStatus | Mock) -> None:
         ),
     )
 
-    with measure_time() as elapsed:
-        await pool.run()
+    await pool.run()
 
-    assert elapsed.wall is not None
-    assert elapsed.wall < 0.3
-
+    # Assert the tasks actually ran concurrently by checking the peak number that overlapped in time.
+    # A sequential (or only partially concurrent) pool would peak below the configured concurrency.
+    # Previously this was inferred from the total wall time, which was flaky under load on slow CI runners.
+    assert max_running_count == 10
     assert done_count >= 10
 
 


### PR DESCRIPTION
`test_runs_concurrently` verifies that `AutoscaledPool` runs tasks concurrently rather than sequentially. It inferred this from the total wall time (`elapsed.wall < 0.3`), which is a fragile proxy: on a slow CI runner (seen on windows-latest / Python 3.14) event-loop scheduling overhead pushed the wall time to 0.314 s even though all 10 tasks did overlap, tripping the tight 0.3 s threshold.

This replaces the timing proxy with a direct, deterministic assertion of the property the test actually protects: the peak number of tasks running simultaneously must reach the configured concurrency (10). The check no longer depends on wall-clock time, so it can't flake under CI load or on slow runners, and it's stronger than before (a sequential or only partially concurrent pool would peak below 10, whereas the old wall-time check could pass at partial concurrency).

Verified locally: a harness replicating the exact pool setup reached peak 10 in 200/200 iterations under 2x CPU oversubscription; the test passes 0 failures across repeated runs; lint and type checks pass.
