### PR TITLE
fix: Name the extra to install in optional-dependency import errors

### DIFF
--- a/src/crawlee/_utils/try_import.py
+++ b/src/crawlee/_utils/try_import.py
@@ -1,22 +1,40 @@
+from __future__ import annotations
+
 import sys
-from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from types import ModuleType
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from typing import Any
 
 
 @contextmanager
-def try_import(module_name: str, *symbol_names: str) -> Iterator[None]:
+def try_import(module_name: str, *symbol_names: str, extra_name: str | list[str]) -> Iterator[None]:
     """Context manager to attempt importing symbols into a module.
 
-    If an `ImportError` is raised during the import, the symbol will be replaced with a `FailedImport` object.
+    If an `ImportError` is raised during the import, the symbols are replaced with `FailedImport` objects. When the
+    error is a `ModuleNotFoundError`, the message also names the optional extra (or one of several) that installs the
+    missing dependency. Other import errors, including those raised by a nested guard, keep their message as is.
     """
     try:
         yield
     except ImportError as e:
+        message = e.args[0]
+        if isinstance(e, ModuleNotFoundError):
+            message = f'{message}. {_get_install_hint(extra_name)}'
         for symbol_name in symbol_names:
-            setattr(sys.modules[module_name], symbol_name, FailedImport(e.args[0]))
+            setattr(sys.modules[module_name], symbol_name, FailedImport(message))
+
+
+def _get_install_hint(extra_name: str | list[str]) -> str:
+    """Build the sentence telling the user which extra installs the missing optional dependency."""
+    if isinstance(extra_name, str):
+        return f"Install the optional '{extra_name}' extra to use it: pip install 'crawlee[{extra_name}]'"
+    extras = ', '.join(f"'{name}'" for name in extra_name)
+    return f"Install one of the optional extras {extras} to use it, e.g. pip install 'crawlee[{extra_name[0]}]'"
 
 
 def install_import_hook(module_name: str) -> None:

--- a/src/crawlee/browsers/__init__.py
+++ b/src/crawlee/browsers/__init__.py
@@ -8,20 +8,20 @@ _install_import_hook(__name__)
 
 # The following imports are wrapped in try_import to handle optional dependencies,
 # ensuring the module can still function even if these dependencies are missing.
-with _try_import(__name__, 'BrowserPool'):
+with _try_import(__name__, 'BrowserPool', extra_name='playwright'):
     from ._browser_pool import BrowserPool
-with _try_import(__name__, 'PlaywrightBrowserController'):
+with _try_import(__name__, 'PlaywrightBrowserController', extra_name='playwright'):
     from ._playwright_browser_controller import PlaywrightBrowserController
-with _try_import(__name__, 'PlaywrightBrowserPlugin'):
+with _try_import(__name__, 'PlaywrightBrowserPlugin', extra_name='playwright'):
     from ._playwright_browser_plugin import PlaywrightBrowserPlugin
-with _try_import(__name__, 'PlaywrightPersistentBrowser'):
+with _try_import(__name__, 'PlaywrightPersistentBrowser', extra_name='playwright'):
     from ._playwright_browser import PlaywrightPersistentBrowser
 
-with _try_import(__name__, 'StagehandBrowserController'):
+with _try_import(__name__, 'StagehandBrowserController', extra_name='stagehand'):
     from ._stagehand_browser_controller import StagehandBrowserController
-with _try_import(__name__, 'StagehandBrowserPlugin'):
+with _try_import(__name__, 'StagehandBrowserPlugin', extra_name='stagehand'):
     from ._stagehand_browser_plugin import StagehandBrowserPlugin
-with _try_import(__name__, 'StagehandOptions', 'StagehandPage'):
+with _try_import(__name__, 'StagehandOptions', 'StagehandPage', extra_name='stagehand'):
     from ._stagehand_types import StagehandOptions, StagehandPage
 
 

