### PR TITLE
fix(key-value store): Avoid "dictionary changed size" error in KVS autosave

### DIFF
--- a/src/crawlee/storages/_key_value_store.py
+++ b/src/crawlee/storages/_key_value_store.py
@@ -299,14 +299,16 @@ class KeyValueStore(Storage):
     async def persist_autosaved_values(self) -> None:
         """Force autosaved values to be saved without waiting for an event in Event Manager."""
         if self.id in self._autosaved_values:
-            cache = self._autosaved_values[self.id]
-            for value in cache.values():
-                await value.persist_state()
+            async with self._autosave_lock:
+                cache = self._autosaved_values[self.id]
+                for value in cache.values():
+                    await value.persist_state()
 
     async def _clear_cache(self) -> None:
         """Clear cache with autosaved values."""
         if self.id in self._autosaved_values:
-            cache = self._autosaved_values[self.id]
-            for value in cache.values():
-                await value.teardown()
-            cache.clear()
+            async with self._autosave_lock:
+                cache = self._autosaved_values[self.id]
+                for value in cache.values():
+                    await value.teardown()
+                cache.clear()

--- a/tests/unit/storages/test_key_value_store.py
+++ b/tests/unit/storages/test_key_value_store.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -1180,3 +1181,74 @@ async def test_record_with_noascii_chars(kvs: KeyValueStore) -> None:
     value = await kvs.get_value(key)
     assert value is not None
     assert value == init_value
