### PR TITLE
test: Deflake memory estimation test and restore its RSS regression coverage

### DIFF
--- a/tests/unit/_utils/test_system.py
+++ b/tests/unit/_utils/test_system.py
@@ -235,7 +235,6 @@ def test_memory_estimation_does_not_overestimate_due_to_shared_memory() -> None:
         children_count = 4
         # Memory calculation is not exact, so allow for some tolerance.
         test_tolerance = 0.3
-        # How many times the whole measurement is attempted before the expectation is declared unmet.
         measurement_rounds = 3
 
         def no_extra_memory_child(ready: synchronize.Barrier, measured: synchronize.Barrier) -> None:
@@ -256,10 +255,8 @@ def test_memory_estimation_does_not_overestimate_due_to_shared_memory() -> None:
             ready: synchronize.Barrier, measured: synchronize.Barrier, memory: SharedMemory
         ) -> None:
             assert memory.buf is not None
-            # Fault every page of the shared segment into this child before the measurement. A child that only maps
-            # the segment does not count it in either memory metric: untouched pages never enter its RSS, which would
-            # hide the very overcount this test guards against, and they are the coldest pages in the tree, so memory
-            # pressure makes the kernel reclaim them first, which pulls them out of the PSS of every mapper.
+            # Fault every page in: untouched pages never enter the RSS (hiding the overcount this test guards
+            # against) and are reclaimed first under memory pressure, which drops them from every mapper's PSS.
             page_sum = sum(memory.buf[::4096])
             print(f'Using the memory... {page_sum}')
             ready.wait()
@@ -300,11 +297,9 @@ def test_memory_estimation_does_not_overestimate_due_to_shared_memory() -> None:
 
             return (memory_during - memory_before).to_mb() / count
 
-        # A PSS reading moves with the state of the whole machine: under memory pressure the kernel reclaims the
-        # coldest pages, and a reclaimed page leaves the PSS of every process mapping it, which skews each phase's
-        # delta differently. A distorted round is re-measured instead of failing outright - transient reclaim does
-        # not repeat identically, while a genuine overcount of shared memory misses the expectation several times
-        # over in every round, so the retries cannot mask it.
+        # Under memory pressure the kernel reclaims cold pages, which silently leave the PSS readings and skew a
+        # round's deltas, so a distorted round is re-measured. A genuine overcount of shared memory misses the
+        # expectation several times over in every round, so the retries cannot mask it.
         for _ in range(measurement_rounds):
             additional_memory_simple_child = get_additional_memory_estimation_while_running_processes(
                 target=no_extra_memory_child, count=children_count

--- a/tests/unit/_utils/test_system.py
+++ b/tests/unit/_utils/test_system.py
@@ -235,6 +235,8 @@ def test_memory_estimation_does_not_overestimate_due_to_shared_memory() -> None:
         children_count = 4
         # Memory calculation is not exact, so allow for some tolerance.
         test_tolerance = 0.3
+        # How many times the whole measurement is attempted before the expectation is declared unmet.
+        measurement_rounds = 3
 
         def no_extra_memory_child(ready: synchronize.Barrier, measured: synchronize.Barrier) -> None:
             ready.wait()
@@ -254,7 +256,12 @@ def test_memory_estimation_does_not_overestimate_due_to_shared_memory() -> None:
             ready: synchronize.Barrier, measured: synchronize.Barrier, memory: SharedMemory
         ) -> None:
             assert memory.buf is not None
-            print(f'Using the memory... {memory.buf[-1]}')
+            # Fault every page of the shared segment into this child before the measurement. A child that only maps
+            # the segment does not count it in either memory metric: untouched pages never enter its RSS, which would
+            # hide the very overcount this test guards against, and they are the coldest pages in the tree, so memory
+            # pressure makes the kernel reclaim them first, which pulls them out of the PSS of every mapper.
+            page_sum = sum(memory.buf[::4096])
+            print(f'Using the memory... {page_sum}')
             ready.wait()
             measured.wait()
 
