### PR TITLE
fix: use stdlib `asyncio.timeout` instead of the deprecated `async-timeout`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ keywords = [
     "scraping",
 ]
 dependencies = [
-    "async-timeout>=5.0.1",
+    # Only needed for Python 3.10; 3.11+ uses stdlib `asyncio.timeout` (#2052).
+    "async-timeout>=5.0.1; python_version < '3.11'",
     "cachetools>=5.5.0",
     "colorama>=0.4.0",
     "impit>=0.8.0",

--- a/src/crawlee/_utils/time.py
+++ b/src/crawlee/_utils/time.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
+import sys
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
-from async_timeout import Timeout, timeout
+if sys.version_info >= (3, 11):
+    # `asyncio.timeout` was added in Python 3.11 and is the recommended replacement
+    # for the deprecated `async-timeout` package (#2052).
+    from asyncio import Timeout, timeout
+else:
+    # Python 3.10: `async-timeout` is the official backport of the same API.
+    from async_timeout import Timeout, timeout
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/uv.lock
+++ b/uv.lock
@@ -802,7 +802,7 @@ name = "crawlee"
 version = "1.9.2"
 source = { editable = "." }
 dependencies = [
-    { name = "async-timeout" },
+    { name = "async-timeout", marker = "python_full_version < '3.11'" },
     { name = "cachetools" },
     { name = "colorama" },
     { name = "impit" },
@@ -960,7 +960,7 @@ requires-dist = [
     { name = "apify-fingerprint-datapoints", marker = "extra == 'httpx'", specifier = ">=0.0.2" },
     { name = "apify-fingerprint-datapoints", marker = "extra == 'playwright'", specifier = ">=0.0.2" },
     { name = "apify-fingerprint-datapoints", marker = "extra == 'stagehand'", specifier = ">=0.0.2" },
-    { name = "async-timeout", specifier = ">=5.0.1" },
+    { name = "async-timeout", marker = "python_full_version < '3.11'", specifier = ">=5.0.1" },
     { name = "asyncpg", marker = "extra == 'sql-postgres'", specifier = ">=0.24.0" },
     { name = "beautifulsoup4", extras = ["lxml"], marker = "extra == 'beautifulsoup'", specifier = ">=4.12.0" },
     { name = "browserforge", marker = "extra == 'adaptive-crawler'", specifier = ">=1.2.4" },


### PR DESCRIPTION
Closes #2052

## Summary

Drops the deprecated `async-timeout` dependency for Python 3.11+ and uses the stdlib equivalent, per #2052.

- `crawlee/_utils/time.py` now imports `asyncio.timeout` / `asyncio.Timeout` on Python 3.11+ and falls back to the `async-timeout` backport only on 3.10 — the two APIs are drop-in identical for `SharedTimeout`.
- `async-timeout>=5.0.1` becomes an environment-marked dependency (`python_version < '3.11'`), so 3.11+ installs no longer pull the deprecated package (the issue's "effectively upstreamed into Python 3.11+" README note). Python 3.10 support is unchanged.
- `uv.lock` regenerated for the marker.

## Validation

- `tests/unit/_utils/` — 294 passed on Python 3.13 (stdlib path exercised, incl. `test_shared_timeout.py`).
- `test_shared_timeout.py` — 4/4 passed on Python 3.10 (backport path).
- Full `tests/unit` — 2166 passed; the 98 failures/26 errors are all in Playwright/stagehand browser tests that require the Playwright browser executable (not installed in this environment), unrelated to this change.
- `ruff check` + `ruff format --check` clean on the changed file.
