### PR TITLE
test: mark test_error_snapshot_through_statistics with run_alone to deflake CI

### DIFF
--- a/tests/unit/crawlers/_playwright/test_playwright_crawler.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_crawler.py
@@ -719,6 +719,7 @@ async def test_get_snapshot(server_url: URL) -> None:
     assert snapshot.html == HELLO_WORLD.decode('utf-8')
 
 
+@pytest.mark.run_alone
 async def test_error_snapshot_through_statistics(server_url: URL) -> None:
     """Test correct use of error snapshotter by the Playwright crawler.
 


### PR DESCRIPTION
Fixes flaky \`test_error_snapshot_through_statistics\` on macOS CI ([run 32569736015](https://github.com/apify/crawlee-python/actions/runs/32569736015/job/97350933296)): Chromium intermittently fails \`Page.screenshot()\` with \`Protocol error: Unable to capture screenshot\` under xdist worker contention on the small macOS runner, so \`get_snapshot()\` degrades to \`screenshot=None\` and the test finds 3 KVS artifacts instead of 4.

Same root cause as #2150 (\`test_get_snapshot\`, same file). Fix: \`@pytest.mark.run_alone\` moves the test to the serial pass, matching the other browser-resource-sensitive tests in this file.

*✍️ Drafted by Claude Code*