### PR TITLE
docs: add guide on building custom extensions

### DIFF
--- a/docs/guides/extending_crawlee.mdx
+++ b/docs/guides/extending_crawlee.mdx
@@ -1,18 +1,18 @@
 ---
 id: extending-crawlee
 title: Extending Crawlee
-description: Learn which parts of Crawlee are designed to be extended, what contract each extension point defines, and where to find the detailed guide for each one.
+description: The extension points Crawlee exposes, the contract each one defines, and how to choose between them.
 ---
 
 import ApiLink from '@site/src/components/ApiLink';
 
-Crawlee is built around a small number of abstract base classes that you can subclass to plug in your own behavior. This guide is the map: it lists every extension point, states the contract each one defines, and links to the guide that covers it in depth.
+Crawlee covers the common cases out of the box, but sooner or later you'll hit something it doesn't do: a parser for a format no built-in crawler understands, an HTTP backend your company mandates, a database you want your data in, or a browser that isn't launched the standard Playwright way. Rather than forking, you can plug your own implementation into the layer that differs and keep everything else.
 
-If you maintain a third-party integration, such as an alternative browser backend or a storage adapter, you can build it against these contracts and host the integration guide in your own project. This page gives your users a stable reference for the interface your integration implements.
+This guide is the map. It covers the extension points, the contract each one defines, and links to the guide that goes deeper on it. If you maintain a third-party integration, you can build it against these contracts and host your own guide for it.
 
 ## Extension points
 
-Crawlee currently has four extension points.
+The four extension points below are the main ones, and they're where most integrations plug in. They aren't the only abstract classes you can subclass - <ApiLink to="class/RequestLoader">`RequestLoader`</ApiLink>, <ApiLink to="class/FingerprintGenerator">`FingerprintGenerator`</ApiLink>, and <ApiLink to="class/RenderingTypePredictor">`RenderingTypePredictor`</ApiLink> are extensible too.
 
 ```mermaid
 ---
@@ -27,6 +27,10 @@ class BasicCrawler {
     <<abstract>>
 }
 
+class AbstractHttpCrawler {
+    <<abstract>>
+}
+
 class PlaywrightCrawler
 
 class HttpClient {
@@ -35,64 +39,91 @@ class HttpClient {
 
 class StorageClient {
     <<abstract>>
+    create_dataset_client()
+    create_kvs_client()
+    create_rq_client()
+}
+
+class DatasetClient {
+    <<abstract>>
+}
+
+class KeyValueStoreClient {
+    <<abstract>>
+}
+
+class RequestQueueClient {
+    <<abstract>>
 }
 
 class BrowserPool
 
 class BrowserPlugin {
     <<abstract>>
+    new_browser()
 }
 
-BasicCrawler --> HttpClient : uses
-BasicCrawler --> StorageClient : uses
+class BrowserController {
+    <<abstract>>
+}
+
+BasicCrawler --|> AbstractHttpCrawler
 BasicCrawler --|> PlaywrightCrawler
+AbstractHttpCrawler --> HttpClient : uses
+BasicCrawler --> StorageClient : uses
+StorageClient --> DatasetClient : opens
+StorageClient --> KeyValueStoreClient : opens
+StorageClient --> RequestQueueClient : opens
 PlaywrightCrawler --> BrowserPool : uses
 BrowserPool --> BrowserPlugin : manages
+BrowserPlugin --> BrowserController : returns
 ```
 
 ### Crawlers
 
-Subclass a crawler when you need a parsing strategy or a request-handler context that the built-in crawlers do not provide.
+A crawler drives the whole run: it takes requests from the queue, fetches each one, builds the context object your handler receives, and manages retries, concurrency, sessions, and storage along the way. <ApiLink to="class/BasicCrawler">`BasicCrawler`</ApiLink> implements all of that and stays agnostic about how a page is fetched or parsed, which is what makes it the base every other crawler builds on.
 
-For HTTP-based crawling, <ApiLink to="class/AbstractHttpCrawler">`AbstractHttpCrawler`</ApiLink> is the base class. A custom crawler supplies a parser that turns an HTTP response into your parsed type, a context type that exposes that parsed data to request handlers, and the crawler class that ties the two together. Everything else, including retries, concurrency, session management, and storage, is inherited from <ApiLink to="class/BasicCrawler">`BasicCrawler`</ApiLink>.
+For HTTP-based crawling, <ApiLink to="class/AbstractHttpCrawler">`AbstractHttpCrawler`</ApiLink> adds the fetch-and-parse layer on top. Extending it means supplying a parser that implements <ApiLink to="class/AbstractHttpParser">`AbstractHttpParser`</ApiLink>: `parse` turns an <ApiLink to="class/HttpResponse">`HttpResponse`</ApiLink> into your parsed type, `parse_text` does the same for a string, `select` and `is_matching_selector` apply selectors to it, and `find_links` extracts the URLs used for link enqueuing. You then pair that parser with a context type that exposes the parsed data to handlers, and a crawler class that ties the two together.
 
-See [HTTP crawlers guide](./http-crawlers) for a worked example built on `selectolax`, and [Architecture overview](./architecture-overview) for how crawlers relate to the other components.
+See the [HTTP crawlers guide](./http-crawlers) for a worked example built on `selectolax`, and the [Architecture overview](./architecture-overview) for how crawlers relate to the other components.
 
 ### HTTP clients
 
-Subclass an HTTP client when you want crawlers to talk to servers through a different HTTP library, or through a proxy or transport layer that the bundled clients do not cover.
+An HTTP client is what actually performs the network calls for HTTP-based crawlers. Swapping it changes the transport - the TLS stack, connection pooling, proxy handling, and browser impersonation - without touching how pages are parsed or how the crawl is orchestrated.
 
-<ApiLink to="class/HttpClient">`HttpClient`</ApiLink> is the base class. Implementations must be async-compatible and must manage their own connection lifecycle and cleanup, because a single client instance is shared across concurrent requests.
+The contract is <ApiLink to="class/HttpClient">`HttpClient`</ApiLink>. `crawl` performs a request inside the crawler's pipeline and returns the result the crawler consumes, `send_request` covers standalone calls made from a handler, `stream` yields a response you read incrementally, and `cleanup` releases whatever the client holds open. Crawlee ships <ApiLink to="class/ImpitHttpClient">`ImpitHttpClient`</ApiLink>, <ApiLink to="class/HttpxHttpClient">`HttpxHttpClient`</ApiLink>, and <ApiLink to="class/CurlImpersonateHttpClient">`CurlImpersonateHttpClient`</ApiLink>.
 