@@ -293,28 +300,40 @@ def test_memory_estimation_does_not_overestimate_due_to_shared_memory() -> None:
 
             return (memory_during - memory_before).to_mb() / count
 
-        additional_memory_simple_child = get_additional_memory_estimation_while_running_processes(
-            target=no_extra_memory_child, count=children_count
-        )
-        additional_memory_extra_memory_child = (
-            get_additional_memory_estimation_while_running_processes(target=extra_memory_child, count=children_count)
-            - additional_memory_simple_child
-        )
-        additional_memory_shared_extra_memory_child = (
-            get_additional_memory_estimation_while_running_processes(
-                target=shared_extra_memory_child, count=children_count, use_shared_memory=True
+        # A PSS reading moves with the state of the whole machine: under memory pressure the kernel reclaims the
+        # coldest pages, and a reclaimed page leaves the PSS of every process mapping it, which skews each phase's
+        # delta differently. A distorted round is re-measured instead of failing outright - transient reclaim does
+        # not repeat identically, while a genuine overcount of shared memory misses the expectation several times
+        # over in every round, so the retries cannot mask it.
+        for _ in range(measurement_rounds):
+            additional_memory_simple_child = get_additional_memory_estimation_while_running_processes(
+                target=no_extra_memory_child, count=children_count
             )
-            - additional_memory_simple_child
-        )
+            additional_memory_extra_memory_child = (
+                get_additional_memory_estimation_while_running_processes(
+                    target=extra_memory_child, count=children_count
+                )
+                - additional_memory_simple_child
+            )
+            additional_memory_shared_extra_memory_child = (
+                get_additional_memory_estimation_while_running_processes(
+                    target=shared_extra_memory_child, count=children_count, use_shared_memory=True
+                )
+                - additional_memory_simple_child
+            )
 
-        memory_estimation_difference_ratio = (
-            abs((additional_memory_shared_extra_memory_child * children_count) - additional_memory_extra_memory_child)
-            / additional_memory_extra_memory_child
-        )
+            memory_estimation_difference_ratio = (
+                abs(
+                    (additional_memory_shared_extra_memory_child * children_count)
+                    - additional_memory_extra_memory_child
+                )
+                / additional_memory_extra_memory_child
+            )
 
-        estimated_memory_expectation.value = memory_estimation_difference_ratio < test_tolerance
+            if memory_estimation_difference_ratio < test_tolerance:
+                estimated_memory_expectation.value = True
+                break
 
-        if not estimated_memory_expectation.value:
             print(
                 f'{additional_memory_shared_extra_memory_child=}\n'
                 f'{children_count=}\n'


### PR DESCRIPTION
`test_memory_estimation_does_not_overestimate_due_to_shared_memory` fails intermittently on Linux CI (e.g. [this run](https://github.com/apify/crawlee-python/actions/runs/33366608389/job/99408458117), ratio 0.52 vs the 0.3 tolerance; previously #1288). The sharing children only map the 100 MB segment and never touch it, so its pages are the coldest in the process tree — under memory pressure the kernel reclaims them first, and every reclaimed page silently leaves the PSS readings that the phase deltas are built from.

Two changes:

1. The sharing children now fault every page of the shared segment before the measurement. Besides removing the reclaim target, this restores the test's original purpose: untouched mappings never enter RSS either, so the test passed even with PSS unavailable — the exact overcount regression it was written to catch in #1210. With this change, a forced RSS fallback fails every round by ~11x the tolerance.
2. A distorted measurement round is retried (up to 3 rounds). Transient reclaim does not repeat identically, while a genuine overcount misses the expectation several times over in every round, so the retries cannot mask it.

Verified by reproducing CI's failure signature locally under cgroup memory pressure (`systemd-run -p MemoryHigh=` plus a hot-page churner): 2/10 failures before, 0/50 after, 0/40 idle runs, and the forced-RSS regression still fails deterministically.

*✍️ Drafted by Claude Code*
