### PR TITLE
test: remove external network dependency from problematic-links tests

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import socket
 import warnings
 from typing import TYPE_CHECKING, Any, cast
 
@@ -18,7 +19,7 @@ from crawlee.http_clients import CurlImpersonateHttpClient, HttpxHttpClient, Imp
 from crawlee.proxy_configuration import ProxyInfo
 from crawlee.statistics import Statistics
 from crawlee.storages import KeyValueStore
-from tests.unit.server import TestServer, app, serve_in_thread
+from tests.unit.server import TestServer, app, no_robots_app, serve_in_thread
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Callable, Iterator
@@ -172,6 +173,32 @@ def http_server(unused_tcp_port_factory: Callable[[], int]) -> Iterator[TestServ
 def server_url(http_server: TestServer) -> URL:
     """Provide the base URL of the test server."""
     return http_server.url
+
+
+@pytest.fixture(scope='session')
+def no_robots_http_server(unused_tcp_port_factory: Callable[[], int]) -> Iterator[TestServer]:
+    """Create and start an HTTP test server that responds with 404 to robots.txt requests."""
+    config = Config(app=no_robots_app, lifespan='off', loop='asyncio', port=unused_tcp_port_factory())
+    server = TestServer(config=config)
+    yield from serve_in_thread(server)
+
+
+@pytest.fixture(scope='session')
+def no_robots_server_url(no_robots_http_server: TestServer) -> URL:
+    """Provide the base URL of the test server that has no robots.txt file."""
+    return no_robots_http_server.url
+
+
+@pytest.fixture(scope='session')
+def unreachable_url() -> Iterator[str]:
+    """Provide a URL that can never be connected to.
+
+    The port is bound for the whole session but never listened on, so nothing else can take it and every
+    connection attempt is refused immediately, without any DNS lookup or external traffic.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(('127.0.0.1', 0))
+        yield f'http://127.0.0.1:{sock.getsockname()[1]}/'
 
 
 # It is needed only in some tests, so we use the standard `scope=function`

--- a/tests/unit/crawlers/_beautifulsoup/test_beautifulsoup_crawler.py
+++ b/tests/unit/crawlers/_beautifulsoup/test_beautifulsoup_crawler.py
@@ -201,8 +201,17 @@ async def test_respect_robots_txt(server_url: URL, http_client: HttpClient) -> N
     visit.assert_has_calls(expected_visit_calls, any_order=True)
 
 
-async def test_respect_robots_txt_with_problematic_links(server_url: URL, http_client: HttpClient) -> None:
+async def test_respect_robots_txt_with_problematic_links(
+    server_url: URL,
+    no_robots_server_url: URL,
+    unreachable_url: str,
+    http_client: HttpClient,
+) -> None:
     """Test checks the crawler behavior with links that may cause problems when attempting to retrieve robots.txt."""
+    no_robots_url = str(no_robots_server_url / 'page')
+    start_url = str(
+        (server_url / 'problematic_links').with_query(unreachable_url=unreachable_url, no_robots_url=no_robots_url)
+    )
     visit = mock.Mock()
     fail = mock.Mock()
     crawler = BeautifulSoupCrawler(
@@ -220,19 +229,19 @@ async def test_respect_robots_txt_with_problematic_links(server_url: URL, http_c
     async def error_handler(context: BasicCrawlingContext, _error: Exception) -> None:
         fail(context.request.url)
 
-    await crawler.run([str(server_url / 'problematic_links')])
+    await crawler.run([start_url])
 
-    # Email must be skipped
-    # https://avatars.githubusercontent.com/apify does not get robots.txt, but is correct for the crawler.
+    # Email must be skipped.
+    # An origin without robots.txt is still crawled, an unavailable file means unrestricted crawling.
     expected_visit_calls = [
-        mock.call(str(server_url / 'problematic_links')),
-        mock.call('https://avatars.githubusercontent.com/apify'),
+        mock.call(start_url),
+        mock.call(no_robots_url),
     ]
     visit.assert_has_calls(expected_visit_calls, any_order=True)
 
-    # The budplaceholder.com does not exist.
+    # The unreachable URL cannot be connected to.
     expected_fail_calls = [
-        mock.call('https://budplaceholder.com/'),
+        mock.call(unreachable_url),
     ]
     fail.assert_has_calls(expected_fail_calls, any_order=True)
 

--- a/tests/unit/crawlers/_parsel/test_parsel_crawler.py
+++ b/tests/unit/crawlers/_parsel/test_parsel_crawler.py
@@ -285,8 +285,17 @@ async def test_respect_robots_txt(server_url: URL, http_client: HttpClient) -> N
     visit.assert_has_calls(expected_visit_calls, any_order=True)
 
 
-async def test_respect_robots_txt_with_problematic_links(server_url: URL, http_client: HttpClient) -> None:
+async def test_respect_robots_txt_with_problematic_links(
+    server_url: URL,
+    no_robots_server_url: URL,
+    unreachable_url: str,
+    http_client: HttpClient,
+) -> None:
     """Test checks the crawler behavior with links that may cause problems when attempting to retrieve robots.txt."""
+    no_robots_url = str(no_robots_server_url / 'page')
+    start_url = str(
+        (server_url / 'problematic_links').with_query(unreachable_url=unreachable_url, no_robots_url=no_robots_url)
+    )
     visit = mock.Mock()
     fail = mock.Mock()
     crawler = ParselCrawler(
@@ -304,19 +313,19 @@ async def test_respect_robots_txt_with_problematic_links(server_url: URL, http_c
     async def error_handler(context: BasicCrawlingContext, _error: Exception) -> None:
         fail(context.request.url)
 
-    await crawler.run([str(server_url / 'problematic_links')])
+    await crawler.run([start_url])
 
-    # Email must be skipped
-    # https://avatars.githubusercontent.com/apify does not get robots.txt, but is correct for the crawler.
+    # Email must be skipped.
+    # An origin without robots.txt is still crawled, an unavailable file means unrestricted crawling.
     expected_visit_calls = [
-        mock.call(str(server_url / 'problematic_links')),
-        mock.call('https://avatars.githubusercontent.com/apify'),
+        mock.call(start_url),
+        mock.call(no_robots_url),
     ]
     visit.assert_has_calls(expected_visit_calls, any_order=True)
 
-    # The budplaceholder.com does not exist.
+    # The unreachable URL cannot be connected to.
     expected_fail_calls = [
-        mock.call('https://budplaceholder.com/'),
+        mock.call(unreachable_url),
     ]
     fail.assert_has_calls(expected_fail_calls, any_order=True)
 

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -721,8 +721,16 @@ async def test_respect_robots_txt(server_url: URL) -> None:
     visit.assert_has_calls(expected_visit_calls, any_order=True)
 
 
-async def test_respect_robots_txt_with_problematic_links(server_url: URL) -> None:
+async def test_respect_robots_txt_with_problematic_links(
+    server_url: URL,
+    no_robots_server_url: URL,
+    unreachable_url: str,
+) -> None:
     """Test checks the crawler behavior with links that may cause problems when attempting to retrieve robots.txt."""
+    no_robots_url = str(no_robots_server_url / 'page')
+    start_url = str(
+        (server_url / 'problematic_links').with_query(unreachable_url=unreachable_url, no_robots_url=no_robots_url)
+    )
     visit = mock.Mock()
     fail = mock.Mock()
     crawler = PlaywrightCrawler(respect_robots_txt_file=True)
@@ -736,19 +744,19 @@ async def test_respect_robots_txt_with_problematic_links(server_url: URL) -> Non
     async def error_handler(context: BasicCrawlingContext, _error: Exception) -> None:
         fail(context.request.url)
 
-    await crawler.run([str(server_url / 'problematic_links')])
+    await crawler.run([start_url])
 
-    # Email must be skipped
-    # https://avatars.githubusercontent.com/apify does not get robots.txt, but is correct for the crawler.
+    # Email must be skipped.
+    # An origin without robots.txt is still crawled, an unavailable file means unrestricted crawling.
     expected_visit_calls = [
-        mock.call(str(server_url / 'problematic_links')),
-        mock.call('https://avatars.githubusercontent.com/apify'),
+        mock.call(start_url),
+        mock.call(no_robots_url),
     ]
     visit.assert_has_calls(expected_visit_calls, any_order=True)
 
-    # The budplaceholder.com does not exist.
+    # The unreachable URL cannot be connected to.
     expected_fail_calls = [
-        mock.call('https://budplaceholder.com/'),
+        mock.call(unreachable_url),
     ]
     fail.assert_has_calls(expected_fail_calls, any_order=True)
 

--- a/tests/unit/server.py
+++ b/tests/unit/server.py
@@ -144,6 +144,15 @@ async def app(scope: dict[str, Any], receive: Receive, send: Send) -> None:
         await hello_world(scope, receive, send)
 
 
+async def no_robots_app(scope: dict[str, Any], receive: Receive, send: Send) -> None:
+    """ASGI application handler that behaves like `app`, except that it serves no robots.txt file."""
+    assert scope['type'] == 'http'
+    if scope['path'] == '/robots.txt':
+        await send_html_response(send, b'Not Found', status=404)
+        return
+    await app(scope, receive, send)
+
+
 async def get_cookies(scope: dict[str, Any], _receive: Receive, send: Send) -> None:
     """Handle requests to retrieve cookies sent in the request."""
     headers = get_headers_dict(scope)
@@ -302,11 +311,20 @@ async def generic_response_endpoint(_scope: dict[str, Any], _receive: Receive, s
     )
 
 
-async def problematic_links_endpoint(_scope: dict[str, Any], _receive: Receive, send: Send) -> None:
-    """Handle requests with a page containing problematic links."""
+async def problematic_links_endpoint(scope: dict[str, Any], _receive: Receive, send: Send) -> None:
+    """Handle requests with a page containing problematic links.
+
+    The links themselves are supplied by the caller through the `unreachable_url` and `no_robots_url` query
+    parameters, because they point at other test servers whose ports are only known at runtime.
+    """
+    query_params = get_query_params(scope.get('query_string', b''))
+    content = PROBLEMATIC_LINKS.format(
+        unreachable_url=query_params['unreachable_url'],
+        no_robots_url=query_params['no_robots_url'],
+    ).encode()
     await send_html_response(
         send,
-        PROBLEMATIC_LINKS,
+        content,
     )
 
 

--- a/tests/unit/server_endpoints.py
+++ b/tests/unit/server_endpoints.py
@@ -59,14 +59,14 @@ INCAPSULA = b"""\
     </iframe>
 </body></html>"""
 
-PROBLEMATIC_LINKS = b"""\
+PROBLEMATIC_LINKS = """\
 <html><head>
     <title>Hello</title>
 </head>
 <body>
-    <a href="https://budplaceholder.com/">Placeholder</a>
+    <a href="{unreachable_url}">Unreachable</a>
     <a href="mailto:test@test.com">test@test.com</a>
-    <a href=https://avatars.githubusercontent.com/apify>Apify avatar/a>
+    <a href={no_robots_url}>No robots.txt/a>
 </body></html>"""
 
 NON_HREF_LINKS = b"""\


### PR DESCRIPTION
### Problem

`test_respect_robots_txt_with_problematic_links` (BeautifulSoup, Parsel and Playwright variants) crawled two live
external hosts: it expected `https://avatars.githubusercontent.com/apify` to be visited successfully and
`https://budplaceholder.com/` to fail. Whenever the runner could not reach GitHub's avatar CDN, the expected visit
never happened and the test failed — as it did on macOS / Python 3.14 in
[this CI run](https://github.com/apify/crawlee-python/actions/runs/31131414320/job/92720899051), where the TCP connect
hit the navigation timeout and, with `max_request_retries=0`, `visit` was never called.

### Solution

Both external hosts are replaced by local test servers, so the tests no longer touch the network:

- `no_robots_http_server` / `no_robots_server_url` — a test server that responds `404` to `/robots.txt`, standing in
  for an origin without a robots.txt file.
- `unreachable_url` — a loopback port bound for the whole session but never listened on, so every connection is
  refused immediately, with no DNS lookup and no external traffic.
- The problematic-links page now templates both links from query parameters, because the ports are only known at
  runtime.

The behavior under test is unchanged: the `mailto:` link is skipped, an origin with an unavailable robots.txt is still
crawled, and an unreachable host reaches the `failed_request_handler`.

### Verification

The failure reproduces deterministically with non-loopback DNS blocked (2 failed before, 0/100 after under the same
condition). Also 0/40 serial, the whole `tests/unit/crawlers` directory under `-n auto`, and the full unit suite.
Serving `Disallow: /` from the new server makes all seven variants fail, confirming the assertions still bite.

*✍️ Drafted by Claude Code*
