### PR TITLE
test: Deflake Redis RQ metadata timestamp test with a controlled clock

### DIFF
--- a/tests/unit/storage_clients/_redis/test_redis_rq_client.py
+++ b/tests/unit/storage_clients/_redis/test_redis_rq_client.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import timedelta
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from redis.exceptions import RedisError
 
 from crawlee import Request
 from crawlee.storage_clients import RedisStorageClient
+from crawlee.storage_clients._redis import _client_mixin
 from crawlee.storage_clients._redis._utils import await_redis_response
 
 if TYPE_CHECKING:
@@ -167,39 +169,34 @@ async def test_drop_removes_records(rq_client: RedisRequestQueueClient) -> None:
         assert handled_set_exists == 0
 
 
-async def test_metadata_file_updates(rq_client: RedisRequestQueueClient) -> None:
-    """Test that metadata file is updated correctly after operations."""
-    # Record initial timestamps
+async def test_metadata_record_updates(rq_client: RedisRequestQueueClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fetching bumps only `accessed_at`, adding requests bumps `modified_at` too, and `created_at` never changes."""
     metadata = await rq_client.get_metadata()
     initial_created = metadata.created_at
-    initial_accessed = metadata.accessed_at
     initial_modified = metadata.modified_at
 
-    # Wait a moment to ensure timestamps can change
-    await asyncio.sleep(0.01)
+    # Stamp the metadata updates from a controlled clock, so the checks don't depend on the wall clock resolution.
+    clock = Mock()
+    monkeypatch.setattr(_client_mixin, 'datetime', clock)
 
-    # Perform a read operation
-    await rq_client.is_empty()
+    read_time = metadata.accessed_at + timedelta(seconds=1)
+    clock.now.return_value = read_time
+    await rq_client.fetch_next_request()
 
-    # Verify accessed timestamp was updated
+    # `get_metadata()` reads the record before stamping its own access, so it reports the fetch's stamp.
     metadata = await rq_client.get_metadata()
     assert metadata.created_at == initial_created
-    assert metadata.accessed_at > initial_accessed
+    assert metadata.accessed_at == read_time
     assert metadata.modified_at == initial_modified
 
-    accessed_after_read = metadata.accessed_at
-
-    # Wait a moment to ensure timestamps can change
-    await asyncio.sleep(0.01)
-
-    # Perform a write operation
+    write_time = read_time + timedelta(seconds=1)
+    clock.now.return_value = write_time
     await rq_client.add_batch_of_requests([Request.from_url('https://example.com')])
 
-    # Verify modified timestamp was updated
     metadata = await rq_client.get_metadata()
     assert metadata.created_at == initial_created
-    assert metadata.modified_at > initial_modified
-    assert metadata.accessed_at > accessed_after_read
+    assert metadata.accessed_at == write_time
+    assert metadata.modified_at == write_time
 
 
 async def test_get_request(rq_client: RedisRequestQueueClient) -> None:


### PR DESCRIPTION
`test_metadata_file_updates` in `tests/unit/storage_clients/_redis/test_redis_rq_client.py` failed on Windows / Python 3.12 with `assert accessed_at > accessed_at` on identical timestamps ([run](https://github.com/apify/crawlee-python/actions/runs/33165535500/job/98829928097)).

The Redis `is_empty()` never stamps `accessed_at`, and `get_metadata()` reads the record before stamping its own access. The two values the test compared were therefore the stamps of two back-to-back `get_metadata()` calls (the fixture's purge check and the test's first call), about a millisecond apart, with the `asyncio.sleep(0.01)` sitting after both. On Windows before Python 3.13, `datetime.now()` ticks at 1–15.6 ms, so the stamps collide.

The test now drives the mixin's clock through a `Mock`, uses a read the Redis client does treat as an access (`fetch_next_request()`), and asserts the exact stamps – no sleeps, no wall clock. Removing the `accessed_at` update from `fetch_next_request()` makes it fail, so it still guards the behaviour.

Locally, quantizing the mixin clock to 15.625 ms ticks reproduced the failure 18/20 times (2/40 at 1 ms); the new test passes 20/20 and 40/40 under the same clocks, and the Redis test directory passes 20/20 with `-n auto`.

Note: `is_empty()` bumps `accessed_at` in the memory and file-system clients but not in the Redis one. Left as is here; worth deciding separately whether that's intended.

*✍️ Drafted by Claude Code*
