### PR TITLE
fix(stagehand): cap the stagehand dependency below the breaking 4.x API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ sql_postgres = [
     "asyncpg>=0.24.0"
 ]
 stagehand = [
-    "stagehand>=3.19.5",
+    "stagehand>=3.19.5,<4.0.0",
     "playwright>=1.27.0",
     "apify_fingerprint_datapoints>=0.0.2",
     "browserforge>=1.2.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1003,7 +1003,7 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'sql-mysql'", specifier = ">=2.0.0,<3.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'sql-postgres'", specifier = ">=2.0.0,<3.0.0" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'sql-sqlite'", specifier = ">=2.0.0,<3.0.0" },
-    { name = "stagehand", marker = "extra == 'stagehand'", specifier = ">=3.19.5" },
+    { name = "stagehand", marker = "extra == 'stagehand'", specifier = ">=3.19.5,<4.0.0" },
     { name = "tldextract", specifier = ">=5.3.0" },
     { name = "typer", marker = "extra == 'cli'", specifier = ">=0.26.0" },
     { name = "typing-extensions", specifier = ">=4.10.0" },


### PR DESCRIPTION
The scheduled E2E tests fail on every stagehand template job with:

```
ImportError: cannot import name 'AsyncStagehand' from 'stagehand'
```

`stagehand` 4.0.0, released on 2026-08-10, is a breaking API redesign. `AsyncStagehand` and `AsyncSession` are gone in favour of a single `Stagehand` plus `Page` / `Locator`, and the whole `stagehand.types.session_*` module tree that `_stagehand_types.py` imports was removed. The `stagehand` extra declared `stagehand>=3.19.5` with no upper bound, so the Actor image resolved 4.0.0 and the plugin's top-level import failed, surfaced through `try_import` as the misleading message above.

Our own CI never saw it, because `uv.lock` pins 3.22.0 and only the Actor image resolves the dependency fresh. That is also why some stagehand jobs still passed: they reused image layers cached before 4.0.0 was published.

This caps the extra at `<4.0.0`, matching the existing `sqlalchemy[asyncio]>=2.0.0,<3.0.0` style. Migrating the integration to the 4.x API is a separate piece of work.

Verified by mirroring the Actor Dockerfile's `pip install ./wheel[stagehand,httpx]`: the capped wheel resolves stagehand 3.22.0 and imports `StagehandCrawler`, `StagehandBrowserPlugin`, `StagehandOptions` and `StagehandPage` cleanly, while a wheel built from master resolves 4.0.0 and reproduces the traceback above.

Failing run: https://github.com/apify/crawlee-python/actions/runs/31583394515

*✍️ Drafted by Claude Code*