-See [HTTP clients guide](./http-clients) for the full interface and the built-in implementations.
+See the [HTTP clients guide](./http-clients) for the full contract and the trade-offs between the built-in clients.
 
 ### Storage clients
 
-Subclass a storage client when you want Crawlee's storages to be backed by a system that is not covered by the built-in memory, file system, SQL, and Redis clients.
+A storage client is the backend behind Crawlee's three storages. <ApiLink to="class/Dataset">`Dataset`</ApiLink>, <ApiLink to="class/KeyValueStore">`KeyValueStore`</ApiLink>, and <ApiLink to="class/RequestQueue">`RequestQueue`</ApiLink> are the API you write against, and the storage client decides where that data actually lives. That separation is what lets you move a crawler from the local file system to a database or a cloud service without changing crawl code.
 
-<ApiLink to="class/StorageClient">`StorageClient`</ApiLink> is the base class. It is a factory: it opens the per-storage clients for datasets, key-value stores, and request queues, and those clients implement the actual create, read, update, and delete operations.
+<ApiLink to="class/StorageClient">`StorageClient`</ApiLink> itself is only three factory methods - `create_dataset_client`, `create_kvs_client`, and `create_rq_client`. The real work sits in what they return: <ApiLink to="class/DatasetClient">`DatasetClient`</ApiLink> handles appending and reading items, <ApiLink to="class/KeyValueStoreClient">`KeyValueStoreClient`</ApiLink> handles record get, set, delete, and iteration, and <ApiLink to="class/RequestQueueClient">`RequestQueueClient`</ApiLink> handles adding, fetching, and marking requests as handled. A custom backend implements all four.
 
-See [Storage clients guide](./storage-clients) for the interface, a custom client example, and how clients are registered and resolved.
+See the [Storage clients guide](./storage-clients) for the built-in implementations and a custom client example.
 
 ### Browser plugins
 
-Subclass a browser plugin when an integration launches browsers through an API other than the standard Playwright one. Configuration options on <ApiLink to="class/PlaywrightBrowserPlugin">`PlaywrightBrowserPlugin`</ApiLink> cover the cases where the standard launch API is enough, so reach for a subclass only when the launch path itself differs.
+A browser plugin is what launches browsers for <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>. The crawler never launches one itself: it goes through <ApiLink to="class/BrowserPool">`BrowserPool`</ApiLink>, which initializes the plugins it's given, forwards browser context options when creating pages, and manages each browser's lifecycle.
 
-A plugin's `new_browser()` launches the browser and returns a <ApiLink to="class/PlaywrightBrowserController">`PlaywrightBrowserController`</ApiLink>; <ApiLink to="class/BrowserPool">`BrowserPool`</ApiLink> initializes the plugin, forwards browser context options when creating pages, and manages the controller's lifecycle.
+The contract is <ApiLink to="class/BrowserPlugin">`BrowserPlugin`</ApiLink>. Its `new_browser` launches a browser and returns a <ApiLink to="class/BrowserController">`BrowserController`</ApiLink>, which is what the pool then drives to open pages and tear things down. Reach for a subclass when the launch path itself differs from the standard Playwright one, since <ApiLink to="class/PlaywrightBrowserPlugin">`PlaywrightBrowserPlugin`</ApiLink>'s configuration options already cover the cases where it doesn't.
 
-See [Playwright crawler guide](./playwright-crawler) for the contract and the responsibilities a subclass has to preserve, and the [Camoufox example](../examples/playwright-crawler-with-camoufox) for a complete integration.
+See the [Playwright crawler guide](./playwright-crawler) for the responsibilities a subclass has to preserve, and the [Camoufox example](../examples/playwright-crawler-with-camoufox) for a complete integration.
 
 ## Choosing an extension point
 
 Match the layer to what actually differs in your integration.
 
-- The response is fetched the usual way but parsed differently: extend a **crawler**.
-- The response is fetched over a different HTTP library or transport: extend an **HTTP client**.
-- Requests and results should live somewhere other than the built-in backends: extend a **storage client**.
-- Browsers are launched through a different API: extend a **browser plugin**.
+- The response format is one no built-in crawler parses - subclass <ApiLink to="class/AbstractHttpCrawler">`AbstractHttpCrawler`</ApiLink> with your own parser.
+- The transport differs, but parsing doesn't - implement <ApiLink to="class/HttpClient">`HttpClient`</ApiLink> and pass it to any HTTP crawler.
+- Data needs to live somewhere Crawlee doesn't support yet - implement <ApiLink to="class/StorageClient">`StorageClient`</ApiLink> and its three per-storage clients.
+- Browsers need to be launched through a different API - implement <ApiLink to="class/BrowserPlugin">`BrowserPlugin`</ApiLink> and hand it to <ApiLink to="class/BrowserPool">`BrowserPool`</ApiLink>.
 
-Prefer configuration over a subclass wherever the built-in class already exposes the knob you need. Subclassing ties your integration to a contract that only changes with Crawlee's major versions, while configuration keeps you on the maintained path.
+When more than one fits, pick the narrowest. A custom HTTP client works with every HTTP crawler, so it's easier to maintain than a crawler subclass that hard-codes the same transport.
 
 ## Conclusion
 
-Crawlee's extension points are crawlers, HTTP clients, storage clients, and browser plugins. Each is an abstract base class with a documented contract and a guide that covers it in depth. If you are building an integration, start from the contract that matches the layer you are replacing, and keep the rest of the pipeline on the built-in path.
+Each extension point is a small abstract class with a documented contract, and everything above it keeps working once you implement one. If you're building a third-party integration, these contracts are also the stable surface to write your own documentation against.
+
+If anything here is unclear or you hit a case the contracts don't cover, open an issue on [GitHub](https://github.com/apify/crawlee-python) or join our [Discord](https://discord.com/invite/jyEM2PRvMU).

--- a/docs/guides/extending_crawlee.mdx
+++ b/docs/guides/extending_crawlee.mdx
@@ -6,13 +6,13 @@ description: The extension points Crawlee exposes, the contract each one defines
 
 import ApiLink from '@site/src/components/ApiLink';
 
