### PR TITLE
docs: fix code block line number alignment

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -629,8 +629,6 @@ html[data-theme='dark'] .runnable-code-block svg .apify-logo {
     min-width: 1.5rem;
     display: inline-block;
     opacity: .3;
-    position: sticky;
-    left: var(--ifm-pre-padding);
 }
 
 div[class^="announcementBar_"] {


### PR DESCRIPTION
The line numbers were `position: sticky`, so they stayed pinned and overlapped the code.

|before|after|
|---|---|
| <img width="784" height="520" alt="image" src="https://github.com/user-attachments/assets/c10ac6da-6cf2-4c36-ab90-0dc594c3ab56" /> |  <img width="867" height="647" alt="image" src="https://github.com/user-attachments/assets/b27b99c7-d7af-466c-aab6-bfa0b83838f2" /> |