### PR TITLE
debt: remove async-timeout in favor of asyncio.timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,12 @@ authors = [{ name = "Apify Technologies s.r.o.", email = "support@apify.com" }]
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -34,7 +33,6 @@ keywords = [
     "scraping",
 ]
 dependencies = [
-    "async-timeout>=5.0.1",
     "cachetools>=5.5.0",
     "colorama>=0.4.0",
     "impit>=0.8.0",
@@ -280,7 +278,7 @@ filterwarnings = [
 ]
 
 [tool.ty.environment]
-python-version = "3.10"
+python-version = "3.11"
 
 [tool.ty.src]
 include = ["src", "tests", "scripts", "docs", "website"]

--- a/src/crawlee/_utils/time.py
+++ b/src/crawlee/_utils/time.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING
-
-from async_timeout import Timeout, timeout
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -46,7 +45,7 @@ class SharedTimeout:
 
     def __init__(self, timeout: timedelta) -> None:
         self._remaining_timeout = timeout
-        self._active_timeout: Timeout | None = None
+        self._active_timeout: asyncio.Timeout | None = None
         self._activation_timestamp: float | None = None
 
     async def __aenter__(self) -> timedelta:
@@ -54,7 +53,7 @@ class SharedTimeout:
             raise RuntimeError('A shared timeout context cannot be entered twice at the same time')
 
         self._activation_timestamp = time.monotonic()
-        self._active_timeout = new_timeout = timeout(self._remaining_timeout.total_seconds())
+        self._active_timeout = new_timeout = asyncio.timeout(self._remaining_timeout.total_seconds())
         await new_timeout.__aenter__()
         return self._remaining_timeout
 


### PR DESCRIPTION
Fixes #2052 

## Description
This PR drops the deprecated `async-timeout` dependency in favor of the standard library's `asyncio.timeout`, as the functionality was upstreamed into Python 3.11+. 

As discussed in the issue (and targeting the 2.0 milestone), this PR drops support for Python 3.10 to allow for the clean path of using the standard library directly without version-guarded imports.

## Changes Made
- **pyproject.toml**: Removed `async-timeout` from dependencies and bumped `requires-python` (and related classifiers) to `>=3.11`.
- **src/crawlee/_utils/time.py**: Replaced `async_timeout.timeout` with `asyncio.timeout` inside the `SharedTimeout` class. Retained the existing context manager logic as `asyncio.timeout` also serves as a drop-in async context manager in Python 3.11+.

## Verification
- Verified that `SharedTimeout` successfully catches operations exceeding the budget and properly propagates `TimeoutError`.
- Ran `ruff` to ensure formatting and linting rules are upheld.