-Crawlee covers the common cases out of the box, but sooner or later you'll hit something it doesn't do: a parser for a format no built-in crawler understands, an HTTP backend your company mandates, a database you want your data in, or a browser that isn't launched the standard Playwright way. Rather than forking, you can plug your own implementation into the layer that differs and keep everything else.
+Crawlee covers the common cases out of the box, but sooner or later you'll hit something it doesn't do: a parser for a format no built-in crawler understands, an HTTP backend your company mandates, a database you want your data in, or a browser that isn't launched through the standard Playwright path. Rather than forking, you can plug your own implementation into the layer that differs and keep everything else.
 
 This guide is the map. It covers the extension points, the contract each one defines, and links to the guide that goes deeper on it. If you maintain a third-party integration, you can build it against these contracts and host your own guide for it.
 
 ## Extension points
 
-The four extension points below are the main ones, and they're where most integrations plug in. They aren't the only abstract classes you can subclass - <ApiLink to="class/RequestLoader">`RequestLoader`</ApiLink>, <ApiLink to="class/FingerprintGenerator">`FingerprintGenerator`</ApiLink>, and <ApiLink to="class/RenderingTypePredictor">`RenderingTypePredictor`</ApiLink> are extensible too.
+The four component families below contain the main extension points, and they're where most integrations plug in. This isn't a complete list of Crawlee's extensible classes. Other examples include <ApiLink to="class/RequestLoader">`RequestLoader`</ApiLink>, <ApiLink to="class/FingerprintGenerator">`FingerprintGenerator`</ApiLink>, and <ApiLink to="class/RenderingTypePredictor">`RenderingTypePredictor`</ApiLink>. The diagram marks the classes in these four families that you can extend or implement as an `extension point`.
 
 ```mermaid
 ---
@@ -24,72 +24,85 @@ config:
 classDiagram
 
 class BasicCrawler {
-    <<abstract>>
+    <<extension point>>
 }
 
 class AbstractHttpCrawler {
-    <<abstract>>
+    <<extension point>>
 }
 
-class PlaywrightCrawler
+class AbstractHttpParser {
+    <<extension point>>
+}
+
+class PlaywrightCrawler {
+    <<extension point>>
+}
+
+class StagehandCrawler
 
 class HttpClient {
-    <<abstract>>
+    <<extension point>>
 }
 
 class StorageClient {
-    <<abstract>>
-    create_dataset_client()
-    create_kvs_client()
-    create_rq_client()
+    <<extension point>>
 }
 
 class DatasetClient {
-    <<abstract>>
+    <<extension point>>
 }
 
 class KeyValueStoreClient {
-    <<abstract>>
+    <<extension point>>
 }
 
 class RequestQueueClient {
-    <<abstract>>
+    <<extension point>>
 }
 
 class BrowserPool
 
 class BrowserPlugin {
-    <<abstract>>
-    new_browser()
+    <<extension point>>
 }
 
 class BrowserController {
-    <<abstract>>
+    <<extension point>>
+}
+
+class PlaywrightBrowserPlugin {
+    <<extension point>>
 }
 
 BasicCrawler --|> AbstractHttpCrawler
 BasicCrawler --|> PlaywrightCrawler
-AbstractHttpCrawler --> HttpClient : uses
+AbstractHttpCrawler --> AbstractHttpParser : parses with
+PlaywrightCrawler --|> StagehandCrawler
+BasicCrawler --> HttpClient : uses
 BasicCrawler --> StorageClient : uses
 StorageClient --> DatasetClient : opens
 StorageClient --> KeyValueStoreClient : opens
 StorageClient --> RequestQueueClient : opens
 PlaywrightCrawler --> BrowserPool : uses
 BrowserPool --> BrowserPlugin : manages
-BrowserPlugin --> BrowserController : returns
+BrowserPlugin --|> PlaywrightBrowserPlugin
+BrowserPlugin --> BrowserController : new_browser() returns
 ```
 
 ### Crawlers
 
-A crawler drives the whole run: it takes requests from the queue, fetches each one, builds the context object your handler receives, and manages retries, concurrency, sessions, and storage along the way. <ApiLink to="class/BasicCrawler">`BasicCrawler`</ApiLink> implements all of that and stays agnostic about how a page is fetched or parsed, which is what makes it the base every other crawler builds on.
+A crawler drives the whole run. It takes requests from the queue, fetches each one, builds the context object your handler receives, and manages retries, concurrency, sessions, and storage along the way. <ApiLink to="class/BasicCrawler">`BasicCrawler`</ApiLink> implements that orchestration and stays agnostic about how a page is fetched or parsed, which is what makes it the base every other crawler builds on.
 
-For HTTP-based crawling, <ApiLink to="class/AbstractHttpCrawler">`AbstractHttpCrawler`</ApiLink> adds the fetch-and-parse layer on top. Extending it means supplying a parser that implements <ApiLink to="class/AbstractHttpParser">`AbstractHttpParser`</ApiLink>: `parse` turns an <ApiLink to="class/HttpResponse">`HttpResponse`</ApiLink> into your parsed type, `parse_text` does the same for a string, `select` and `is_matching_selector` apply selectors to it, and `find_links` extracts the URLs used for link enqueuing. You then pair that parser with a context type that exposes the parsed data to handlers, and a crawler class that ties the two together.
+For HTTP-based crawling, <ApiLink to="class/AbstractHttpCrawler">`AbstractHttpCrawler`</ApiLink> adds the fetch-and-parse layer. Its contract pairs a parser, a crawling context type, and a crawler class. The parser implements <ApiLink to="class/AbstractHttpParser">`AbstractHttpParser`</ApiLink>. Its `parse` method turns an <ApiLink to="class/HttpResponse">`HttpResponse`</ApiLink> into your parsed type, `parse_text` does the same for a string, `select` and `is_matching_selector` apply selectors, and `find_links` extracts URLs for link enqueuing. The context exposes the parsed data to handlers, and the crawler ties the parser and context together.
 
-See the [HTTP crawlers guide](./http-crawlers) for a worked example built on `selectolax`, and the [Architecture overview](./architecture-overview) for how crawlers relate to the other components.
+Browser crawlers use the same orchestration with a browser-backed context. Extend <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink> when an integration needs crawler-level browser behavior or a different handler context. <ApiLink to="class/StagehandCrawler">`StagehandCrawler`</ApiLink> is an example. It extends `PlaywrightCrawler` with a Stagehand-specific context and browser behavior. If only browser launch or lifecycle differs, a browser plugin is the narrower extension point.
+
+See the [HTTP crawlers guide](./http-crawlers) for a worked example built on `selectolax`. The [Architecture overview](./architecture-overview) explains how HTTP and browser crawlers relate to the other components.
 
 ### HTTP clients
 
