### PR TITLE
fix(playwright): scope custom request headers to the navigation request

### DIFF
--- a/docs/guides/code_examples/http_headers/browser_page_headers.py
+++ b/docs/guides/code_examples/http_headers/browser_page_headers.py
@@ -1,0 +1,27 @@
+import asyncio
+
+from crawlee.crawlers import (
+    PlaywrightCrawler,
+    PlaywrightCrawlingContext,
+    PlaywrightPreNavCrawlingContext,
+)
+
+
+async def main() -> None:
+    crawler = PlaywrightCrawler(max_requests_per_crawl=10)
+
+    # Page headers are attached to every request the page makes, to any origin.
+    @crawler.pre_navigation_hook
+    async def set_page_headers(context: PlaywrightPreNavCrawlingContext) -> None:
+        await context.page.set_extra_http_headers({'X-Custom-Header': 'my-value'})
+
+    @crawler.router.default_handler
+    async def request_handler(context: PlaywrightCrawlingContext) -> None:
+        # `httpbin.org/headers` echoes the received request headers back.
+        context.log.info(await context.response.text())
+
+    await crawler.run(['https://httpbin.org/headers'])
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/docs/guides/http_headers.mdx
+++ b/docs/guides/http_headers.mdx
@@ -109,6 +109,27 @@ The example below sets `X-Api-Key` on the client and `Accept` on one of two requ
 
 Header names are case-insensitive, and <ApiLink to="class/HttpHeaders">`HttpHeaders`</ApiLink> normalizes the casing for you, so `user-agent` and `User-Agent` refer to the same header.
 
