### PR TITLE
fix(playwright): update context.request.headers with actual playwright headers

### DIFF
--- a/src/crawlee/crawlers/_playwright/_playwright_crawler.py
+++ b/src/crawlee/crawlers/_playwright/_playwright_crawler.py
@@ -435,6 +435,11 @@ class PlaywrightCrawler(
         # Set the loaded URL to the actual URL after redirection.
         context.request.loaded_url = context.page.url
 
+        # Update the request headers with the actual headers used by Playwright
+        from crawlee._types import HttpHeaders
+
+        context.request.headers = HttpHeaders(await response.request.all_headers())
+
         yield self._build_post_nav_context(context, response=response)
 
     def _create_extract_links_function(self, context: TPostNavContext) -> ExtractLinksFunction:


### PR DESCRIPTION
## Problem
Request headers when using fingerprint generator or header generator are not saved in context.request.headers.

## Root Cause
When browserforge injects headers, they bypass the Crawlee-level request headers list. Because the framework does not sync back the actual headers used by Playwright for the navigation, the context remains unaware of them.

## Solution
Updated _playwright_crawler.py to retrieve the actual headers from Playwright's response.request and update the Crawlee context.request.headers after navigation.

## Testing
Manual verification / static analysis. (Verified that actual Playwright headers are parsed into HttpHeaders).

## Risk
Low risk. Modifies the state of context.request.headers after navigation, which ensures consistency with what was actually sent over the wire.

## Issue
Closes #1055