--- a/src/crawlee/crawlers/__init__.py
+++ b/src/crawlee/crawlers/__init__.py
@@ -10,10 +10,16 @@ _install_import_hook(__name__)
 
 # The following imports use try_import to handle optional dependencies, as they may not always be available.
 
-with _try_import(__name__, 'BeautifulSoupCrawler', 'BeautifulSoupCrawlingContext', 'BeautifulSoupParserType'):
+with _try_import(
+    __name__,
+    'BeautifulSoupCrawler',
+    'BeautifulSoupCrawlingContext',
+    'BeautifulSoupParserType',
+    extra_name='beautifulsoup',
+):
     from ._beautifulsoup import BeautifulSoupCrawler, BeautifulSoupCrawlingContext, BeautifulSoupParserType
 
-with _try_import(__name__, 'ParselCrawler', 'ParselCrawlingContext'):
+with _try_import(__name__, 'ParselCrawler', 'ParselCrawlingContext', extra_name='parsel'):
     from ._parsel import ParselCrawler, ParselCrawlingContext
 
 with _try_import(
@@ -22,6 +28,7 @@ with _try_import(
     'PlaywrightCrawlingContext',
     'PlaywrightPostNavCrawlingContext',
     'PlaywrightPreNavCrawlingContext',
+    extra_name='playwright',
 ):
     from ._playwright import (
         PlaywrightCrawler,
@@ -40,6 +47,7 @@ with _try_import(
     'RenderingType',
     'RenderingTypePrediction',
     'RenderingTypePredictor',
+    extra_name='adaptive-crawler',
 ):
     from ._adaptive_playwright import (
         AdaptivePlaywrightCrawler,
@@ -58,6 +66,7 @@ with _try_import(
     'StagehandCrawlingContext',
     'StagehandPostNavCrawlingContext',
     'StagehandPreNavCrawlingContext',
+    extra_name='stagehand',
 ):
     from ._stagehand import (
         StagehandCrawler,
@@ -80,6 +89,7 @@ with _try_import(
     'BasePydanticAiHtmlDistiller',
     'BasePydanticAiHtmlExtractor',
     'get_basic_http_cleaner',
+    extra_name='pydantic-ai',
 ):
     from ._pydantic_ai import (
         BasePydanticAiHtmlDistiller,

--- a/src/crawlee/crawlers/_adaptive_playwright/__init__.py
+++ b/src/crawlee/crawlers/_adaptive_playwright/__init__.py
@@ -12,11 +12,13 @@ _install_import_hook(__name__)
 
 # The following imports are wrapped in try_import to handle optional dependencies,
 # ensuring the module can still function even if these dependencies are missing.
-with _try_import(__name__, 'RenderingType', 'RenderingTypePrediction', 'RenderingTypePredictor'):
+with _try_import(
+    __name__, 'RenderingType', 'RenderingTypePrediction', 'RenderingTypePredictor', extra_name='adaptive-crawler'
+):
     from ._rendering_type_predictor import RenderingType, RenderingTypePrediction, RenderingTypePredictor
-with _try_import(__name__, 'AdaptivePlaywrightCrawler'):
+with _try_import(__name__, 'AdaptivePlaywrightCrawler', extra_name='adaptive-crawler'):
     from ._adaptive_playwright_crawler import AdaptivePlaywrightCrawler
-with _try_import(__name__, 'AdaptivePlaywrightCrawlerStatisticState'):
+with _try_import(__name__, 'AdaptivePlaywrightCrawlerStatisticState', extra_name='adaptive-crawler'):
     from ._adaptive_playwright_crawler import AdaptivePlaywrightCrawlerStatisticState
 
 __all__ = [

--- a/src/crawlee/crawlers/_beautifulsoup/__init__.py
+++ b/src/crawlee/crawlers/_beautifulsoup/__init__.py
@@ -5,11 +5,11 @@ _install_import_hook(__name__)
 
 # The following imports are wrapped in try_import to handle optional dependencies,
 # ensuring the module can still function even if these dependencies are missing.
-with _try_import(__name__, 'BeautifulSoupCrawler'):
+with _try_import(__name__, 'BeautifulSoupCrawler', extra_name='beautifulsoup'):
     from ._beautifulsoup_crawler import BeautifulSoupCrawler
-with _try_import(__name__, 'BeautifulSoupCrawlingContext'):
+with _try_import(__name__, 'BeautifulSoupCrawlingContext', extra_name='beautifulsoup'):
     from ._beautifulsoup_crawling_context import BeautifulSoupCrawlingContext
-with _try_import(__name__, 'BeautifulSoupParserType'):
+with _try_import(__name__, 'BeautifulSoupParserType', extra_name='beautifulsoup'):
     from ._beautifulsoup_parser import BeautifulSoupParserType
 
 __all__ = [

--- a/src/crawlee/crawlers/_parsel/__init__.py
+++ b/src/crawlee/crawlers/_parsel/__init__.py
@@ -5,9 +5,9 @@ _install_import_hook(__name__)
 
 # The following imports are wrapped in try_import to handle optional dependencies,
 # ensuring the module can still function even if these dependencies are missing.
-with _try_import(__name__, 'ParselCrawler'):
+with _try_import(__name__, 'ParselCrawler', extra_name='parsel'):
     from ._parsel_crawler import ParselCrawler
-with _try_import(__name__, 'ParselCrawlingContext'):
+with _try_import(__name__, 'ParselCrawlingContext', extra_name='parsel'):
     from ._parsel_crawling_context import ParselCrawlingContext
 
 __all__ = [

--- a/src/crawlee/crawlers/_playwright/__init__.py
+++ b/src/crawlee/crawlers/_playwright/__init__.py
@@ -5,13 +5,13 @@ _install_import_hook(__name__)
 
 # The following imports are wrapped in try_import to handle optional dependencies,
 # ensuring the module can still function even if these dependencies are missing.
-with _try_import(__name__, 'PlaywrightCrawler'):
+with _try_import(__name__, 'PlaywrightCrawler', extra_name='playwright'):
     from ._playwright_crawler import PlaywrightCrawler
-with _try_import(__name__, 'PlaywrightCrawlingContext'):
+with _try_import(__name__, 'PlaywrightCrawlingContext', extra_name='playwright'):
     from ._playwright_crawling_context import PlaywrightCrawlingContext
-with _try_import(__name__, 'PlaywrightPreNavCrawlingContext'):
+with _try_import(__name__, 'PlaywrightPreNavCrawlingContext', extra_name='playwright'):
     from ._playwright_pre_nav_crawling_context import PlaywrightPreNavCrawlingContext
-with _try_import(__name__, 'PlaywrightPostNavCrawlingContext'):
+with _try_import(__name__, 'PlaywrightPostNavCrawlingContext', extra_name='playwright'):
     from ._playwright_post_nav_crawling_context import PlaywrightPostNavCrawlingContext
 
 __all__ = [

--- a/src/crawlee/crawlers/_pydantic_ai/__init__.py
+++ b/src/crawlee/crawlers/_pydantic_ai/__init__.py
@@ -5,25 +5,27 @@ _install_import_hook(__name__)
 
 # The following imports are wrapped in try_import to handle optional dependencies (the `pydantic-ai` extra),
 # ensuring the module can still function even if these dependencies are missing.
-with _try_import(__name__, 'PydanticAiCrawler'):
+with _try_import(__name__, 'PydanticAiCrawler', extra_name='pydantic-ai'):
     from ._pydantic_ai_crawler import PydanticAiCrawler
-with _try_import(__name__, 'PydanticAiCrawlingContext'):
+with _try_import(__name__, 'PydanticAiCrawlingContext', extra_name='pydantic-ai'):
     from ._pydantic_ai_crawling_context import PydanticAiCrawlingContext
-with _try_import(__name__, 'BasePydanticAiHtmlExtractor'):
+with _try_import(__name__, 'BasePydanticAiHtmlExtractor', extra_name='pydantic-ai'):
     from ._base_extractor import BasePydanticAiHtmlExtractor
-with _try_import(__name__, 'PydanticAiDirectExtractor'):
+with _try_import(__name__, 'PydanticAiDirectExtractor', extra_name='pydantic-ai'):
     from ._direct_extractor import PydanticAiDirectExtractor
-with _try_import(__name__, 'PydanticAiSelectorExtractor'):
+with _try_import(__name__, 'PydanticAiSelectorExtractor', extra_name='pydantic-ai'):
     from ._selector_extractor import PydanticAiSelectorExtractor
-with _try_import(__name__, 'BasePydanticAiHtmlDistiller'):
+with _try_import(__name__, 'BasePydanticAiHtmlDistiller', extra_name='pydantic-ai'):
     from ._base_distiller import BasePydanticAiHtmlDistiller
-with _try_import(__name__, 'PydanticAiCleanHtmlDistiller'):
+with _try_import(__name__, 'PydanticAiCleanHtmlDistiller', extra_name='pydantic-ai'):
     from ._clean_html_distiller import PydanticAiCleanHtmlDistiller
-with _try_import(__name__, 'PydanticAiSkeletonDistiller'):
+with _try_import(__name__, 'PydanticAiSkeletonDistiller', extra_name='pydantic-ai'):
     from ._skeleton_distiller import PydanticAiSkeletonDistiller
-with _try_import(__name__, 'PydanticAiHtmlDistiller', 'PydanticAiHtmlExtractor', 'PydanticAiUsageStats'):
+with _try_import(
+    __name__, 'PydanticAiHtmlDistiller', 'PydanticAiHtmlExtractor', 'PydanticAiUsageStats', extra_name='pydantic-ai'
+):
     from ._types import PydanticAiHtmlDistiller, PydanticAiHtmlExtractor, PydanticAiUsageStats
-with _try_import(__name__, 'get_basic_http_cleaner'):
+with _try_import(__name__, 'get_basic_http_cleaner', extra_name='pydantic-ai'):
     from ._utils import get_basic_http_cleaner
 
 __all__ = [

--- a/src/crawlee/crawlers/_stagehand/__init__.py
+++ b/src/crawlee/crawlers/_stagehand/__init__.py
@@ -5,10 +5,14 @@ _install_import_hook(__name__)
 
 # The following imports are wrapped in try_import to handle optional dependencies,
 # ensuring the module can still function even if these dependencies are missing.
-with _try_import(__name__, 'StagehandCrawler'):
+with _try_import(__name__, 'StagehandCrawler', extra_name='stagehand'):
     from ._stagehand_crawler import StagehandCrawler
 with _try_import(
-    __name__, 'StagehandCrawlingContext', 'StagehandPostNavCrawlingContext', 'StagehandPreNavCrawlingContext'
+    __name__,
+    'StagehandCrawlingContext',
+    'StagehandPostNavCrawlingContext',
+    'StagehandPreNavCrawlingContext',
+    extra_name='stagehand',
 ):
     from ._stagehand_crawling_context import (
         StagehandCrawlingContext,

--- a/src/crawlee/http_clients/__init__.py
+++ b/src/crawlee/http_clients/__init__.py
@@ -9,10 +9,10 @@ _install_import_hook(__name__)
 
 # The following imports are wrapped in try_import to handle optional dependencies,
 # ensuring the module can still function even if these dependencies are missing.
-with _try_import(__name__, 'CurlImpersonateHttpClient'):
+with _try_import(__name__, 'CurlImpersonateHttpClient', extra_name='curl-impersonate'):
     from ._curl_impersonate import CurlImpersonateHttpClient
 
-with _try_import(__name__, 'HttpxHttpClient'):
+with _try_import(__name__, 'HttpxHttpClient', extra_name='httpx'):
     from ._httpx import HttpxHttpClient
 
 

--- a/src/crawlee/storage_clients/__init__.py
+++ b/src/crawlee/storage_clients/__init__.py
@@ -10,10 +10,10 @@ _install_import_hook(__name__)
 
 # The following imports are wrapped in try_import to handle optional dependencies,
 # ensuring the module can still function even if these dependencies are missing.
-with _try_import(__name__, 'SqlStorageClient'):
+with _try_import(__name__, 'SqlStorageClient', extra_name=['sql_sqlite', 'sql_postgres', 'sql_mysql']):
     from ._sql import SqlStorageClient
 
-with _try_import(__name__, 'RedisStorageClient'):
+with _try_import(__name__, 'RedisStorageClient', extra_name='redis'):
     from ._redis import RedisStorageClient
 
 __all__ = [

--- a/tests/unit/_utils/test_try_import.py
+++ b/tests/unit/_utils/test_try_import.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+
+from crawlee._utils.try_import import FailedImport, install_import_hook, try_import
+
+
+@pytest.fixture
+def module_name(monkeypatch: pytest.MonkeyPatch) -> str:
+    name = 'test_try_import_module'
+    monkeypatch.setitem(sys.modules, name, ModuleType(name))
+    return name
+
+
+def test_missing_module_message_names_the_extra(module_name: str) -> None:
+    """A missing optional dependency becomes a placeholder whose message tells the user which extra to install."""
+    with try_import(module_name, 'OptionalSymbol', extra_name='parsel'):
+        raise ModuleNotFoundError("No module named 'parsel'", name='parsel')
+
+    placeholder = sys.modules[module_name].OptionalSymbol
+    assert isinstance(placeholder, FailedImport)
+    assert placeholder.message == (
+        "No module named 'parsel'. Install the optional 'parsel' extra to use it: pip install 'crawlee[parsel]'"
+    )
+
+
+def test_missing_module_message_lists_alternative_extras(module_name: str) -> None:
+    """When several extras provide the dependency, the message lists them and shows one install command."""
+    with try_import(module_name, 'OptionalSymbol', extra_name=['sql_sqlite', 'sql_postgres', 'sql_mysql']):
+        raise ModuleNotFoundError("No module named 'sqlalchemy'", name='sqlalchemy')
+
+    assert sys.modules[module_name].OptionalSymbol.message == (
+        "No module named 'sqlalchemy'. Install one of the optional extras 'sql_sqlite', 'sql_postgres', 'sql_mysql' "
+        "to use it, e.g. pip install 'crawlee[sql_sqlite]'"
+    )
+
+
+def test_nested_guard_keeps_the_inner_message(module_name: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Re-exporting a guarded symbol through another guard does not append the install hint a second time."""
+    inner_name = 'test_try_import_inner_module'
+    monkeypatch.setitem(sys.modules, inner_name, ModuleType(inner_name))
+    install_import_hook(inner_name)
+    with try_import(inner_name, 'OptionalSymbol', extra_name='parsel'):
+        raise ModuleNotFoundError("No module named 'parsel'", name='parsel')
+    inner_message = vars(sys.modules[inner_name])['OptionalSymbol'].message
+
+    with try_import(module_name, 'OptionalSymbol', extra_name='parsel'):
+        getattr(sys.modules[inner_name], 'OptionalSymbol')  # noqa: B009
+
+    assert sys.modules[module_name].OptionalSymbol.message == inner_message
+    assert inner_message.count('pip install') == 1


### PR DESCRIPTION
Accessing a symbol guarded by `try_import` without its extra installed raises an `ImportError` that now also names the extra to install:

```
No module named 'bs4'. Install the optional 'beautifulsoup' extra to use it: pip install 'crawlee[beautifulsoup]'
```

`try_import` takes a required `extra_name`, and every guarded site passes it. `SqlStorageClient` passes the three SQL extras, so the message lists them and shows one install command. The hint is added only for a `ModuleNotFoundError`; the `ImportError` re-raised by a nested guard (e.g. `crawlee.crawlers` re-exporting `crawlee.crawlers._beautifulsoup`) already carries it and is kept as is.

*✍️ Drafted by Claude Code*