+## Custom headers in browser-based crawlers
+
+The `headers` field of a <ApiLink to="class/Request">`Request`</ApiLink> works differently in browser-based crawlers such as <ApiLink to="class/PlaywrightCrawler">`PlaywrightCrawler`</ApiLink>. The custom headers are sent with the navigation request and any redirects it goes through, merged into the headers the browser sends on its own. They aren't attached to the requests the page then makes by itself, such as images, scripts, or API calls. The scoping keeps sensitive values like `Authorization` from leaking to third-party origins that the crawled page decides to contact.
+
+There are two ways to send a header with every request the browser makes:
+
+- Set it on the browser context through `browser_new_context_options`. Context headers apply to all pages and all requests from them, so use them for values you're willing to send to every origin, and keep credentials on the request.
+- Set it on a single page with `page.set_extra_http_headers()` in a [pre-navigation hook](./request-router#pre-navigation-hooks).
+
+```python
+from crawlee.crawlers import PlaywrightCrawler
+
+crawler = PlaywrightCrawler(
+    browser_new_context_options={
+        'extra_http_headers': {
+            'X-Custom-Header': 'my-value',
+        },
+    },
+)
+```
+
 ## Header order and fingerprinting
 
 Anti-bot systems look at more than header values. They look at which headers are present, their casing, and the order they arrive in. Real browsers send a consistent, recognizable set. A request that has a browser `User-Agent` but the wrong header order, or missing client hints, still looks automated.

--- a/docs/guides/http_headers.mdx
+++ b/docs/guides/http_headers.mdx
@@ -8,6 +8,7 @@ import ApiLink from '@site/src/components/ApiLink';
 import RunnableCodeBlock from '@site/src/components/RunnableCodeBlock';
 
 import SetHeadersExample from '!!raw-loader!roa-loader!./code_examples/http_headers/set_headers.py';
+import BrowserPageHeadersExample from '!!raw-loader!roa-loader!./code_examples/http_headers/browser_page_headers.py';
 
 Every request a crawler sends includes [HTTP headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers). These headers tell the server who is making the request, what content is acceptable, and in what language. The server reads them and decides what to return. The same URL can return different content, a different status code, or a blocked page depending on the headers it sees. This guide covers the headers that shape a scraping request, like `User-Agent`, `Accept-Language`, and `Content-Type`, what Crawlee sends by default, and how to change them.
 
@@ -115,20 +116,14 @@ The `headers` field of a <ApiLink to="class/Request">`Request`</ApiLink> works d
 
 There are two ways to send a header with every request the browser makes:
 
-- Set it on the browser context through `browser_new_context_options`. Context headers apply to all pages and all requests from them, so use them for values you're willing to send to every origin, and keep credentials on the request.
 - Set it on a single page with `page.set_extra_http_headers()` in a [pre-navigation hook](./request-router#pre-navigation-hooks).
+- Set it on the browser context through `browser_new_context_options={'extra_http_headers': {...}}`. The default fingerprint generator replaces context-level headers with its own, so context headers only take effect with fingerprinting turned off (`fingerprint_generator=None`).
 
-```python
-from crawlee.crawlers import PlaywrightCrawler
+Either way, the header goes to every origin the page contacts, so use these options for values you're willing to send anywhere, and keep credentials on the request. The following example sets a page header in a pre-navigation hook, which works with the default fingerprinting:
 
-crawler = PlaywrightCrawler(
-    browser_new_context_options={
-        'extra_http_headers': {
-            'X-Custom-Header': 'my-value',
-        },
-    },
-)
-```
+<RunnableCodeBlock className="language-python" language="python">
+    {BrowserPageHeadersExample}
+</RunnableCodeBlock>
 
 ## Header order and fingerprinting
 

--- a/src/crawlee/crawlers/_playwright/_playwright_crawler.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_crawler.py
@@ -356,18 +356,18 @@ class PlaywrightCrawler(
         headers: HttpHeaders | dict[str, str] | None = None,
         payload: HttpPayload | None = None,
     ) -> Callable:
-        """Create a request interceptor for Playwright to support non-GET methods with custom parameters.
-
-        The interceptor modifies requests by adding custom headers and payload before they are sent.
+        """Create a request interceptor that applies a custom method, headers, and payload to matching requests.
 
         Args:
             method: HTTP method to use for the request.
-            headers: Custom HTTP headers to send with the request.
+            headers: Custom HTTP headers to send with the request. They are merged into the headers the browser
+                would send on its own (e.g. `User-Agent` or fingerprint headers), with the custom ones winning.
             payload: Request body data for POST/PUT requests.
         """
 
-        async def route_handler(route: Route, _: PlaywrightRequest) -> None:
-            await route.continue_(method=method, headers=dict(headers) if headers else None, post_data=payload)
+        async def route_handler(route: Route, request: PlaywrightRequest) -> None:
+            merged_headers = {**request.headers, **dict(headers)} if headers else None
+            await route.continue_(method=method, headers=merged_headers, post_data=payload)
 
         return route_handler
 
@@ -399,9 +399,6 @@ class PlaywrightCrawler(
             session_cookies = context.session.cookies.get_cookies_as_playwright_format()
             await self._update_cookies(context.page, session_cookies)
 
-        if context.request.headers:
-            await context.page.set_extra_http_headers(context.request.headers.model_dump())
-        # Navigate to the URL and get response.
         if context.request.method != 'GET':
             # Call the notification only once
             warnings.warn(
@@ -411,6 +408,9 @@ class PlaywrightCrawler(
                 stacklevel=2,
             )
 
+        # Apply custom headers via a route scoped to the navigation URL; page-wide `set_extra_http_headers`
+        # would leak sensitive values like `Authorization` to every subresource request the page makes.
+        if context.request.headers or context.request.method != 'GET':
             route_handler = self._prepare_request_interceptor(
                 method=context.request.method,
                 headers=context.request.headers,

--- a/src/crawlee/crawlers/_playwright/_playwright_crawler.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_crawler.py
@@ -33,23 +33,19 @@ from ._playwright_http_client import PlaywrightHttpClient, browser_page_context
 from ._playwright_post_nav_crawling_context import PlaywrightPostNavCrawlingContext
 from ._playwright_pre_nav_crawling_context import PlaywrightPreNavCrawlingContext
 from ._types import BlockRequestsFunction, GotoOptions
-from ._utils import block_requests, infinite_scroll
+from ._utils import NavigationRequestInterceptor, block_requests, infinite_scroll
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Awaitable, Callable, Iterator, Mapping
     from pathlib import Path
 
-    from playwright.async_api import Page, Response, Route
-    from playwright.async_api import Request as PlaywrightRequest
+    from playwright.async_api import Page, Response
     from typing_extensions import Unpack
 
     from crawlee import RequestTransformAction
     from crawlee._types import (
         EnqueueLinksKwargs,
         ExtractLinksFunction,
-        HttpHeaders,
-        HttpMethod,
-        HttpPayload,
         JsonSerializable,
     )
     from crawlee.browsers._types import BrowserType
@@ -350,27 +346,6 @@ class PlaywrightCrawler(
             # Yield should be inside the browser_page_context.
             yield pre_navigation_context
 
-    def _prepare_request_interceptor(
-        self,
-        method: HttpMethod = 'GET',
-        headers: HttpHeaders | dict[str, str] | None = None,
-        payload: HttpPayload | None = None,
-    ) -> Callable:
-        """Create a request interceptor that applies a custom method, headers, and payload to matching requests.
-
-        Args:
-            method: HTTP method to use for the request.
-            headers: Custom HTTP headers to send with the request. They are merged into the headers the browser
-                would send on its own (e.g. `User-Agent` or fingerprint headers), with the custom ones winning.
-            payload: Request body data for POST/PUT requests.
-        """
-
-        async def route_handler(route: Route, request: PlaywrightRequest) -> None:
-            merged_headers = {**request.headers, **dict(headers)} if headers else None
-            await route.continue_(method=method, headers=merged_headers, post_data=payload)
-
-        return route_handler
-
     async def _navigate(
         self,
         context: TPreNavContext,
@@ -408,30 +383,16 @@ class PlaywrightCrawler(
                 stacklevel=2,
             )
 
-        # Apply custom headers via a route scoped to the navigation request; page-wide `set_extra_http_headers`
-        # would leak sensitive values like `Authorization` to every subresource request the page makes.
+        # Apply the custom method, headers, and payload to the navigation request only; the details of doing
+        # that correctly live in `NavigationRequestInterceptor`.
         if context.request.headers or context.request.method != 'GET':
-            route_handler = self._prepare_request_interceptor(
+            interceptor = NavigationRequestInterceptor(
+                context.page,
                 method=context.request.method,
                 headers=context.request.headers,
                 payload=context.request.payload,
             )
-            applied = False
-
-            async def navigation_route_handler(route: Route, request: PlaywrightRequest) -> None:
-                nonlocal applied
-                # Match the main-frame navigation request itself rather than its URL; the browser normalizes
-                # URLs (adds the root path, strips fragments), so a string comparison with `request.url` can
-                # silently miss. Redirect hops bypass routing and inherit the header overrides.
-                if not applied and request.is_navigation_request() and request.frame == context.page.main_frame:
-                    applied = True
-                    await route_handler(route, request)
-                else:
-                    await route.fallback()
-
-            # Once the overrides are applied, the predicate stops matching, so subresource requests
-            # skip the handler entirely.
-            await context.page.route(lambda _: not applied, navigation_route_handler)
+            await interceptor.register()
 
         try:
             async with self._shared_navigation_timeouts[id(context.request)] as remaining_timeout:

--- a/src/crawlee/crawlers/_playwright/_playwright_crawler.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_crawler.py
@@ -408,7 +408,7 @@ class PlaywrightCrawler(
                 stacklevel=2,
             )
 
-        # Apply custom headers via a route scoped to the navigation URL; page-wide `set_extra_http_headers`
+        # Apply custom headers via a route scoped to the navigation request; page-wide `set_extra_http_headers`
         # would leak sensitive values like `Authorization` to every subresource request the page makes.
         if context.request.headers or context.request.method != 'GET':
             route_handler = self._prepare_request_interceptor(
@@ -416,9 +416,22 @@ class PlaywrightCrawler(
                 headers=context.request.headers,
                 payload=context.request.payload,
             )
+            applied = False
 
-            # Set route_handler only for current request
-            await context.page.route(context.request.url, route_handler)
+            async def navigation_route_handler(route: Route, request: PlaywrightRequest) -> None:
+                nonlocal applied
+                # Match the main-frame navigation request itself rather than its URL; the browser normalizes
+                # URLs (adds the root path, strips fragments), so a string comparison with `request.url` can
+                # silently miss. Redirect hops bypass routing and inherit the header overrides.
+                if not applied and request.is_navigation_request() and request.frame == context.page.main_frame:
+                    applied = True
+                    await route_handler(route, request)
+                else:
+                    await route.fallback()
+
+            # Once the overrides are applied, the predicate stops matching, so subresource requests
+            # skip the handler entirely.
+            await context.page.route(lambda _: not applied, navigation_route_handler)
 
         try:
             async with self._shared_navigation_timeouts[id(context.request)] as remaining_timeout:

--- a/src/crawlee/crawlers/_playwright/_utils.py
+++ b/src/crawlee/crawlers/_playwright/_utils.py
@@ -5,8 +5,10 @@ from contextlib import suppress
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from playwright.async_api import Page
+    from playwright.async_api import Page, Route
     from playwright.async_api import Request as PlaywrightRequest
+
+    from crawlee._types import HttpHeaders, HttpMethod, HttpPayload
 
 _DEFAULT_BLOCK_REQUEST_URL_PATTERNS = [
     '.css',
@@ -20,6 +22,51 @@ _DEFAULT_BLOCK_REQUEST_URL_PATTERNS = [
     '.pdf',
     '.zip',
 ]
+
+
+class NavigationRequestInterceptor:
+    """One-shot page route that applies a custom method, headers, and payload to the main-frame navigation request.
+
+    Scoping the overrides to the navigation request is the point: applying headers page-wide via
+    `Page.set_extra_http_headers` would leak sensitive values like `Authorization` to every subresource request
+    the page makes, including cross-origin ones. The navigation request is matched by its role (a main-frame
+    navigation) rather than by its URL, because the browser normalizes URLs (adds the root path, strips
+    fragments), so a URL comparison can silently miss. Redirect hops bypass routing and inherit the overrides.
+
+    Custom headers are merged into the headers the browser would send on its own (e.g. `User-Agent` or
+    fingerprint headers), with the custom ones winning.
+    """
+
+    def __init__(
+        self,
+        page: Page,
+        *,
+        method: HttpMethod = 'GET',
+        headers: HttpHeaders | dict[str, str] | None = None,
+        payload: HttpPayload | None = None,
+    ) -> None:
+        self._page = page
+        self._method = method
+        self._headers = headers
+        self._payload = payload
+        self._applied = False
+
+    async def register(self) -> None:
+        """Start routing the page's requests through this interceptor.
+
+        Once the overrides are applied, the route's predicate stops matching, so any later request
+        (subresources, XHRs, client-side navigations) skips the handler entirely.
+        """
+        await self._page.route(lambda _: not self._applied, self._handle_route)
+
+    async def _handle_route(self, route: Route, request: PlaywrightRequest) -> None:
+        if self._applied or not request.is_navigation_request() or request.frame != self._page.main_frame:
+            await route.fallback()
+            return
+
+        self._applied = True
+        merged_headers = {**request.headers, **dict(self._headers)} if self._headers else None
+        await route.continue_(method=self._method, headers=merged_headers, post_data=self._payload)
 
 
 async def infinite_scroll(page: Page) -> None:

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -344,8 +344,43 @@ async def test_custom_headers_not_sent_with_cross_origin_requests(server_url: UR
     await crawler.run([Request.from_url(start_url, headers={'authorization': 'Bearer secret-token'})])
 
     assert navigation_headers.get('authorization') == 'Bearer secret-token'
+    # Custom headers are merged into the browser-generated ones, not replacing them.
+    assert 'user-agent' in navigation_headers
     assert subresource_headers
     assert 'authorization' not in subresource_headers
+
+
+async def test_custom_headers_sent_when_browser_normalizes_url(server_url: URL) -> None:
+    """Custom headers are applied even when the browser normalizes the request URL (e.g. adds the root path)."""
+    crawler = PlaywrightCrawler()
+    navigation_headers = dict[str, str]()
+
+    @crawler.router.default_handler
+    async def request_handler(context: PlaywrightCrawlingContext) -> None:
+        navigation_headers.update(await context.response.request.all_headers())
+
+    # A bare origin without the trailing slash; the browser requests `/`.
+    bare_url = f'http://{server_url.host}:{server_url.port}'
+    await crawler.run([Request.from_url(bare_url, headers={'authorization': 'Bearer secret-token'})])
+
+    assert navigation_headers.get('authorization') == 'Bearer secret-token'
+
+
+async def test_custom_headers_survive_redirect(server_url: URL) -> None:
+    """Custom headers applied to the navigation request are inherited by redirect hops."""
+    crawler = PlaywrightCrawler()
+    received_headers = dict[str, str]()
+
+    @crawler.router.default_handler
+    async def request_handler(context: PlaywrightCrawlingContext) -> None:
+        # The `/headers` endpoint echoes what the server actually received after the redirect hop.
+        received_headers.update(json.loads(await context.response.text()))
+
+    target_url = str(server_url / 'headers')
+    start_url = str((server_url / 'redirect').with_query(url=target_url))
+    await crawler.run([Request.from_url(start_url, headers={'authorization': 'Bearer secret-token'})])
+
+    assert received_headers.get('authorization') == 'Bearer secret-token'
 
 
 async def test_pre_navigation_hook() -> None:

--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -47,6 +47,7 @@ from tests.unit.server_endpoints import GENERIC_RESPONSE, HELLO_WORLD
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from playwright.async_api import Request as PlaywrightRequest
     from yarl import URL
 
     from crawlee._request import RequestOptions
@@ -314,6 +315,37 @@ async def test_custom_headers(server_url: URL) -> None:
     assert response_headers.get('power-header') == request_headers['Power-Header']
     assert response_headers.get('library') == request_headers['Library']
     assert response_headers.get('my-test-header') == request_headers['My-Test-Header']
+
+
+async def test_custom_headers_not_sent_with_cross_origin_requests(server_url: URL, redirect_server_url: URL) -> None:
+    """Request headers are sent with the main navigation only, not with cross-origin requests made by the page."""
+    crawler = PlaywrightCrawler()
+
+    subresource_url = str(redirect_server_url / 'headers')
+    page_html = f'<html><body><img src="{subresource_url}"></body></html>'
+    start_url = str((server_url / 'echo_content').with_query(content=page_html))
+
+    navigation_headers = dict[str, str]()
+    subresource_headers = dict[str, str]()
+
+    @crawler.pre_navigation_hook
+    async def capture_subresource_headers(context: PlaywrightPreNavCrawlingContext) -> None:
+        def capture(request: PlaywrightRequest) -> None:
+            if request.url == subresource_url:
+                subresource_headers.update(request.headers)
+
+        context.page.on('request', capture)
+
+    @crawler.router.default_handler
+    async def request_handler(context: PlaywrightCrawlingContext) -> None:
+        await context.page.wait_for_load_state()
+        navigation_headers.update(await context.response.request.all_headers())
+
+    await crawler.run([Request.from_url(start_url, headers={'authorization': 'Bearer secret-token'})])
+
+    assert navigation_headers.get('authorization') == 'Bearer secret-token'
+    assert subresource_headers
+    assert 'authorization' not in subresource_headers
 
 
 async def test_pre_navigation_hook() -> None:


### PR DESCRIPTION
## Description

- `PlaywrightCrawler._navigate()` applied `Request.headers` page-wide via `page.set_extra_http_headers()`, so the browser attached them to every request the page initiated - including cross-origin subresources chosen by the crawled page. Sensitive per-request values (e.g. `Authorization`) could leak to third-party origins.
- Headers are now applied through the route interceptor already used for non-GET requests, matched to the first main-frame navigation request itself rather than to its URL (a URL match breaks on browser URL normalization and on glob metacharacters in the URL). The interceptor merges the custom headers into the headers the browser sends on its own (`User-Agent`, fingerprint headers) instead of replacing them.
- Behavior change: custom headers are sent with the navigation request (and inherited by its redirect hops), but no longer with any page-initiated request afterwards - subresources, XHRs, or later client-side navigations.
- Covers `PlaywrightCrawler`, `AdaptivePlaywrightCrawler`, and `StagehandCrawler`, which all share `_navigate()`. Mirrors how crawlee JS scopes request headers in `gotoExtended`.
- Added regression tests: cross-origin subresources don't receive the headers, browser-normalized URLs still do, and redirect hops inherit them.

*✍️ Drafted by Claude Code*