### PR TITLE
test: Deflake adaptive statistics and browser plugin tests on slow CI runners

### DIFF
--- a/tests/unit/browsers/test_playwright_browser_plugin.py
+++ b/tests/unit/browsers/test_playwright_browser_plugin.py
@@ -40,7 +40,7 @@ async def test_new_browser(plugin: PlaywrightBrowserPlugin, server_url: URL) -> 
     assert browser_controller.is_browser_connected
 
     page = await browser_controller.new_page()
-    await page.goto(str(server_url))
+    await page.goto(str(server_url), timeout=60_000)
 
     await page.close()
     await browser_controller.close()

--- a/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
+++ b/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
@@ -492,6 +492,9 @@ async def test_adaptive_crawling_statistics(test_urls: list[str]) -> None:
     crawler = AdaptivePlaywrightCrawler.with_beautifulsoup_static_parser(
         rendering_type_predictor=static_only_predictor_no_detection,
         result_checker=lambda result: False,  #  noqa: ARG005  # Intentionally unused argument.
+        # Generous ceiling for each sub crawler run: a slow browser launch that exceeded it would make `BasicCrawler`
+        # retry the request and increment every counter below once more.
+        request_handler_timeout=timedelta(minutes=5),
     )
 
     @crawler.router.default_handler


### PR DESCRIPTION
Two unit tests flake on the Windows CI shard under parallel load ([example run](https://github.com/apify/crawlee-python/actions/runs/33367270395/job/99410412450)):

- `test_adaptive_crawling_statistics` asserts each adaptive counter equals exactly 1, but when a slow Chromium launch pushes the browser sub-crawl past the default 60s `request_handler_timeout`, `BasicCrawler` retries the request - correct behavior - and every counter increments again (`assert 2 == 1`). The test now passes a 5-minute `request_handler_timeout`, removing the retry trigger while keeping the exact-count assertions, so a real double-counting regression still fails it.
- `test_new_browser` ran `page.goto` with Playwright's default 30s timeout, which the first navigation on a saturated runner can exceed. Raised to 60s, matching `test_browser_pool.py`.

Verified with deterministic fault injection: a 70s stall in `BrowserPool.new_page` reproduced the exact CI failure before the fix and 0/3 failures after; a 40s-slow server reproduced the `goto` timeout with the default and passed with 60s. Plus 0/30 failures re-running both modules under `pytest -n auto`. No production code is touched.

*✍️ Drafted by Claude Code*