### PR TITLE
test: mark test_get_snapshot with run_alone to deflake CI

### DIFF
--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -630,6 +630,7 @@ async def test_launch_with_user_data_dir_and_fingerprint(tmp_path: Path, server_
     assert 'headless' not in fingerprints['window.navigator.userAgent'].lower()
 
 
+@pytest.mark.run_alone
 async def test_get_snapshot(server_url: URL) -> None:
     crawler = PlaywrightCrawler()
 


### PR DESCRIPTION
`test_get_snapshot` failed on `macos-latest` / Python 3.10 in [run 31388378733](https://github.com/apify/crawlee-python/actions/runs/31388378733/job/93453970610) on `assert snapshot.screenshot is not None`, with Chromium answering `Protocol error (Page.captureScreenshot): Unable to capture screenshot`.

The macOS image is the smallest of the three (~3 vCPU / 7 GB), yet the `-m "not run_alone"` pass drives 8 xdist workers. At the failure timestamp three of them were each running their own Chromium: `gw7` in `test_get_snapshot`, `gw0` cycling the `test_chromium_headless_headers` parametrizations, and `gw4` in the stagehand browser-controller tests. Under that contention the renderer cannot composite a frame for a `full_page` capture, and Playwright does not retry the error.

`PlaywrightPreNavCrawlingContext.get_snapshot()` deliberately degrades that failure to `screenshot=None` - an error snapshot must never break a crawl, and `ErrorSnapshotter` already guards on it - so the test observes `None`. The nondeterminism is runner contention, not a race in Crawlee, so product code is unchanged.

`@pytest.mark.run_alone` moves the test into the serial `--numprocesses=1` pass, removing the contention while keeping every assertion intact. This is the second tier of the hierarchy documented in `tests/unit/README.md`; the same file already marks `test_firefox_headless_headers` and `test_isolation_cookies` this way.

The failure does not reproduce on Linux - 0/20 runs of the Playwright module at `-n 16` (oversubscribing 8 cores) - so macOS CI is what re-verifies the fix. Locally the marker routes the test correctly (53 collected in the parallel pass, 4 in the serial one) and the full `run_alone` group is green at 14 items.

*✍️ Drafted by Claude Code*
