### PR TITLE
test: pin proxy fixture to a single worker/acceptor to deflake Windows CI

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -128,6 +128,12 @@ async def proxy(proxy_info: ProxyInfo) -> AsyncGenerator[ProxyInfo, None]:
             str(proxy_info.port),
             '--basic-auth',
             f'{proxy_info.username}:{proxy_info.password}',
+            # Without this, `Proxy` spawns one acceptor and one executor process per CPU core, which is
+            # unnecessary for a single-test proxy and crashes xdist workers under parallel CI load.
+            '--num-workers',
+            '1',
+            '--num-acceptors',
+            '1',
         ]
     ):
         yield proxy_info
@@ -144,6 +150,10 @@ async def disabled_proxy(proxy_info: ProxyInfo) -> AsyncGenerator[ProxyInfo, Non
             '--basic-auth',
             f'{proxy_info.username}:{proxy_info.password}',
             '--disable-http-proxy',
+            '--num-workers',
+            '1',
+            '--num-acceptors',
+            '1',
         ]
     ):
         yield proxy_info


### PR DESCRIPTION
Fixes flaky `test_proxy_kwarg_works_against_a_real_proxy` on Windows CI ([run 32528651226](https://github.com/apify/crawlee-python/actions/runs/32528651226/job/96916028382)): an xdist worker crashed ("node down: Not properly terminated") while starting the real local proxy.

Root cause: the `proxy`/`disabled_proxy` fixtures start `proxy.py`'s `Proxy(...)` without `--num-workers`/`--num-acceptors`, so it defaults both to `multiprocessing.cpu_count()` — spawning ~8 extra OS processes (confirmed empirically) for a single-test proxy. Under xdist's own parallel workers on a resource-constrained Windows runner, this process-spawn amplification crashed a worker. `proxy.py`'s own test harness (`proxy/testing/test_case.py`) pins `--num-workers 1 --num-acceptors 1` for exactly this reason.

Fix: add the same flags to both fixtures, cutting the fixture's spawned processes from ~8 to 1.

Verified 40/40 clean runs of the affected test modules under `-n auto` after the fix (previously confirmed 8 child processes spawned per fixture use before the fix vs. 1 after).

*✍️ Drafted by Claude Code*