+
+
+async def test_persist_autosaved_values_with_concurrent_new_key(
+    kvs: KeyValueStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that persisting autosaved values tolerates a concurrent new autosaved key.
+
+    `get_auto_saved_value` mutates the shared autosave cache while holding the autosave lock, so
+    `persist_autosaved_values` must hold the same lock while iterating that cache. Otherwise a request
+    inserting a new key mid-iteration raises `RuntimeError: dictionary changed size during iteration`.
+    """
+    await kvs.get_auto_saved_value('existing')
+
+    # Park the persist loop mid-iteration by blocking the underlying write, then insert a new key.
+    persist_entered = asyncio.Event()
+    release_persist = asyncio.Event()
+    original_set_value = kvs.set_value
+
+    async def blocking_set_value(*args: Any, **kwargs: Any) -> None:
+        persist_entered.set()
+        await release_persist.wait()
+        await original_set_value(*args, **kwargs)
+
+    monkeypatch.setattr(kvs, 'set_value', blocking_set_value)
+
+    persist_task = asyncio.ensure_future(kvs.persist_autosaved_values())
+    await persist_entered.wait()
+
+    insert_task = asyncio.ensure_future(kvs.get_auto_saved_value('added-during-persist'))
+    await asyncio.sleep(0)  # Give the insert a chance to reach the shared cache.
+    release_persist.set()
+
+    # Should not raise `RuntimeError: dictionary changed size during iteration`.
+    await asyncio.gather(persist_task, insert_task)
+
+
+async def test_drop_with_concurrent_new_autosaved_key(
+    storage_client: StorageClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that dropping a store tolerates a concurrent new autosaved key.
+
+    `drop` clears the autosave cache via `_clear_cache`, which must hold the autosave lock while
+    iterating. Otherwise a request inserting a new key mid-iteration raises
+    `RuntimeError: dictionary changed size during iteration`.
+    """
+    kvs = await KeyValueStore.open(storage_client=storage_client)
+    await kvs.get_auto_saved_value('existing')
+
+    # Park the clear loop mid-iteration by blocking the underlying write, then insert a new key.
+    clear_entered = asyncio.Event()
+    release_clear = asyncio.Event()
+    original_set_value = kvs.set_value
+
+    async def blocking_set_value(*args: Any, **kwargs: Any) -> None:
+        clear_entered.set()
+        await release_clear.wait()
+        await original_set_value(*args, **kwargs)
+
+    monkeypatch.setattr(kvs, 'set_value', blocking_set_value)
+
+    drop_task = asyncio.ensure_future(kvs.drop())
+    await clear_entered.wait()
+
+    insert_task = asyncio.ensure_future(kvs.get_auto_saved_value('added-during-drop'))
+    await asyncio.sleep(0)  # Give the insert a chance to reach the shared cache.
+    release_clear.set()
+
+    # Should not raise `RuntimeError: dictionary changed size during iteration`.
+    await asyncio.gather(drop_task, insert_task)

--- a/tests/unit/storages/test_key_value_store.py
+++ b/tests/unit/storages/test_key_value_store.py
@@ -1187,12 +1187,7 @@ async def test_persist_autosaved_values_with_concurrent_new_key(
     kvs: KeyValueStore,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that persisting autosaved values tolerates a concurrent new autosaved key.
-
-    `get_auto_saved_value` mutates the shared autosave cache while holding the autosave lock, so
-    `persist_autosaved_values` must hold the same lock while iterating that cache. Otherwise a request
-    inserting a new key mid-iteration raises `RuntimeError: dictionary changed size during iteration`.
-    """
+    """Test persisting autosaved values while adding a new autosaved key."""
     await kvs.get_auto_saved_value('existing')
 
     # Park the persist loop mid-iteration by blocking the underlying write, then insert a new key.
@@ -1202,33 +1197,33 @@ async def test_persist_autosaved_values_with_concurrent_new_key(
 
     async def blocking_set_value(*args: Any, **kwargs: Any) -> None:
         persist_entered.set()
-        await release_persist.wait()
+        await asyncio.wait_for(release_persist.wait(), timeout=5)
         await original_set_value(*args, **kwargs)
 
     monkeypatch.setattr(kvs, 'set_value', blocking_set_value)
 
-    persist_task = asyncio.ensure_future(kvs.persist_autosaved_values())
-    await persist_entered.wait()
+    persist_task = asyncio.create_task(kvs.persist_autosaved_values())
+    await asyncio.wait_for(persist_entered.wait(), timeout=5)
 
-    insert_task = asyncio.ensure_future(kvs.get_auto_saved_value('added-during-persist'))
-    await asyncio.sleep(0)  # Give the insert a chance to reach the shared cache.
+    insert_started = asyncio.Event()
+
+    async def insert_autosaved_value() -> None:
+        insert_started.set()
+        await kvs.get_auto_saved_value('added-during-persist')
+
+    insert_task = asyncio.create_task(insert_autosaved_value())
+    await asyncio.wait_for(insert_started.wait(), timeout=5)
     release_persist.set()
 
     # Should not raise `RuntimeError: dictionary changed size during iteration`.
-    await asyncio.gather(persist_task, insert_task)
+    await asyncio.wait_for(asyncio.gather(persist_task, insert_task), timeout=5)
 
 
-async def test_drop_with_concurrent_new_autosaved_key(
-    storage_client: StorageClient,
+async def test_clear_cache_with_concurrent_new_autosaved_key(
+    kvs: KeyValueStore,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that dropping a store tolerates a concurrent new autosaved key.
-
-    `drop` clears the autosave cache via `_clear_cache`, which must hold the autosave lock while
-    iterating. Otherwise a request inserting a new key mid-iteration raises
-    `RuntimeError: dictionary changed size during iteration`.
-    """
-    kvs = await KeyValueStore.open(storage_client=storage_client)
+    """Test clearing the cache while adding a new autosaved key."""
     await kvs.get_auto_saved_value('existing')
 
     # Park the clear loop mid-iteration by blocking the underlying write, then insert a new key.
@@ -1238,17 +1233,23 @@ async def test_drop_with_concurrent_new_autosaved_key(
 
     async def blocking_set_value(*args: Any, **kwargs: Any) -> None:
         clear_entered.set()
-        await release_clear.wait()
+        await asyncio.wait_for(release_clear.wait(), timeout=5)
         await original_set_value(*args, **kwargs)
 
     monkeypatch.setattr(kvs, 'set_value', blocking_set_value)
 
-    drop_task = asyncio.ensure_future(kvs.drop())
-    await clear_entered.wait()
+    clear_task = asyncio.create_task(kvs._clear_cache())
+    await asyncio.wait_for(clear_entered.wait(), timeout=5)
 
-    insert_task = asyncio.ensure_future(kvs.get_auto_saved_value('added-during-drop'))
-    await asyncio.sleep(0)  # Give the insert a chance to reach the shared cache.
+    insert_started = asyncio.Event()
+
+    async def insert_autosaved_value() -> None:
+        insert_started.set()
+        await kvs.get_auto_saved_value('added-during-clear')
+
+    insert_task = asyncio.create_task(insert_autosaved_value())
+    await asyncio.wait_for(insert_started.wait(), timeout=5)
     release_clear.set()
 
     # Should not raise `RuntimeError: dictionary changed size during iteration`.
-    await asyncio.gather(drop_task, insert_task)
+    await asyncio.wait_for(asyncio.gather(clear_task, insert_task), timeout=5)


### PR DESCRIPTION


`KeyValueStore.get_auto_saved_value` mutates the shared per-store autosave cache
(`self._autosaved_values[self.id]`) while holding `self._autosave_lock`. But the
two consumers of that cache iterated it and awaited I/O inside the loop *without*
taking the lock:

- `persist_autosaved_values` iterated `cache.values()` and `await`ed
  `value.persist_state()` per entry.
- `_clear_cache` (called from `drop()`) iterated `cache.values()` and `await`ed
  `value.teardown()` per entry, then cleared the cache.

Because both loops suspend at an `await`, a request handler that calls
`get_auto_saved_value` with a new key while a persist or drop is mid-iteration
inserts into the same dict and grows it during iteration, raising
`RuntimeError: dictionary changed size during iteration` and aborting the
persist/drop.

This wraps both loops in `async with self._autosave_lock:`, the same lock
`get_auto_saved_value` already uses, so the iteration and any concurrent insert
are serialized. No public API changes; `_clear_cache` still calls
`cache.clear()` (now inside the lock, which is strictly safer).

The awaited bodies (`RecoverableState.persist_state()` / `.teardown()`) bottom
out in `set_value` and never re-enter `get_auto_saved_value`,
`persist_autosaved_values`, or `_clear_cache`, so the non-reentrant
`asyncio.Lock` is never re-acquired on the same instance (no deadlock).

### Issues

- No existing issue; found while reading the autosave/`use_state` code path.

### Testing

Added two regression tests in `tests/unit/storages/test_key_value_store.py`
(both run across all four storage backends via the `storage_client` fixture):

- `test_persist_autosaved_values_with_concurrent_new_key`
- `test_drop_with_concurrent_new_autosaved_key`

Each parks the persist/clear loop mid-iteration (by blocking the underlying
`set_value`, which `persist_state`/`teardown` call) and then inserts a new
autosaved key concurrently. Without the fix they fail with `RuntimeError:
dictionary changed size during iteration`; with the fix they pass.

- `uv run pytest tests/unit/storages/test_key_value_store.py` -> 296 passed, 2 skipped
- `uv run pytest tests/unit/storages/` -> 887 passed, 6 skipped
- `uv run poe lint` -> clean
- `uv run poe type-check` -> no new diagnostics vs `master`

### Checklist

- [ ] CI passed