-An HTTP client is what actually performs the network calls for HTTP-based crawlers. Swapping it changes the transport - the TLS stack, connection pooling, proxy handling, and browser impersonation - without touching how pages are parsed or how the crawl is orchestrated.
+An HTTP client performs network calls for crawlers. Swapping it changes the transport, including the TLS stack, connection pooling, proxy handling, and browser impersonation. It doesn't change how pages are parsed or how the crawl is orchestrated.
 
 The contract is <ApiLink to="class/HttpClient">`HttpClient`</ApiLink>. `crawl` performs a request inside the crawler's pipeline and returns the result the crawler consumes, `send_request` covers standalone calls made from a handler, `stream` yields a response you read incrementally, and `cleanup` releases whatever the client holds open. Crawlee ships <ApiLink to="class/ImpitHttpClient">`ImpitHttpClient`</ApiLink>, <ApiLink to="class/HttpxHttpClient">`HttpxHttpClient`</ApiLink>, and <ApiLink to="class/CurlImpersonateHttpClient">`CurlImpersonateHttpClient`</ApiLink>.
 
@@ -99,31 +112,34 @@ See the [HTTP clients guide](./http-clients) for the full contract and the trade
 
 A storage client is the backend behind Crawlee's three storages. <ApiLink to="class/Dataset">`Dataset`</ApiLink>, <ApiLink to="class/KeyValueStore">`KeyValueStore`</ApiLink>, and <ApiLink to="class/RequestQueue">`RequestQueue`</ApiLink> are the API you write against, and the storage client decides where that data actually lives. That separation is what lets you move a crawler from the local file system to a database or a cloud service without changing crawl code.
 
-<ApiLink to="class/StorageClient">`StorageClient`</ApiLink> itself is only three factory methods - `create_dataset_client`, `create_kvs_client`, and `create_rq_client`. The real work sits in what they return: <ApiLink to="class/DatasetClient">`DatasetClient`</ApiLink> handles appending and reading items, <ApiLink to="class/KeyValueStoreClient">`KeyValueStoreClient`</ApiLink> handles record get, set, delete, and iteration, and <ApiLink to="class/RequestQueueClient">`RequestQueueClient`</ApiLink> handles adding, fetching, and marking requests as handled. A custom backend implements all four.
+The <ApiLink to="class/StorageClient">`StorageClient`</ApiLink> contract defines three factory methods: `create_dataset_client`, `create_kvs_client`, and `create_rq_client`. The returned clients define the rest of the contract. <ApiLink to="class/DatasetClient">`DatasetClient`</ApiLink> handles appending and reading items, <ApiLink to="class/KeyValueStoreClient">`KeyValueStoreClient`</ApiLink> handles record access and iteration, and <ApiLink to="class/RequestQueueClient">`RequestQueueClient`</ApiLink> handles adding, fetching, and marking requests as handled. A custom backend implements all four classes.
 
 See the [Storage clients guide](./storage-clients) for the built-in implementations and a custom client example.
 
 ### Browser plugins
 
-A browser plugin is what launches browsers for <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>. The crawler never launches one itself: it goes through <ApiLink to="class/BrowserPool">`BrowserPool`</ApiLink>, which initializes the plugins it's given, forwards browser context options when creating pages, and manages each browser's lifecycle.
+A browser plugin launches browsers for <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>. The crawler delegates that work to <ApiLink to="class/BrowserPool">`BrowserPool`</ApiLink>. The pool initializes its plugins, forwards browser context options when creating pages, and manages each browser's lifecycle.
 
-The contract is <ApiLink to="class/BrowserPlugin">`BrowserPlugin`</ApiLink>. Its `new_browser` launches a browser and returns a <ApiLink to="class/BrowserController">`BrowserController`</ApiLink>, which is what the pool then drives to open pages and tear things down. Reach for a subclass when the launch path itself differs from the standard Playwright one, since <ApiLink to="class/PlaywrightBrowserPlugin">`PlaywrightBrowserPlugin`</ApiLink>'s configuration options already cover the cases where it doesn't.
+The abstract contract is <ApiLink to="class/BrowserPlugin">`BrowserPlugin`</ApiLink>. Its `new_browser` method launches a browser and returns a <ApiLink to="class/BrowserController">`BrowserController`</ApiLink>. The pool uses that controller to open pages and tear down the browser. Implement this base contract directly when the launch and lifecycle are too specific for Crawlee's Playwright integration.
+
+Most integrations should start with <ApiLink to="class/PlaywrightBrowserPlugin">`PlaywrightBrowserPlugin`</ApiLink>. Configure it when its launch and context options cover the required browser. Extend it when you need a custom Playwright-compatible launch path while preserving its standard lifecycle and context handling.
 
 See the [Playwright crawler guide](./playwright-crawler) for the responsibilities a subclass has to preserve, and the [Camoufox example](../examples/playwright-crawler-with-camoufox) for a complete integration.
 
 ## Choosing an extension point
 
-Match the layer to what actually differs in your integration.
+Start with configuration before writing a subclass. You can parse a response with a third-party library inside an <ApiLink to="class/HttpCrawler">`HttpCrawler`</ApiLink> handler, pass an existing `http_client` to any crawler, or configure <ApiLink to="class/PlaywrightBrowserPlugin">`PlaywrightBrowserPlugin`</ApiLink>. Use an extension contract only when the maintained options don't cover the required behavior.
 
