### PR TITLE
feat: support timeouts in the `send_request` context helper (#2138)

### DIFF
--- a/src/crawlee/_types.py
+++ b/src/crawlee/_types.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     import logging
     import re
     from collections.abc import Awaitable, Coroutine, MutableMapping, Sequence
+    from datetime import timedelta
 
     from typing_extensions import NotRequired, Required, Self, Unpack
 
@@ -558,6 +559,7 @@ class SendRequestFunction(Protocol):
         method: HttpMethod = 'GET',
         payload: HttpPayload | None = None,
         headers: HttpHeaders | dict[str, str] | None = None,
+        timeout: timedelta | None = None,
     ) -> Coroutine[None, None, HttpResponse]:
         """Call send request function.
 
@@ -566,6 +568,7 @@ class SendRequestFunction(Protocol):
             method: The HTTP method to use.
             headers: The headers to include in the request.
             payload: The payload to include in the request.
+            timeout: Maximum time allowed to process the request.
 
         Returns:
             The HTTP response received from the server.

--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -1321,6 +1321,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
             method: HttpMethod = 'GET',
             payload: HttpPayload | None = None,
             headers: HttpHeaders | dict[str, str] | None = None,
+            timeout: timedelta | None = None,
         ) -> HttpResponse:
             return await self._http_client.send_request(
                 url=url,
@@ -1329,6 +1330,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
                 headers=headers,
                 session=session,
                 proxy_info=proxy_info,
+                timeout=timeout,
             )
 
         return send_request

--- a/tests/unit/crawlers/_basic/test_basic_crawler.py
+++ b/tests/unit/crawlers/_basic/test_basic_crawler.py
@@ -523,6 +523,25 @@ async def test_send_request_works(server_url: URL, method: HttpMethod, path: str
     assert content_type == 'application/json'
 
 
+async def test_send_request_respects_timeout(server_url: URL) -> None:
+    request_timed_out = asyncio.Event()
+
+    crawler = BasicCrawler(max_request_retries=3)
+
+    @crawler.router.default_handler
+    async def handler(context: BasicCrawlingContext) -> None:
+        with pytest.raises(asyncio.TimeoutError):
+            await context.send_request(
+                str(server_url / 'slow') + '?delay=2',
+                timeout=timedelta(milliseconds=100),
+            )
+        request_timed_out.set()
+
+    await crawler.run(['https://a.placeholder.com'])
+
+    assert request_timed_out.is_set()
+
+
 @dataclass
 class AddRequestsTestInput:
     start_url: str


### PR DESCRIPTION
Closes #2138

## Summary

`SendRequestFunction` (used via `context.send_request()` in request handlers) only accepted `url`, `method`, `payload` and `headers`, so a handler could not bound how long an extra HTTP call may take. All four HTTP client implementations (`HttpxHttpClient`, `CurlImpersonateHttpClient`, `ImpitHttpClient`, `PlaywrightHttpClient`) already support a per-request `timeout: timedelta | None` — this PR just exposes it through the public contract.

## Changes

- `src/crawlee/_types.py`: add `timeout: timedelta | None = None` to the `SendRequestFunction` protocol + docstring.
- `src/crawlee/crawlers/_basic/_basic_crawler.py`: thread `timeout` through the `_prepare_send_request_function` closure into `HttpClient.send_request`.
- `tests/unit/crawlers/_basic/test_basic_crawler.py`: regression test — `context.send_request('/slow?delay=2', timeout=timedelta(milliseconds=100))` raises `asyncio.TimeoutError`.

## Validation

- `pytest tests/unit/crawlers/_basic` → 112 passed, 5 skipped (3.10/3.11-only features)
- `ruff check` + `ruff format --check` clean on all touched files

Note: no new dependency; `timeout` uses the existing `timedelta` convention across the Python HTTP clients (the JS implementation names it `timeoutMillis`, but the Python clients are timedelta-based).
