### PR TITLE
docs: Enable Ruff formatting of Python code blocks in Markdown

### DIFF
--- a/.rules.md
+++ b/.rules.md
@@ -113,6 +113,7 @@ Pluggable via `HttpClient` interface in `src/crawlee/http_clients/`:
 @crawler.router.default_handler
 async def handler(context: BeautifulSoupCrawlingContext): ...
 
+
 @crawler.router.handler(label='detail')
 async def detail(context: BeautifulSoupCrawlingContext): ...
 ```

--- a/docs/guides/stagehand_crawler.mdx
+++ b/docs/guides/stagehand_crawler.mdx
@@ -104,7 +104,8 @@ result = await context.page.execute(
     agent_config={},
     execute_options={
         'instruction': 'Search for "web scraping" and return the titles of the first five results',
-    })
+    },
+)
 ```
 
 ## Browserbase integration

--- a/docs/upgrading/upgrading_to_v1.md
+++ b/docs/upgrading/upgrading_to_v1.md
@@ -281,7 +281,7 @@ crawler_2 = BasicCrawler(
     configuration=custom_configuration_2,
     event_manager=custom_event_manager_2,
     storage_client=custom_storage_client_2,
-  )
+)
 
 # use crawlers without runtime crash...
 ```
@@ -311,6 +311,7 @@ The method `HttpResponse.read` is now asynchronous. This affects all HTTP-based 
 ```python
 from crawlee.crawlers import ParselCrawler, ParselCrawlingContext
 
+
 async def main() -> None:
     crawler = ParselCrawler()
 
@@ -327,6 +328,7 @@ async def main() -> None:
 
 ```python
 from crawlee.crawlers import ParselCrawler, ParselCrawlingContext
+
 
 async def main() -> None:
     crawler = ParselCrawler()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,11 +169,16 @@ include = [
     "scripts/**/*.py",
     "docs/**/*.py",
     "website/**/*.py",
+    # Ruff formats Python code blocks embedded in Markdown files.
+    "**/*.md",
+    "**/*.mdx",
 ]
 exclude = [
     "website/versioned_docs/**",
 ]
 extend-exclude = ["src/crawlee/project_template"]
+# MDX is Markdown; without this mapping Ruff would try to parse `.mdx` files as Python.
+extension = { mdx = "markdown" }
 
 [tool.ruff.lint]
 select = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,11 +164,7 @@ only-include = [
 [tool.ruff]
 line-length = 120
 include = [
-    "src/**/*.py",
-    "tests/**/*.py",
-    "scripts/**/*.py",
-    "docs/**/*.py",
-    "website/**/*.py",
+    "**/*.py",
     # Ruff formats Python code blocks embedded in Markdown files.
     "**/*.md",
     "**/*.mdx",


### PR DESCRIPTION
### What & why

Ruff 0.16 formats Python code blocks embedded in Markdown files, and does so by default. In this repo the feature was inert because `[tool.ruff] include` was an allowlist of `*.py` globs, so no Markdown file ever reached the formatter. Adding `**/*.md` and `**/*.mdx` turns it on, which means docs snippets are now held to the same formatting standard as the rest of the codebase instead of drifting by hand.

MDX needs the explicit `extension = { mdx = "markdown" }` mapping - without it Ruff would try to parse `.mdx` as Python and fail. Most of the Python snippets in `docs/` live in `.mdx`, so the mapping is what makes this useful here.

No changes to the `lint` / `format` Poe tasks are needed. `lint` already runs `ruff format --check` and `format` already runs `ruff format`, so both pick Markdown up automatically. Note that `ruff check` (lint rules) does not support Markdown yet, so only formatting is enforced there.

### Notes

- Code blocks under `docs/` are formatted to 90 columns, not 120, because of the existing `docs/pyproject.toml` override that keeps doc snippets free of a horizontal scrollbar.
- `website/versioned_docs/**` and `src/crawlee/project_template` stay excluded, so frozen doc snapshots and the template are untouched.
- The second commit collapses the `include` allowlist to a single `**/*.py` glob. This is a pure simplification: no tracked `.py` file lives outside the previously listed directories, and Ruff processes exactly the same 585 files before and after.

*✍️ Drafted by Claude Code*