-- The response format is one no built-in crawler parses - subclass <ApiLink to="class/AbstractHttpCrawler">`AbstractHttpCrawler`</ApiLink> with your own parser.
-- The transport differs, but parsing doesn't - implement <ApiLink to="class/HttpClient">`HttpClient`</ApiLink> and pass it to any HTTP crawler.
-- Data needs to live somewhere Crawlee doesn't support yet - implement <ApiLink to="class/StorageClient">`StorageClient`</ApiLink> and its three per-storage clients.
-- Browsers need to be launched through a different API - implement <ApiLink to="class/BrowserPlugin">`BrowserPlugin`</ApiLink> and hand it to <ApiLink to="class/BrowserPool">`BrowserPool`</ApiLink>.
+- If reusable HTTP parsing and the handler context both need to change, extend <ApiLink to="class/AbstractHttpCrawler">`AbstractHttpCrawler`</ApiLink> and implement <ApiLink to="class/AbstractHttpParser">`AbstractHttpParser`</ApiLink>.
+- If browser-level orchestration or the handler context needs to change, extend <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>.
+- If the network transport needs to change while crawler behavior stays the same, implement <ApiLink to="class/HttpClient">`HttpClient`</ApiLink> and pass it to the crawler.
+- If the storage backend needs to change while the storage API stays the same, implement <ApiLink to="class/StorageClient">`StorageClient`</ApiLink> and its three per-storage clients.
+- If browser launch needs to change while the Playwright lifecycle stays the same, extend <ApiLink to="class/PlaywrightBrowserPlugin">`PlaywrightBrowserPlugin`</ApiLink>. Implement <ApiLink to="class/BrowserPlugin">`BrowserPlugin`</ApiLink> directly only when its launch and lifecycle contract needs a different implementation.
 
 When more than one fits, pick the narrowest. A custom HTTP client works with every HTTP crawler, so it's easier to maintain than a crawler subclass that hard-codes the same transport.
 
 ## Conclusion
 
-Each extension point is a small abstract class with a documented contract, and everything above it keeps working once you implement one. If you're building a third-party integration, these contracts are also the stable surface to write your own documentation against.
+Each extension point has a documented class contract, and everything above it keeps working once you implement that contract. These public abstract class contracts only change with a major release. That versioning policy makes them the stable surface for a third-party integration and its documentation.
 
