### PR TITLE
fix(templates): Decouple the Camoufox Playwright version from other images

### DIFF
--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
@@ -6,10 +6,14 @@
    `playwright` version resolved by the lockfile so the installed package matches the browser
    binaries shipped in the base image. #}
 # % set playwright_version = '1.60.0'
+{# Camoufox ships its own Firefox build and caps the Playwright version it supports, so it keeps
+   an explicit compatible version instead of following the automatically updated shared pin. #}
+# % set camoufox_playwright_version = '1.60.0'
 
 # % if cookiecutter.crawler_type == 'playwright' or cookiecutter.crawler_type.startswith('adaptive-') or cookiecutter.crawler_type == 'stagehand'
 # % set base_image = 'apify/actor-python-playwright:3.13-' ~ playwright_version
 # % elif cookiecutter.crawler_type == 'playwright-camoufox'
+# % set playwright_version = camoufox_playwright_version
 # % set base_image = 'apify/actor-python-playwright-camoufox:3.13-' ~ playwright_version
 # % elif cookiecutter.crawler_type == 'playwright-chrome'
 # % set base_image = 'apify/actor-python-playwright-chrome:3.13-' ~ playwright_version


### PR DESCRIPTION
### Description

Pin `camoufox_playwright_version` to make it independent of other Playwright versions used in non-Camoufox images

### Issues

- Closes: #2175

