### PR TITLE
test: Deflake adaptive crawler routing tests against request retries

### DIFF
--- a/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
+++ b/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
@@ -80,7 +80,11 @@ async def key_value_store() -> AsyncGenerator[KeyValueStore, None]:
 
 
 class _SimpleRenderingTypePredictor(RenderingTypePredictor):
-    """Simplified predictor for tests."""
+    """Simplified predictor for tests.
+
+    Predictions are memoized per URL, so a request that gets retried keeps the rendering type it was first
+    assigned instead of consuming the next value from the iterators.
+    """
 
     def __init__(
         self,
@@ -92,10 +96,15 @@ class _SimpleRenderingTypePredictor(RenderingTypePredictor):
         default_rendering_types: list[RenderingType] = ['static']
         self._rendering_types = rendering_types or cycle(default_rendering_types)
         self._detection_probability_recommendation = detection_probability_recommendation or cycle([1])
+        self._predictions = dict[str, RenderingTypePrediction]()
 
     @override
     def predict(self, request: Request) -> RenderingTypePrediction:
-        return RenderingTypePrediction(next(self._rendering_types), next(self._detection_probability_recommendation))
+        if request.url not in self._predictions:
+            self._predictions[request.url] = RenderingTypePrediction(
+                next(self._rendering_types), next(self._detection_probability_recommendation)
+            )
+        return self._predictions[request.url]
 
     @override
     def store_result(self, request: Request, rendering_type: RenderingType) -> None:
@@ -169,43 +178,39 @@ async def test_adaptive_crawling(
         rendering_type_predictor=predictor,
     )
 
-    pw_handler_count = 0
-    static_handler_count = 0
+    # Collected as URL sets rather than call counters. A sub crawler failure makes `BasicCrawler` retry the whole
+    # request, which runs the hooks and handlers for that URL again, and only the routing is under test here.
+    pw_handler_urls = set[str]()
+    static_handler_urls = set[str]()
 
-    pw_hook_count = 0
-    static_hook_count = 0
+    pw_hook_urls = set[str]()
+    static_hook_urls = set[str]()
 
     @crawler.router.default_handler
     async def request_handler(context: AdaptivePlaywrightCrawlingContext) -> None:
-        nonlocal pw_handler_count
-        nonlocal static_handler_count
-
         try:
             # page is available only if it was crawled by PlaywrightCrawler.
             context.page  # noqa:B018 Intentionally "useless expression". Can trigger exception.
-            pw_handler_count += 1
+            pw_handler_urls.add(context.request.url)
         except AdaptiveContextError:
-            static_handler_count += 1
+            static_handler_urls.add(context.request.url)
 
     @crawler.pre_navigation_hook
-    async def pre_nav_hook(context: AdaptivePlaywrightPreNavCrawlingContext) -> None:  # Intentionally unused arg
-        nonlocal static_hook_count
-        nonlocal pw_hook_count
-
+    async def pre_nav_hook(context: AdaptivePlaywrightPreNavCrawlingContext) -> None:
         try:
             # page is available only if it was crawled by PlaywrightCrawler.
             context.page  # noqa:B018 Intentionally "useless expression". Can trigger exception.
-            pw_hook_count += 1
+            pw_hook_urls.add(context.request.url)
         except AdaptiveContextError:
-            static_hook_count += 1
+            static_hook_urls.add(context.request.url)
 
     await crawler.run(test_urls)
 
-    assert pw_handler_count == test_input.expected_pw_count
-    assert pw_hook_count == test_input.expected_pw_count
+    assert len(pw_handler_urls) == test_input.expected_pw_count
+    assert len(pw_hook_urls) == test_input.expected_pw_count
 
-    assert static_handler_count == test_input.expected_static_count
-    assert static_hook_count == test_input.expected_static_count
+    assert len(static_handler_urls) == test_input.expected_static_count
+    assert len(static_hook_urls) == test_input.expected_static_count
 
 
 async def test_adaptive_crawling_parsel(test_urls: list[str]) -> None:
@@ -219,25 +224,22 @@ async def test_adaptive_crawling_parsel(test_urls: list[str]) -> None:
         rendering_type_predictor=predictor,
     )
 
-    pw_handler_count = 0
-    static_handler_count = 0
+    pw_handler_urls = set[str]()
+    static_handler_urls = set[str]()
 
     @crawler.router.default_handler
     async def request_handler(context: AdaptivePlaywrightCrawlingContext) -> None:
