### PR TITLE
fix(http-clients): reject a non-positive timeout instead of silently ignoring it

### DIFF
--- a/src/crawlee/crawlers/_playwright/_playwright_http_client.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_http_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import contextvars
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import TYPE_CHECKING
@@ -90,13 +91,15 @@ class PlaywrightHttpClient(HttpClient):
         if browser_context is None:
             raise RuntimeError('Unable to create an `APIRequestContext` outside the browser context')
 
+        self._raise_if_non_positive_timeout(timeout)
+
         # Proxies appropriate to the browser context are used
         response = await browser_context.request.fetch(
             url_or_request=url,
             method=method.lower(),
             headers=dict(headers) if headers else None,
             data=payload,
-            timeout=timeout.total_seconds() if timeout else None,
+            timeout=timeout.total_seconds() if timeout is not None else None,
         )
 
         return await PlaywrightHttpResponse.from_playwright_response(response, protocol='')
@@ -114,6 +117,16 @@ class PlaywrightHttpClient(HttpClient):
         timeout: timedelta | None = None,
     ) -> AbstractAsyncContextManager[HttpResponse]:
         raise NotImplementedError('The `stream` method should not be used for `PlaywrightHttpClient`')
+
+    @staticmethod
+    def _raise_if_non_positive_timeout(timeout: timedelta | None) -> None:
+        """Raise `asyncio.TimeoutError` for a non-positive timeout.
+
+        Playwright treats an explicit `0` timeout as "disable timeout", so a non-positive timeout must be
+        rejected here instead of being forwarded as-is.
+        """
+        if timeout is not None and timeout.total_seconds() <= 0:
+            raise asyncio.TimeoutError
 
     async def cleanup(self) -> None:
         # The `browser_page_context` is responsible for resource cleanup

--- a/src/crawlee/http_clients/_curl_impersonate.py
+++ b/src/crawlee/http_clients/_curl_impersonate.py
@@ -176,6 +176,11 @@ class CurlImpersonateHttpClient(HttpClient):
     ) -> HttpCrawlingResult:
         client = self._get_client(proxy_info.url if proxy_info else None)
 
+        # `curl_cffi` (like `libcurl`) treats an explicit `0` timeout as "no timeout", so a non-positive
+        # timeout must be rejected here instead of being forwarded as-is.
+        if timeout is not None and timeout.total_seconds() <= 0:
+            raise asyncio.TimeoutError
+
         try:
             response = await client.request(
                 url=request.url,
@@ -183,7 +188,7 @@ class CurlImpersonateHttpClient(HttpClient):
                 headers=request.headers,
                 data=request.payload,
                 cookies=session.cookies.jar if session else None,
-                timeout=timeout.total_seconds() if timeout else None,
+                timeout=timeout.total_seconds() if timeout is not None else None,
             )
         except Timeout as exc:
             raise asyncio.TimeoutError from exc
@@ -225,6 +230,11 @@ class CurlImpersonateHttpClient(HttpClient):
         proxy_url = proxy_info.url if proxy_info else None
         client = self._get_client(proxy_url)
 
+        # `curl_cffi` (like `libcurl`) treats an explicit `0` timeout as "no timeout", so a non-positive
+        # timeout must be rejected here instead of being forwarded as-is.
+        if timeout is not None and timeout.total_seconds() <= 0:
+            raise asyncio.TimeoutError
+
         try:
             response = await client.request(
                 url=url,
@@ -232,7 +242,7 @@ class CurlImpersonateHttpClient(HttpClient):
                 headers=dict(headers) if headers else None,
                 data=payload,
                 cookies=session.cookies.jar if session else None,
-                timeout=timeout.total_seconds() if timeout else None,
+                timeout=timeout.total_seconds() if timeout is not None else None,
             )
         except Timeout as exc:
             raise asyncio.TimeoutError from exc
@@ -268,6 +278,11 @@ class CurlImpersonateHttpClient(HttpClient):
         proxy_url = proxy_info.url if proxy_info else None
         client = self._get_client(proxy_url)
 
