### PR TITLE
test: Rebalance parallel test scheduling and trim fixture overhead

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,7 +263,7 @@ builtins-ignorelist = ["id"]
 known-first-party = ["crawlee"]
 
 [tool.pytest.ini_options]
-addopts = "-r a --verbose"
+addopts = "-r a --verbose --dist worksteal"
 asyncio_default_fixture_loop_scope = "function"
 asyncio_mode = "auto"
 timeout = 1800
@@ -339,7 +339,6 @@ shell = "uv run ruff check --fix && uv run ruff format"
 [tool.poe.tasks.unit-tests]
 shell = """
 uv run pytest \
-    --numprocesses=1 \
     -m "run_alone" \
     tests/unit && \
 uv run pytest \
@@ -349,9 +348,10 @@ uv run pytest \
 """
 
 [tool.poe.tasks.unit-tests-cov]
+# Falls back to the default core with a warning on Python < 3.12.
+env = { COVERAGE_CORE = "sysmon" }
 shell = """
 uv run pytest \
-    --numprocesses=1 \
     -m "run_alone" \
     --cov=src/crawlee \
     --cov-report=xml:coverage-unit.xml \

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -103,23 +103,37 @@ def _set_crawler_log_level(pytestconfig: pytest.Config, monkeypatch: pytest.Monk
         monkeypatch.setattr(_log_config, 'get_configured_log_level', lambda: getattr(logging, loglevel.upper()))
 
 
-@pytest.fixture
-async def proxy_info(unused_tcp_port: int) -> ProxyInfo:
+def _proxy_info(port: int) -> ProxyInfo:
+    """Describe a local proxy listening on `port`, authenticated with fixed throwaway credentials."""
     username = 'user'
     password = 'pass'
 
     return ProxyInfo(
-        url=f'http://{username}:{password}@127.0.0.1:{unused_tcp_port}',
+        url=f'http://{username}:{password}@127.0.0.1:{port}',
         scheme='http',
         hostname='127.0.0.1',
-        port=unused_tcp_port,
+        port=port,
         username=username,
         password=password,
     )
 
 
-@pytest.fixture
-async def proxy(proxy_info: ProxyInfo) -> AsyncGenerator[ProxyInfo, None]:
+# Session-scoped because a `Proxy` teardown blocks for up to a second on its acceptor's
+# `selector.select(timeout=1)`. Sync because a session-scoped async fixture is incompatible with
+# `asyncio_default_fixture_loop_scope = "function"`.
+@pytest.fixture(scope='session')
+def proxy_info(unused_tcp_port_factory: Callable[[], int]) -> ProxyInfo:
+    return _proxy_info(unused_tcp_port_factory())
+
+
+@pytest.fixture(scope='session')
+def disabled_proxy_info(unused_tcp_port_factory: Callable[[], int]) -> ProxyInfo:
+    """Describe the disabled proxy, which needs a port of its own now that both servers outlive a test."""
+    return _proxy_info(unused_tcp_port_factory())
+
+
+@pytest.fixture(scope='session')
+def proxy(proxy_info: ProxyInfo) -> Iterator[ProxyInfo]:
     with Proxy(
         [
             '--hostname',
@@ -139,16 +153,16 @@ async def proxy(proxy_info: ProxyInfo) -> AsyncGenerator[ProxyInfo, None]:
         yield proxy_info
 
 
-@pytest.fixture
-async def disabled_proxy(proxy_info: ProxyInfo) -> AsyncGenerator[ProxyInfo, None]:
+@pytest.fixture(scope='session')
+def disabled_proxy(disabled_proxy_info: ProxyInfo) -> Iterator[ProxyInfo]:
     with Proxy(
         [
             '--hostname',
-            proxy_info.hostname,
+            disabled_proxy_info.hostname,
             '--port',
-            str(proxy_info.port),
+            str(disabled_proxy_info.port),
             '--basic-auth',
-            f'{proxy_info.username}:{proxy_info.password}',
+            f'{disabled_proxy_info.username}:{disabled_proxy_info.password}',
             '--disable-http-proxy',
             '--num-workers',
             '1',
@@ -156,7 +170,7 @@ async def disabled_proxy(proxy_info: ProxyInfo) -> AsyncGenerator[ProxyInfo, Non
             '1',
         ]
     ):
-        yield proxy_info
+        yield disabled_proxy_info
 
 
 @pytest.fixture(scope='session')

--- a/tests/unit/crawlers/_playwright/test_utils.py
+++ b/tests/unit/crawlers/_playwright/test_utils.py
@@ -20,12 +20,13 @@ async def test_infinite_scroll_on_dynamic_page(server_url: URL) -> None:
         # Get data with manual scrolling
         await page.goto(target_url)
 
-        manual_items = []
-        for _ in range(4):
-            items = await page.query_selector_all('.item')
-            manual_items = items
+        # The page appends one batch of items per scroll, for three batches. Wait for each batch to land
+        # instead of sleeping, so the baseline costs as long as the page takes rather than a fixed 4 seconds.
+        manual_items = await page.query_selector_all('.item')
+        for _ in range(3):
             await page.evaluate('window.scrollTo(0, document.body.scrollHeight)')
-            await page.wait_for_timeout(1000)
+            await page.wait_for_function(f'document.querySelectorAll(".item").length > {len(manual_items)}')
+            manual_items = await page.query_selector_all('.item')
 
         # Reset page
         await page.close()


### PR DESCRIPTION
The unit suite spends most of its wall-clock waiting. On a reference CI job (`ubuntu-latest / 3.14`, run 33047203526) the main pass does 578 worker-seconds of work in 131.8s across 8 workers and burns 476 of them idle. `--dist load` seeds each worker with a fixed chunk of consecutive tests and never reassigns, so `gw4` was still running `_playwright/test_utils.py` at 125s with the other seven idle for about a minute. Perfect balance would finish at 72.3s.

Same failure mode as apify/apify-client-python#1037.

## Changes

1. **`--dist worksteal` in `addopts`** so an idle worker takes over tests still queued on a busy one. Nothing in the repo uses `xdist_group`, and `--dist` is inert without `-n`.
2. **`proxy` and `disabled_proxy` are session-scoped and sync.** Each teardown blocks ~1s on proxy.py's hardcoded `selector.select(timeout=1)`; with 17 servers built and destroyed that is ~17 worker-seconds of pure waiting. The server is a stateless forwarder, so one per session is enough. Sync because a session-scoped async fixture is incompatible with `asyncio_default_fixture_loop_scope = "function"`, and neither ever awaited.
3. **Dropped `--numprocesses=1` from the `run_alone` pass** - it paid the full xdist worker bootstrap for a 15-test serial suite.
4. **`COVERAGE_CORE=sysmon` on `unit-tests-cov`.** Measured on a 1397-test subset: default core +14%, sysmon +0%. Coverage falls back with a warning where `sys.monitoring` is unavailable, so 3.10 and 3.11 are safe.
5. **`test_infinite_scroll_on_dynamic_page` waits on the page instead of the clock** - four `wait_for_timeout(1000)` sleeps for a `loadMore()` that awaits 100ms, on the critical-path worker.

## Measured

Full suite, both passes, same machine, two reps each: **~114s -> ~74s (-35%)**. These runs are without coverage, so change 4 is not reflected. 2456 tests pass on both sides; `ruff format`, `ruff check` and `ty` are clean.

## Not in this PR

- `from crawlee.crawlers import HttpCrawler` costs 3.51s, of which 1.28s is scikit-learn and scipy, imported eagerly by `_adaptive_playwright._rendering_type_predictor` (behind the optional `adaptive-crawler` extra). Every worker pays it, as does every `crawlee[all]` cold start. Not a one-liner - `RenderingTypePredictorState` needs `LogisticRegression` at class-creation time. Worth its own issue.
- 14 of the 15 matrix jobs compute coverage that is never uploaded; skipping it needs a change in `apify/workflows`.
- `tests_concurrency: "8"` may be 2x oversubscription on 4-vCPU runners; worth one run with `nproc` echoed and an `-n4` comparison.
- `test_http_2` still hits the real internet - it needs an HTTP/2 endpoint the local uvicorn server does not speak.

*✍️ Drafted by Claude Code*
