### PR TITLE
chore: bump Playwright to 1.61.0 in the project template

### DIFF
--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
@@ -5,7 +5,7 @@
 {# The Playwright version baked into the Apify Playwright base images. Keep this in sync with the
    `playwright` version resolved by the lockfile so the installed package matches the browser
    binaries shipped in the base image. #}
-# % set playwright_version = '1.62.0'
+# % set playwright_version = '1.61.0'
 
 # % if cookiecutter.crawler_type == 'playwright' or cookiecutter.crawler_type.startswith('adaptive-') or cookiecutter.crawler_type == 'stagehand'
 # % set base_image = 'apify/actor-python-playwright:3.13-' ~ playwright_version

--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
@@ -5,7 +5,7 @@
 {# The Playwright version baked into the Apify Playwright base images. Keep this in sync with the
    `playwright` version resolved by the lockfile so the installed package matches the browser
    binaries shipped in the base image. #}
-# % set playwright_version = '1.60.0'
+# % set playwright_version = '1.62.0'
 
 # % if cookiecutter.crawler_type == 'playwright' or cookiecutter.crawler_type.startswith('adaptive-') or cookiecutter.crawler_type == 'stagehand'
 # % set base_image = 'apify/actor-python-playwright:3.13-' ~ playwright_version


### PR DESCRIPTION
Automated bump of the Playwright version pinned by the project template Dockerfile.

> Generated by the [Update Playwright version](https://github.com/apify/crawlee-python/actions/workflows/update_playwright_version.yaml) workflow.