+        # `curl_cffi` (like `libcurl`) treats an explicit `0` timeout as "no timeout", so a non-positive
+        # timeout must be rejected here instead of being forwarded as-is.
+        if timeout is not None and timeout.total_seconds() <= 0:
+            raise asyncio.TimeoutError
+
         try:
             response = await client.request(
                 url=url,
@@ -276,7 +291,7 @@ class CurlImpersonateHttpClient(HttpClient):
                 data=payload,
                 cookies=session.cookies.jar if session else None,
                 stream=True,
-                timeout=timeout.total_seconds() if timeout else None,
+                timeout=timeout.total_seconds() if timeout is not None else None,
             )
         except Timeout as exc:
             raise asyncio.TimeoutError from exc

--- a/src/crawlee/http_clients/_curl_impersonate.py
+++ b/src/crawlee/http_clients/_curl_impersonate.py
@@ -175,11 +175,7 @@ class CurlImpersonateHttpClient(HttpClient):
         timeout: timedelta | None = None,
     ) -> HttpCrawlingResult:
         client = self._get_client(proxy_info.url if proxy_info else None)
-
-        # `curl_cffi` (like `libcurl`) treats an explicit `0` timeout as "no timeout", so a non-positive
-        # timeout must be rejected here instead of being forwarded as-is.
-        if timeout is not None and timeout.total_seconds() <= 0:
-            raise asyncio.TimeoutError
+        self._raise_if_non_positive_timeout(timeout)
 
         try:
             response = await client.request(
@@ -229,11 +225,7 @@ class CurlImpersonateHttpClient(HttpClient):
 
         proxy_url = proxy_info.url if proxy_info else None
         client = self._get_client(proxy_url)
-
-        # `curl_cffi` (like `libcurl`) treats an explicit `0` timeout as "no timeout", so a non-positive
-        # timeout must be rejected here instead of being forwarded as-is.
-        if timeout is not None and timeout.total_seconds() <= 0:
-            raise asyncio.TimeoutError
+        self._raise_if_non_positive_timeout(timeout)
 
         try:
             response = await client.request(
@@ -277,11 +269,7 @@ class CurlImpersonateHttpClient(HttpClient):
 
         proxy_url = proxy_info.url if proxy_info else None
         client = self._get_client(proxy_url)
-
-        # `curl_cffi` (like `libcurl`) treats an explicit `0` timeout as "no timeout", so a non-positive
-        # timeout must be rejected here instead of being forwarded as-is.
-        if timeout is not None and timeout.total_seconds() <= 0:
-            raise asyncio.TimeoutError
+        self._raise_if_non_positive_timeout(timeout)
 
         try:
             response = await client.request(
@@ -332,6 +320,16 @@ class CurlImpersonateHttpClient(HttpClient):
             self._client_by_proxy_url[proxy_url] = _AsyncSession(**kwargs)
 
         return self._client_by_proxy_url[proxy_url]
+
+    @staticmethod
+    def _raise_if_non_positive_timeout(timeout: timedelta | None) -> None:
+        """Raise `asyncio.TimeoutError` for a non-positive timeout.
+
+        `curl_cffi` (like `libcurl`) treats an explicit `0` timeout as "no timeout", so a non-positive timeout
+        must be rejected here instead of being forwarded as-is.
+        """
+        if timeout is not None and timeout.total_seconds() <= 0:
+            raise asyncio.TimeoutError
 
     def _convert_method(self, method: HttpMethod) -> CurlHttpMethod:
         """Convert from Crawlee HTTP method to curl-cffi HTTP method.

--- a/src/crawlee/http_clients/_httpx.py
+++ b/src/crawlee/http_clients/_httpx.py
@@ -286,7 +286,7 @@ class HttpxHttpClient(HttpClient):
             headers=headers,
             payload=payload,
             session=session,
-            timeout=httpx.Timeout(None, connect=timeout.total_seconds()) if timeout else None,
+            timeout=httpx.Timeout(None, connect=timeout.total_seconds()) if timeout is not None else None,
         )
 
         try:

--- a/src/crawlee/http_clients/_impit.py
+++ b/src/crawlee/http_clients/_impit.py
@@ -308,7 +308,7 @@ class ImpitHttpClient(HttpClient):
         current_url = URL(url, encoded=True)
         content = payload
         # The timeout bounds the whole chain rather than each hop, which is how `impit` treats it as well.
-        deadline = monotonic() + timeout.total_seconds() if timeout else None
+        deadline = monotonic() + timeout.total_seconds() if timeout is not None else None
 
         for _ in range(self._max_redirects + 1):
             remaining = deadline - monotonic() if deadline is not None else None

--- a/tests/unit/crawlers/_playwright/test_playwright_http_client.py
+++ b/tests/unit/crawlers/_playwright/test_playwright_http_client.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from crawlee.crawlers._playwright._playwright_http_client import PlaywrightHttpClient, browser_page_context
+
+
+async def test_send_request_zero_timeout_expires_immediately() -> None:
+    """A `timedelta(0)` timeout must expire immediately rather than being forwarded as "disable timeout"."""
+    page = Mock()
+    page.request.fetch = AsyncMock()
+    client = PlaywrightHttpClient()
+
+    async with browser_page_context(page):
+        with pytest.raises(asyncio.TimeoutError):
+            await client.send_request('https://example.com', timeout=timedelta(0))
+
+    page.request.fetch.assert_not_awaited()

--- a/tests/unit/http_clients/test_http_clients.py
+++ b/tests/unit/http_clients/test_http_clients.py
@@ -59,6 +59,29 @@ async def test_send_request_zero_timeout_expires_immediately(http_client: HttpCl
     assert time.monotonic() - start < 1
 
 
+async def test_crawl_zero_timeout_expires_immediately(http_client: HttpClient, server_url: URL) -> None:
+    """A `timedelta(0)` timeout must expire immediately rather than being silently treated as no timeout."""
+    slow_url = str((server_url / 'slow').with_query(delay=2))
+    start = time.monotonic()
+
+    with pytest.raises(asyncio.TimeoutError):
+        await http_client.crawl(Request.from_url(slow_url), timeout=timedelta(0))
+
+    assert time.monotonic() - start < 1
+
+
+async def test_stream_zero_timeout_expires_immediately(http_client: HttpClient, server_url: URL) -> None:
+    """A `timedelta(0)` timeout must expire immediately rather than being silently treated as no timeout."""
+    slow_url = str((server_url / 'slow').with_query(delay=2))
+    start = time.monotonic()
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with http_client.stream(slow_url, timeout=timedelta(0)):
+            pass
+
+    assert time.monotonic() - start < 1
+
+
 async def test_http_1(http_client: HttpClient, server_url: URL) -> None:
     response = await http_client.send_request(str(server_url))
     assert response.http_version == 'HTTP/1.1'

--- a/tests/unit/http_clients/test_http_clients.py
+++ b/tests/unit/http_clients/test_http_clients.py
@@ -5,6 +5,8 @@ import importlib
 import json
 import os
 import sys
+import time
+from datetime import timedelta
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -44,6 +46,17 @@ async def custom_http_client(request: SubRequest) -> AsyncGenerator[HttpClient]:
 
 async def read_json(response: HttpResponse) -> dict:
     return json.loads((await response.read()).decode())
+
+
+async def test_send_request_zero_timeout_expires_immediately(http_client: HttpClient, server_url: URL) -> None:
+    """A `timedelta(0)` timeout must expire immediately rather than being silently treated as no timeout."""
+    slow_url = str((server_url / 'slow').with_query(delay=2))
+    start = time.monotonic()
+
+    with pytest.raises(asyncio.TimeoutError):
+        await http_client.send_request(slow_url, timeout=timedelta(0))
+
+    assert time.monotonic() - start < 1
 
 
 async def test_http_1(http_client: HttpClient, server_url: URL) -> None:


### PR DESCRIPTION
Follow-up to #2174: a `timedelta(0)` timeout is falsy, so `if timeout else None`-style checks silently dropped it and treated it as "no timeout" instead of "expire immediately".

- `ImpitHttpClient` and `HttpxHttpClient.stream()` only needed the `is not None` fix — both already enforce an explicit `0` timeout correctly on their own.
- `CurlImpersonateHttpClient` needed more: `curl_cffi` (via `libcurl`) treats an explicit `timeout=0` as *no timeout*, so the same fix alone doesn't change observable behavior there. Added an explicit guard in `crawl`, `send_request`, and `stream` that raises `asyncio.TimeoutError` immediately for a non-positive timeout, verified against a real slow endpoint.
- `PlaywrightHttpClient` needed the same guard as `CurlImpersonateHttpClient`: Playwright's `APIRequestContext.fetch` also treats an explicit `timeout=0` as "disable timeout". #2174 originally carried this fix; it's included here instead so all four HTTP clients are covered in one place.
- Added a regression test covering all four clients.

*✍️ Drafted by Claude Code*
