### PR TITLE
test: Deflake adaptive crawler timeout test against slow CI browser navigation

### DIFF
--- a/src/crawlee/crawlers/_playwright/_playwright_crawler.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_crawler.py
@@ -630,6 +630,9 @@ class _PlaywrightCrawlerAdditionalOptions(TypedDict):
     headless: NotRequired[bool]
     """Whether to run the browser in headless mode. This option should not be used if `browser_pool` is provided."""
 
+    navigation_timeout: NotRequired[timedelta]
+    """Timeout for navigation (the process between opening a Playwright page and calling the request handler)."""
+
 
 class PlaywrightCrawlerOptions(
     _PlaywrightCrawlerAdditionalOptions,

--- a/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
+++ b/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
@@ -601,6 +601,11 @@ async def test_adaptive_playwright_crawler_timeout_in_sub_crawler(test_urls: lis
         max_request_retries=0,
         rendering_type_predictor=static_only_predictor_no_detection,
         request_handler_timeout=request_handler_timeout,
+        # The fallback browser request navigates under its own `navigation_timeout` budget, separate from
+        # the request handler timeout relaxed in the handler below. Give it the same generous ceiling:
+        # with `max_request_retries=0`, a single navigation slower than the default budget on a loaded CI
+        # runner would fail the only attempt before the handler ever runs.
+        playwright_crawler_specific_kwargs={'navigation_timeout': timedelta(seconds=120)},
     )
     mocked_static_handler = Mock(name='static_handler')
     mocked_browser_handler = Mock(name='browser_handler')


### PR DESCRIPTION
`test_adaptive_playwright_crawler_timeout_in_sub_crawler` fails intermittently on Windows CI with
`Expected 'browser_handler' to be called once. Called 0 times.`
([example run](https://github.com/apify/crawlee-python/actions/runs/33467016711/job/99728873095)).
The fallback browser request navigates under the Playwright sub-crawler's own `navigation_timeout`
(default 1 minute) - a budget separate from the request handler timeout the test already relaxes to
120s. On a saturated runner (8 xdist workers, each driving Chromium) `page.goto` can exceed it, and
with `max_request_retries=0` that single slow navigation fails the only attempt before the handler
ever runs.

The test now grants navigation the same 120s ceiling via `playwright_crawler_specific_kwargs`. To
pass that type-safely, the missing `navigation_timeout` key is added to
`_PlaywrightCrawlerAdditionalOptions` - typing only, `PlaywrightCrawler.__init__` already accepts it.

Verified by deterministic fault injection (a playwright-only pre-navigation delay consuming the
shared navigation budget): a 70s navigation-phase delay reproduces the exact CI failure under the
default ceiling and passes under the 120s one. After the fix, 0/96 failures across 8 concurrent
Chromium-saturated lanes, and the adaptive + playwright test modules pass under `-n auto`. The
assertions are unchanged.

*✍️ Drafted by Claude Code*