-        nonlocal pw_handler_count
-        nonlocal static_handler_count
-
         try:
             # page is available only if it was crawled by PlaywrightCrawler.
             context.page  # noqa:B018 Intentionally "useless expression". Can trigger exception.
-            pw_handler_count += 1
+            pw_handler_urls.add(context.request.url)
         except AdaptiveContextError:
-            static_handler_count += 1
+            static_handler_urls.add(context.request.url)
 
     await crawler.run(test_urls)
 
-    assert pw_handler_count == 1
-    assert static_handler_count == 1
+    assert len(pw_handler_urls) == 1
+    assert len(static_handler_urls) == 1
 
 
 @pytest.mark.flaky(

--- a/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
+++ b/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
@@ -82,8 +82,8 @@ async def key_value_store() -> AsyncGenerator[KeyValueStore, None]:
 class _SimpleRenderingTypePredictor(RenderingTypePredictor):
     """Simplified predictor for tests.
 
-    Predictions are memoized per URL, so a request that gets retried keeps the rendering type it was first
-    assigned instead of consuming the next value from the iterators.
+    Predictions are memoized per URL, so a request that gets retried keeps the rendering type it was first assigned
+    instead of consuming the next value from the iterators.
     """
 
     def __init__(
@@ -178,8 +178,8 @@ async def test_adaptive_crawling(
         rendering_type_predictor=predictor,
     )
 
-    # Collected as URL sets rather than call counters. A sub crawler failure makes `BasicCrawler` retry the whole
-    # request, which runs the hooks and handlers for that URL again, and only the routing is under test here.
+    # `BasicCrawler` retries the whole request when a sub crawler fails, so hooks and handlers can run more than once
+    # per URL. Only the routing is under test, so sets keep the assertions insensitive to that.
     pw_handler_urls = set[str]()
     static_handler_urls = set[str]()
 
@@ -206,11 +206,15 @@ async def test_adaptive_crawling(
 
     await crawler.run(test_urls)
 
-    assert len(pw_handler_urls) == test_input.expected_pw_count
-    assert len(pw_hook_urls) == test_input.expected_pw_count
+    # Each URL must reach the hook and the handler of the same sub crawler.
+    assert pw_hook_urls == pw_handler_urls
+    assert static_hook_urls == static_handler_urls
 
+    assert len(pw_handler_urls) == test_input.expected_pw_count
     assert len(static_handler_urls) == test_input.expected_static_count
-    assert len(static_hook_urls) == test_input.expected_static_count
+
+    # The sizes alone would also be satisfied by one URL taking both routes and the other never being crawled.
+    assert pw_handler_urls | static_handler_urls == set(test_urls)
 
 
 async def test_adaptive_crawling_parsel(test_urls: list[str]) -> None:
@@ -240,6 +244,7 @@ async def test_adaptive_crawling_parsel(test_urls: list[str]) -> None:
 
     assert len(pw_handler_urls) == 1
     assert len(static_handler_urls) == 1
+    assert pw_handler_urls | static_handler_urls == set(test_urls)
 
 
 @pytest.mark.flaky(


### PR DESCRIPTION
`test_adaptive_crawling[Enforced rendering type detection]` fails intermittently on Windows CI with
`assert 4 == 2` ([example run](https://github.com/apify/crawlee-python/actions/runs/32976162639/job/98201309967)).
When the Playwright sub-crawl stalls and times out, `BasicCrawler` retries the whole request - which is correct
behavior - but the test counts every hook and handler invocation and pulls each rendering type from a shared
`cycle()`. The retry therefore fires the pre-navigation hook a second time for the same URL and advances the cycle,
so the expected `2` becomes `4`.

The fix makes the assertions insensitive to retries instead of tolerating them:

- `test_adaptive_crawling` and `test_adaptive_crawling_parsel` assert the set of URLs routed to each sub crawler
  rather than raw invocation counters.
- `_SimpleRenderingTypePredictor` memoizes its prediction per URL, so a retried request keeps the rendering type it
  was first assigned.

Verified with deterministic fault injection - patching `PlaywrightCrawler._navigate` to fail the first navigation
per URL, which runs after the pre-navigation hooks and so reproduces the CI sequence exactly. Before the change 4
of the 5 affected cases fail, including the exact `assert 4 == 2`; after it all pass, plus 0/100 failures under a
repeated parallel run.

No production code is touched, and the routing property under test is unchanged: wrong routing, a missing
pre-navigation hook, or a URL reaching both sub crawlers all still fail.

*✍️ Drafted by Claude Code*