-If anything here is unclear or you hit a case the contracts don't cover, open an issue on [GitHub](https://github.com/apify/crawlee-python) or join our [Discord](https://discord.com/invite/jyEM2PRvMU).
+If you have questions or need assistance, feel free to reach out on our [GitHub](https://github.com/apify/crawlee-python) or join our [Discord community](https://discord.com/invite/jyEM2PRvMU). Happy scraping!

--- a/docs/guides/extending_crawlee.mdx
+++ b/docs/guides/extending_crawlee.mdx
@@ -1,0 +1,92 @@
+---
+id: extending-crawlee
+title: Extending Crawlee
+description: Learn which parts of Crawlee are designed to be extended, what contract each extension point defines, and where to find the detailed guide for each one.
+---
+
+import ApiLink from '@site/src/components/ApiLink';
+
+Crawlee is built around a small number of abstract base classes that you can subclass to plug in your own behavior. This guide is the map: it lists every extension point, states the contract each one defines, and links to the guide that covers it in depth.
+
+If you maintain a third-party integration, such as an alternative browser backend or a storage adapter, you can build it against these contracts and host the integration guide in your own project. This page gives your users a stable reference for the interface your integration implements.
+
+## Extension points
+
+Crawlee currently has four extension points.
+
+```mermaid
+---
+config:
+    class:
+        hideEmptyMembersBox: true
+---
+
+classDiagram
+
+class BasicCrawler {
+    <<abstract>>
+}
+
+class HttpClient {
+    <<abstract>>
+}
+
+class StorageClient {
+    <<abstract>>
+}
+
+class BrowserPlugin {
+    <<abstract>>
+}
+
+BasicCrawler --> HttpClient : uses
+BasicCrawler --> StorageClient : uses
+BasicCrawler --> BrowserPlugin : uses
+```
+
+### Crawlers
+
+Subclass a crawler when you need a parsing strategy or a request-handler context that the built-in crawlers do not provide.
+
+For HTTP-based crawling, <ApiLink to="class/AbstractHttpCrawler">`AbstractHttpCrawler`</ApiLink> is the base class. A custom crawler supplies a parser that turns an HTTP response into your parsed type, a context type that exposes that parsed data to request handlers, and the crawler class that ties the two together. Everything else, including retries, concurrency, session management, and storage, is inherited from <ApiLink to="class/BasicCrawler">`BasicCrawler`</ApiLink>.
+
+See [HTTP crawlers guide](./http-crawlers) for a worked example built on `selectolax`, and [Architecture overview](./architecture-overview) for how crawlers relate to the other components.
+
+### HTTP clients
+
+Subclass an HTTP client when you want crawlers to talk to servers through a different HTTP library, or through a proxy or transport layer that the bundled clients do not cover.
+
+<ApiLink to="class/HttpClient">`HttpClient`</ApiLink> is the base class. Implementations must be async-compatible and must manage their own connection lifecycle and cleanup, because a single client instance is shared across concurrent requests.
+
+See [HTTP clients guide](./http-clients) for the full interface and the built-in implementations.
+
+### Storage clients
+
+Subclass a storage client when you want Crawlee's storages to be backed by a system that is not covered by the built-in memory, file system, SQL, and Redis clients.
+
+<ApiLink to="class/StorageClient">`StorageClient`</ApiLink> is the base class. It is a factory: it opens the per-storage clients for datasets, key-value stores, and request queues, and those clients implement the actual create, read, update, and delete operations.
+
+See [Storage clients guide](./storage-clients) for the interface, a custom client example, and how clients are registered and resolved.
+
+### Browser plugins
+
+Subclass a browser plugin when an integration launches browsers through an API other than the standard Playwright one. Configuration options on <ApiLink to="class/PlaywrightBrowserPlugin">`PlaywrightBrowserPlugin`</ApiLink> cover the cases where the standard launch API is enough, so reach for a subclass only when the launch path itself differs.
+
+A plugin's `new_browser()` launches the browser and returns a <ApiLink to="class/PlaywrightBrowserController">`PlaywrightBrowserController`</ApiLink>; <ApiLink to="class/BrowserPool">`BrowserPool`</ApiLink> initializes the plugin, forwards browser context options when creating pages, and manages the controller's lifecycle.
+
+See [Playwright crawler guide](./playwright-crawler) for the contract and the responsibilities a subclass has to preserve, and the [Camoufox example](../examples/playwright-crawler-with-camoufox) for a complete integration.
+
+## Choosing an extension point
+
+Match the layer to what actually differs in your integration.
+
+- The response is fetched the usual way but parsed differently: extend a **crawler**.
+- The response is fetched over a different HTTP library or transport: extend an **HTTP client**.
+- Requests and results should live somewhere other than the built-in backends: extend a **storage client**.
+- Browsers are launched through a different API: extend a **browser plugin**.
+
+Prefer configuration over a subclass wherever the built-in class already exposes the knob you need. Subclassing ties your integration to a contract that only changes with Crawlee's major versions, while configuration keeps you on the maintained path.
+
+## Conclusion
+
+Crawlee's extension points are crawlers, HTTP clients, storage clients, and browser plugins. Each is an abstract base class with a documented contract and a guide that covers it in depth. If you are building an integration, start from the contract that matches the layer you are replacing, and keep the rest of the pipeline on the built-in path.

--- a/docs/guides/extending_crawlee.mdx
+++ b/docs/guides/extending_crawlee.mdx
@@ -27,6 +27,8 @@ class BasicCrawler {
     <<abstract>>
 }
 
+class PlaywrightCrawler
+
 class HttpClient {
     <<abstract>>
 }
@@ -35,13 +37,17 @@ class StorageClient {
     <<abstract>>
 }
 
+class BrowserPool
+
 class BrowserPlugin {
     <<abstract>>
 }
 
 BasicCrawler --> HttpClient : uses
 BasicCrawler --> StorageClient : uses
-BasicCrawler --> BrowserPlugin : uses
+BasicCrawler --|> PlaywrightCrawler
+PlaywrightCrawler --> BrowserPool : uses
+BrowserPool --> BrowserPlugin : manages
 ```
 
 ### Crawlers

--- a/docs/guides/extending_crawlee.mdx
+++ b/docs/guides/extending_crawlee.mdx
@@ -8,11 +8,11 @@ import ApiLink from '@site/src/components/ApiLink';
 
 Crawlee covers the common cases out of the box, but sooner or later you'll hit something it doesn't do: a parser for a format no built-in crawler understands, an HTTP backend your company mandates, a database you want your data in, or a browser that isn't launched through the standard Playwright path. Rather than forking, you can plug your own implementation into the layer that differs and keep everything else.
 
-This guide is the map. It covers the extension points, the contract each one defines, and links to the guide that goes deeper on it. If you maintain a third-party integration, you can build it against these contracts and host your own guide for it.
+This guide covers the extension points, the contract each one defines, and links to the guides that go deeper on each. If you maintain a third-party integration, you can build it against these contracts and host your own guide for it.
 
 ## Extension points
 
-The four component families below contain the main extension points, and they're where most integrations plug in. This isn't a complete list of Crawlee's extensible classes. Other examples include <ApiLink to="class/RequestLoader">`RequestLoader`</ApiLink>, <ApiLink to="class/FingerprintGenerator">`FingerprintGenerator`</ApiLink>, and <ApiLink to="class/RenderingTypePredictor">`RenderingTypePredictor`</ApiLink>. The diagram marks the classes in these four families that you can extend or implement as an `extension point`.
+The four component families covered here contain the main extension points, and they're where most integrations plug in. They don't cover every extensible class in Crawlee. Other examples include <ApiLink to="class/RequestLoader">`RequestLoader`</ApiLink>, <ApiLink to="class/FingerprintGenerator">`FingerprintGenerator`</ApiLink>, and <ApiLink to="class/RenderingTypePredictor">`RenderingTypePredictor`</ApiLink>. In the diagram, the `extension point` marker means a class you can extend or implement.
 
 ```mermaid
 ---
@@ -22,6 +22,10 @@ config:
 ---
 
 classDiagram
+
+%% ========================
+%% Crawlers
+%% ========================
 
 class BasicCrawler {
     <<extension point>>
@@ -41,9 +45,17 @@ class PlaywrightCrawler {
 
 class StagehandCrawler
 
+%% ========================
+%% HTTP clients
+%% ========================
+
 class HttpClient {
     <<extension point>>
 }
+
+%% ========================
+%% Storage clients
+%% ========================
 
 class StorageClient {
     <<extension point>>
@@ -61,6 +73,10 @@ class RequestQueueClient {
     <<extension point>>
 }
 
+%% ========================
+%% Browsers
+%% ========================
+
 class BrowserPool
 
 class BrowserPlugin {
@@ -75,15 +91,19 @@ class PlaywrightBrowserPlugin {
     <<extension point>>
 }
 
+%% ========================
+%% Relations
+%% ========================
+
 BasicCrawler --|> AbstractHttpCrawler
 BasicCrawler --|> PlaywrightCrawler
 AbstractHttpCrawler --> AbstractHttpParser : parses with
 PlaywrightCrawler --|> StagehandCrawler
 BasicCrawler --> HttpClient : uses
 BasicCrawler --> StorageClient : uses
-StorageClient --> DatasetClient : opens
-StorageClient --> KeyValueStoreClient : opens
-StorageClient --> RequestQueueClient : opens
+StorageClient --> DatasetClient : creates
+StorageClient --> KeyValueStoreClient : creates
+StorageClient --> RequestQueueClient : creates
 PlaywrightCrawler --> BrowserPool : uses
 BrowserPool --> BrowserPlugin : manages
 BrowserPlugin --|> PlaywrightBrowserPlugin
@@ -92,27 +112,46 @@ BrowserPlugin --> BrowserController : new_browser() returns
 
 ### Crawlers
 
-A crawler drives the whole run. It takes requests from the queue, fetches each one, builds the context object your handler receives, and manages retries, concurrency, sessions, and storage along the way. <ApiLink to="class/BasicCrawler">`BasicCrawler`</ApiLink> implements that orchestration and stays agnostic about how a page is fetched or parsed, which is what makes it the base every other crawler builds on.
+A crawler drives the whole run. It takes requests from the queue, fetches each one, builds the context object your handler receives, and manages retries, concurrency, sessions, and storage along the way. <ApiLink to="class/BasicCrawler">`BasicCrawler`</ApiLink> implements that orchestration and stays agnostic about how a page is fetched or parsed, which is what makes it the base every other crawler builds on. Extend it directly when a crawler has to fetch pages in a way neither the HTTP nor the browser layer covers.
 
-For HTTP-based crawling, <ApiLink to="class/AbstractHttpCrawler">`AbstractHttpCrawler`</ApiLink> adds the fetch-and-parse layer. Its contract pairs a parser, a crawling context type, and a crawler class. The parser implements <ApiLink to="class/AbstractHttpParser">`AbstractHttpParser`</ApiLink>. Its `parse` method turns an <ApiLink to="class/HttpResponse">`HttpResponse`</ApiLink> into your parsed type, `parse_text` does the same for a string, `select` and `is_matching_selector` apply selectors, and `find_links` extracts URLs for link enqueuing. The context exposes the parsed data to handlers, and the crawler ties the parser and context together.
+For HTTP-based crawling, <ApiLink to="class/AbstractHttpCrawler">`AbstractHttpCrawler`</ApiLink> adds the fetch-and-parse layer. Its contract pairs a parser, a crawling context type, and a crawler class. The parser implements <ApiLink to="class/AbstractHttpParser">`AbstractHttpParser`</ApiLink>:
+
+- `parse` turns an <ApiLink to="class/HttpResponse">`HttpResponse`</ApiLink> into your parsed type, and `parse_text` does the same for a string.
+- `select` and `is_matching_selector` apply selectors.
+- `find_links` extracts URLs for link enqueuing.
+
+The context exposes the parsed data to handlers, and the crawler ties the parser and context together.
 
 Browser crawlers use the same orchestration with a browser-backed context. Extend <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink> when an integration needs crawler-level browser behavior or a different handler context. <ApiLink to="class/StagehandCrawler">`StagehandCrawler`</ApiLink> is an example. It extends `PlaywrightCrawler` with a Stagehand-specific context and browser behavior. If only browser launch or lifecycle differs, a browser plugin is the narrower extension point.
 
-See the [HTTP crawlers guide](./http-crawlers) for a worked example built on `selectolax`. The [Architecture overview](./architecture-overview) explains how HTTP and browser crawlers relate to the other components.
+See the [HTTP crawlers guide](./http-crawlers) for a worked example built on `selectolax`, and the [Stagehand crawler guide](./stagehand-crawler) for `StagehandCrawler` itself. The [Architecture overview](./architecture-overview) explains how HTTP and browser crawlers relate to the other components.
 
 ### HTTP clients
 
 An HTTP client performs network calls for crawlers. Swapping it changes the transport, including the TLS stack, connection pooling, proxy handling, and browser impersonation. It doesn't change how pages are parsed or how the crawl is orchestrated.
 
-The contract is <ApiLink to="class/HttpClient">`HttpClient`</ApiLink>. `crawl` performs a request inside the crawler's pipeline and returns the result the crawler consumes, `send_request` covers standalone calls made from a handler, `stream` yields a response you read incrementally, and `cleanup` releases whatever the client holds open. Crawlee ships <ApiLink to="class/ImpitHttpClient">`ImpitHttpClient`</ApiLink>, <ApiLink to="class/HttpxHttpClient">`HttpxHttpClient`</ApiLink>, and <ApiLink to="class/CurlImpersonateHttpClient">`CurlImpersonateHttpClient`</ApiLink>.
+The contract is <ApiLink to="class/HttpClient">`HttpClient`</ApiLink>:
 
-See the [HTTP clients guide](./http-clients) for the full contract and the trade-offs between the built-in clients.
+- `crawl` performs a request inside the crawler's pipeline and returns the result the crawler consumes.
+- `send_request` covers standalone calls made from a handler.
+- `stream` yields a response you read incrementally.
+- `cleanup` releases whatever the client holds open.
+
+Crawlee ships <ApiLink to="class/ImpitHttpClient">`ImpitHttpClient`</ApiLink>, <ApiLink to="class/HttpxHttpClient">`HttpxHttpClient`</ApiLink>, and <ApiLink to="class/CurlImpersonateHttpClient">`CurlImpersonateHttpClient`</ApiLink>.
+
+See the [HTTP clients guide](./http-clients) for the libraries these clients wrap and their installation requirements.
 
 ### Storage clients
 
 A storage client is the backend behind Crawlee's three storages. <ApiLink to="class/Dataset">`Dataset`</ApiLink>, <ApiLink to="class/KeyValueStore">`KeyValueStore`</ApiLink>, and <ApiLink to="class/RequestQueue">`RequestQueue`</ApiLink> are the API you write against, and the storage client decides where that data actually lives. That separation is what lets you move a crawler from the local file system to a database or a cloud service without changing crawl code.
 
-The <ApiLink to="class/StorageClient">`StorageClient`</ApiLink> contract defines three factory methods: `create_dataset_client`, `create_kvs_client`, and `create_rq_client`. The returned clients define the rest of the contract. <ApiLink to="class/DatasetClient">`DatasetClient`</ApiLink> handles appending and reading items, <ApiLink to="class/KeyValueStoreClient">`KeyValueStoreClient`</ApiLink> handles record access and iteration, and <ApiLink to="class/RequestQueueClient">`RequestQueueClient`</ApiLink> handles adding, fetching, and marking requests as handled. A custom backend implements all four classes.
+The <ApiLink to="class/StorageClient">`StorageClient`</ApiLink> contract defines three factory methods: `create_dataset_client`, `create_kvs_client`, and `create_rq_client`. The returned clients define the rest of the contract:
+
+- <ApiLink to="class/DatasetClient">`DatasetClient`</ApiLink> handles appending and reading items.
+- <ApiLink to="class/KeyValueStoreClient">`KeyValueStoreClient`</ApiLink> handles record access and iteration.
+- <ApiLink to="class/RequestQueueClient">`RequestQueueClient`</ApiLink> handles adding, fetching, and marking requests as handled.
+
+A custom backend implements all four classes.
 
 See the [Storage clients guide](./storage-clients) for the built-in implementations and a custom client example.
 
@@ -120,7 +159,14 @@ See the [Storage clients guide](./storage-clients) for the built-in implementati
 
 A browser plugin launches browsers for <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>. The crawler delegates that work to <ApiLink to="class/BrowserPool">`BrowserPool`</ApiLink>. The pool initializes its plugins, forwards browser context options when creating pages, and manages each browser's lifecycle.
 
-The abstract contract is <ApiLink to="class/BrowserPlugin">`BrowserPlugin`</ApiLink>. Its `new_browser` method launches a browser and returns a <ApiLink to="class/BrowserController">`BrowserController`</ApiLink>. The pool uses that controller to open pages and tear down the browser. Implement this base contract directly when the launch and lifecycle are too specific for Crawlee's Playwright integration.
+The abstract contract is <ApiLink to="class/BrowserPlugin">`BrowserPlugin`</ApiLink>:
+
+- `new_browser` launches a browser and returns a <ApiLink to="class/BrowserController">`BrowserController`</ApiLink>, which the pool uses to open pages and tear down the browser.
+- `browser_launch_options` and `browser_new_context_options` hold the options the pool forwards.
+- `browser_type` tells the pool what the plugin launches, and `max_open_pages_per_browser` is the per-browser page limit the plugin passes to the controllers it creates. The pool asks the controller for free capacity, not the plugin.
+- `__aenter__` and `__aexit__` start and stop whatever the plugin holds open, and `active` reports whether the plugin is started.
+
+Implement this base contract directly when the launch and lifecycle are too specific for Crawlee's Playwright integration. A plugin that launches something other than a standard Playwright browser also needs its own `BrowserController` implementation.
 
 Most integrations should start with <ApiLink to="class/PlaywrightBrowserPlugin">`PlaywrightBrowserPlugin`</ApiLink>. Configure it when its launch and context options cover the required browser. Extend it when you need a custom Playwright-compatible launch path while preserving its standard lifecycle and context handling.
 
@@ -128,18 +174,18 @@ See the [Playwright crawler guide](./playwright-crawler) for the responsibilitie
 
 ## Choosing an extension point
 
-Start with configuration before writing a subclass. You can parse a response with a third-party library inside an <ApiLink to="class/HttpCrawler">`HttpCrawler`</ApiLink> handler, pass an existing `http_client` to any crawler, or configure <ApiLink to="class/PlaywrightBrowserPlugin">`PlaywrightBrowserPlugin`</ApiLink>. Use an extension contract only when the maintained options don't cover the required behavior.
+Start with configuration before writing a subclass. You can parse a response with a third-party library inside an <ApiLink to="class/HttpCrawler">`HttpCrawler`</ApiLink> handler, pass an existing `http_client` to any crawler, or configure <ApiLink to="class/PlaywrightBrowserPlugin">`PlaywrightBrowserPlugin`</ApiLink>. Use an extension contract only when configuration doesn't cover the required behavior.
 
 - If reusable HTTP parsing and the handler context both need to change, extend <ApiLink to="class/AbstractHttpCrawler">`AbstractHttpCrawler`</ApiLink> and implement <ApiLink to="class/AbstractHttpParser">`AbstractHttpParser`</ApiLink>.
 - If browser-level orchestration or the handler context needs to change, extend <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>.
 - If the network transport needs to change while crawler behavior stays the same, implement <ApiLink to="class/HttpClient">`HttpClient`</ApiLink> and pass it to the crawler.
 - If the storage backend needs to change while the storage API stays the same, implement <ApiLink to="class/StorageClient">`StorageClient`</ApiLink> and its three per-storage clients.
-- If browser launch needs to change while the Playwright lifecycle stays the same, extend <ApiLink to="class/PlaywrightBrowserPlugin">`PlaywrightBrowserPlugin`</ApiLink>. Implement <ApiLink to="class/BrowserPlugin">`BrowserPlugin`</ApiLink> directly only when its launch and lifecycle contract needs a different implementation.
+- If browser launch needs to change while the Playwright lifecycle stays the same, extend <ApiLink to="class/PlaywrightBrowserPlugin">`PlaywrightBrowserPlugin`</ApiLink>. Implement <ApiLink to="class/BrowserPlugin">`BrowserPlugin`</ApiLink> directly only when the Playwright plugin's launch and lifecycle contract needs a different implementation.
 
 When more than one fits, pick the narrowest. A custom HTTP client works with every HTTP crawler, so it's easier to maintain than a crawler subclass that hard-codes the same transport.
 
 ## Conclusion
 
-Each extension point has a documented class contract, and everything above it keeps working once you implement that contract. These public abstract class contracts only change with a major release. That versioning policy makes them the stable surface for a third-party integration and its documentation.
+Each extension point has a documented class contract, and everything built on top of it keeps working once you implement that contract. Crawlee changes those contracts only in a major release, which makes them the stable surface for a third-party integration and its documentation.
 
 If you have questions or need assistance, feel free to reach out on our [GitHub](https://github.com/apify/crawlee-python) or join our [Discord community](https://discord.com/invite/jyEM2PRvMU). Happy scraping!


### PR DESCRIPTION
### Description

Refs #1936. Adds `docs/guides/extending_crawlee.mdx`, a page that maps Crawlee's extension points.

The four extension points you listed in the issue each already document their own contract in the guide that owns them: crawlers in the [HTTP crawlers guide](https://crawlee.dev/python/docs/guides/http-crawlers), HTTP clients and storage clients in theirs, and browser plugins in the Playwright crawler guide (#2089). What is still missing is the map, so someone who wants to extend Crawlee has to already know which guide to open, and a third-party project has no single page to point its users at for "here is the interface this integration implements".

This page is that map. For each extension point it states when to subclass rather than configure, names the base class and what its contract covers, and links to the guide that goes deep. It deliberately does not restate those guides.

### Contents

- **Extension points** — a class diagram plus one section each for crawlers (`AbstractHttpCrawler`), HTTP clients (`HttpClient`), storage clients (`StorageClient`), and browser plugins (`PlaywrightBrowserPlugin`), each linking to its detailed guide.
- **Choosing an extension point** — matches the layer to what actually differs in an integration, and says to prefer configuration over a subclass where the built-in class already exposes the knob.
- Framing for third-party integrations, per the issue's rationale: they host their own guide and reference the contract here.

### Notes

- Placed as its own guide rather than a section inside an existing one, since it spans all four extension points. The sidebar picks it up automatically (`autogenerated` over `docs/guides`).
- No new code examples: each linked guide already carries a runnable one for its own extension point, so duplicating them here would mean two copies to keep in sync.
- Happy to adjust the placement, depth, or wording, especially if you would rather this live under a different section or carry a worked example of its own.

### Testing

- `uv run poe build-docs` — build succeeds, the page renders at `/docs/next/guides/extending-crawlee`, and the build reports no broken links or anchors for it (the broken anchors in the log are pre-existing ones on API pages).
- Verified every link target resolves before building: the five doc ids (`http-crawlers`, `http-clients`, `storage-clients`, `playwright-crawler`, `architecture-overview`), the `playwright-crawler-with-camoufox` example, and each ApiLink class (`AbstractHttpCrawler`, `BasicCrawler`, `HttpClient`, `StorageClient`, `PlaywrightBrowserPlugin`, `PlaywrightBrowserController`, `BrowserPool`) against `src/crawlee/`.

### AI assistance

Written with AI assistance (Claude). The scoping decision was mine to check first what each extension point already documents, which is why this is a map rather than four new sections; the browser-plugin quarter was covered by my earlier #2089.
