### PR TITLE
docs: align maxRequestsPerCrawl intro example with the JS SDK

### DIFF
--- a/docs/introduction/03_adding_more_urls.mdx
+++ b/docs/introduction/03_adding_more_urls.mdx
@@ -43,10 +43,10 @@ The <ApiLink to="class/EnqueueLinksFunction">`enqueue_links`</ApiLink> function 
 When you're just testing your code or when your crawler could potentially find millions of links, it's very useful to set a maximum limit of crawled pages. The option is called <ApiLink to="class/BasicCrawlerOptions#max_requests_per_crawl">`max_requests_per_crawl`</ApiLink>, is available in all crawlers, and you can set it like this:
 
 ```python
-crawler = BeautifulSoupCrawler(max_requests_per_crawl=10)
+crawler = BeautifulSoupCrawler(max_requests_per_crawl=20)
 ```
 
-This means that no new requests will be started after the 10th request is finished. The actual number of processed requests might be a little higher thanks to parallelization, because the running requests won't be forcefully aborted. It's not even possible in most cases.
+This means that no new requests will be started after the 20th request is finished. The actual number of processed requests might be a little higher thanks to parallelization, because the running requests won't be forcefully aborted. It's not even possible in most cases.
 
 ## Finding new links
 

--- a/docs/introduction/code_examples/03_finding_new_links.py
+++ b/docs/introduction/code_examples/03_finding_new_links.py
@@ -5,7 +5,7 @@ from crawlee.crawlers import BeautifulSoupCrawler, BeautifulSoupCrawlingContext
 
 async def main() -> None:
     # Let's limit our crawls to make our tests shorter and safer.
-    crawler = BeautifulSoupCrawler(max_requests_per_crawl=10)
+    crawler = BeautifulSoupCrawler(max_requests_per_crawl=20)
 
     @crawler.router.default_handler
     async def request_handler(context: BeautifulSoupCrawlingContext) -> None:


### PR DESCRIPTION
### Description

The **"Limit your crawls"** section of the Python introduction uses `max_requests_per_crawl=10`, whereas the [equivalent section in the JavaScript SDK docs](https://crawlee.dev/js/docs/introduction/adding-urls) uses `20`. The two introductions are otherwise near-identical ports of each other, so this aligns the Python example to `20` for cross-SDK consistency.

Changes:

- `docs/introduction/03_adding_more_urls.mdx` — the inline snippet and the explanatory prose in the "Limit your crawls" section (`10` → `20`, and "10th" → "20th").
- `docs/introduction/code_examples/03_finding_new_links.py` — the runnable example rendered immediately below on the same page, so the page stays consistent with the section above it.

I deliberately scoped this to the "Limit your crawls" section and its adjacent runnable example. A few other intro examples (e.g. `06_scraping.py`, `07_final_code.py`) also use `max_requests_per_crawl=10` as an incidental testing limit — I left those untouched to keep the diff minimal, but I'm happy to broaden it to the whole introduction if page-wide consistency is preferred.

### Issues

- Closes: #2091

### Testing

Documentation-only change — the edits swap the integer value in an existing, already-runnable example and its accompanying prose; no code paths or behavior are affected.

### Checklist

- [ ] CI passed
