### PR TITLE
fix: isolate default request queues per crawler

### DIFF
--- a/src/crawlee/crawlers/_basic/_basic_crawler.py
+++ b/src/crawlee/crawlers/_basic/_basic_crawler.py
@@ -274,6 +274,7 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
     _CRAWLEE_STATE_KEY = 'CRAWLEE_STATE'
     _request_handler_timeout_text = 'Request handler timed out after'
     __next_id = 0
+    __next_instance_id = 0
 
     def __init__(
         self,
@@ -368,6 +369,9 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
             _logger: A logger instance, typically provided by a subclass, for consistent logging labels.
                 Intended for use by subclasses rather than direct instantiation of `BasicCrawler`.
         """
+        self._instance_id = BasicCrawler.__next_instance_id
+        BasicCrawler.__next_instance_id += 1
+
         if id is None:
             self._id = BasicCrawler.__next_id
             BasicCrawler.__next_id += 1
@@ -615,9 +619,10 @@ class BasicCrawler(Generic[TCrawlingContext, TStatisticsState]):
         )
 
     async def get_request_manager(self) -> RequestManager:
-        """Return the configured request manager. If none is configured, open and return the default request queue."""
+        """Return the configured request manager, or open and return this crawler's default request queue."""
         if not self._request_manager:
             self._request_manager = await RequestQueue.open(
+                alias=None if self._instance_id == 0 else f'__default_{self._id}__',
                 storage_client=self._service_locator.get_storage_client(),
                 configuration=self._service_locator.get_configuration(),
             )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -77,6 +77,7 @@ def prepare_test_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Callabl
         KeyValueStore._autosaved_values = {}
         Statistics._Statistics__next_id = 0  # ty:ignore[unresolved-attribute] # Mangled attribute
         BasicCrawler._BasicCrawler__next_id = 0  # ty:ignore[unresolved-attribute] # Mangled attribute
+        BasicCrawler._BasicCrawler__next_instance_id = 0  # ty:ignore[unresolved-attribute] # Mangled attribute
 
     return _prepare_test_env
 

--- a/tests/unit/crawlers/_basic/test_default_request_queue.py
+++ b/tests/unit/crawlers/_basic/test_default_request_queue.py
@@ -1,0 +1,109 @@
+from crawlee.configuration import Configuration
+from crawlee.crawlers import AdaptivePlaywrightCrawler, BasicCrawler
+from crawlee.storage_clients import MemoryStorageClient
+from crawlee.storages import RequestQueue
+
+
+async def test_first_crawler_uses_global_default_request_queue() -> None:
+    storage_client = MemoryStorageClient()
+    configuration = Configuration()
+    crawler = BasicCrawler(configuration=configuration, storage_client=storage_client)
+
+    queue = await crawler.get_request_manager()
+    global_default = await RequestQueue.open(configuration=configuration, storage_client=storage_client)
+
+    assert queue is global_default
+
+
+async def test_three_crawlers_have_independent_default_request_queues() -> None:
+    storage_client = MemoryStorageClient()
+    configuration = Configuration()
+    crawlers = [
+        BasicCrawler(configuration=configuration, storage_client=storage_client),
+        BasicCrawler(configuration=configuration, storage_client=storage_client),
+        BasicCrawler(configuration=configuration, storage_client=storage_client),
+    ]
+    queues = [await crawler.get_request_manager() for crawler in crawlers]
+
+    for queue in queues:
+        await queue.add_request('https://example.test/same-request')
+
+    assert len({id(queue) for queue in queues}) == 3
+    assert [await queue.get_total_count() for queue in queues] == [1, 1, 1]
+
+
+async def test_explicit_first_id_does_not_control_global_default_selection() -> None:
+    storage_client = MemoryStorageClient()
+    configuration = Configuration()
+    first = BasicCrawler(id=42, configuration=configuration, storage_client=storage_client)
+    later = BasicCrawler(configuration=configuration, storage_client=storage_client)
+
+    first_queue = await first.get_request_manager()
+    later_queue = await later.get_request_manager()
+
+    assert first._id == 42
+    assert later._id == 0
+    assert first_queue is await RequestQueue.open(configuration=configuration, storage_client=storage_client)
+    assert later_queue is await RequestQueue.open(
+        alias=f'__default_{later._id}__', configuration=configuration, storage_client=storage_client
+    )
+    assert first_queue is not later_queue
+
+
+async def test_injected_first_manager_consumes_global_default_selection() -> None:
+    storage_client = MemoryStorageClient()
+    configuration = Configuration()
+    injected = await RequestQueue.open(alias='injected', configuration=configuration, storage_client=storage_client)
+    first = BasicCrawler(request_manager=injected, configuration=configuration, storage_client=storage_client)
+    later = BasicCrawler(configuration=configuration, storage_client=storage_client)
+
+    later_queue = await later.get_request_manager()
+
+    assert first._id == 0
+    assert later._id == 1
+    assert await first.get_request_manager() is injected
+    assert later_queue is await RequestQueue.open(
+        alias=f'__default_{later._id}__', configuration=configuration, storage_client=storage_client
+    )
+    assert later_queue is not await RequestQueue.open(configuration=configuration, storage_client=storage_client)
+
+
+async def test_repeated_later_explicit_ids_share_stable_default_alias() -> None:
+    storage_client = MemoryStorageClient()
+    configuration = Configuration()
+    _ = BasicCrawler(configuration=configuration, storage_client=storage_client)
+    first = BasicCrawler(id=42, configuration=configuration, storage_client=storage_client)
+    second = BasicCrawler(id=42, configuration=configuration, storage_client=storage_client)
+
+    first_queue = await first.get_request_manager()
+    second_queue = await second.get_request_manager()
+
+    assert first_queue is second_queue
+    assert first_queue is await first.get_request_manager()
+    assert first_queue is await RequestQueue.open(
+        alias=f'__default_{first._id}__', configuration=configuration, storage_client=storage_client
+    )
+
+
+async def test_adaptive_subclass_construction_preserves_ids_and_queue_ownership() -> None:
+    storage_client = MemoryStorageClient()
+    configuration = Configuration()
+    adaptive = AdaptivePlaywrightCrawler.with_beautifulsoup_static_parser(
+        configuration=configuration, storage_client=storage_client
+    )
+    following = BasicCrawler(configuration=configuration, storage_client=storage_client)
+
+    adaptive_queue = await adaptive.get_request_manager()
+    following_queue = await following.get_request_manager()
+    await adaptive_queue.add_request('https://example.test/adaptive')
+
+    assert adaptive._id == 0
+    assert following._id == 3
+    assert adaptive._pw_context_pipeline is not None
+    assert adaptive._static_context_pipeline is not None
+    assert following_queue is await RequestQueue.open(
+        alias=f'__default_{following._id}__', configuration=configuration, storage_client=storage_client
+    )
+    assert await adaptive_queue.get_total_count() == 1
+    assert await following_queue.get_total_count() == 0
+    assert adaptive_queue is not following_queue


### PR DESCRIPTION
Use a separate construction index to retain the first crawler's global default request queue while routing each later implicit manager through the crawler ID-derived stable alias. Reset the counter during unit isolation and cover ordinary, explicit-ID, injected-manager, repeated-ID, and adaptive construction paths.

## Verification

Recorded against `2b4ac0104a82723e0b39febc26325dd2b66425d0`. From the repository root, with the project and test dependencies plus uvloop installed, the Python test invocation was:

```sh
python3 -u -c "import asyncio, uvloop, pytest, sys; asyncio.set_event_loop_policy(uvloop.EventLoopPolicy()); sys.exit(pytest.main(['-p', 'no:rerunfailures', '--timeout=60', '-q', '-o', 'addopts=', 'tests/unit/crawlers/_basic', '-k', 'explicit_queue or request_source_tandem or crawler_get_storages or share_state or own_state or share_stats or consecutive_runs or default_storages or other_storages or storage_client_overwrite or state_persistence or default_request_queue']))"
```

Result: 21 passed, 104 deselected, 81 warnings. This selected six new default-queue tests and fifteen existing queue/state/storage tests. The warnings were one unknown `flaky` marker and 80 multiprocessing fork deprecations, also observed on the clean base. The test environment selected this checkout's `src` on `PYTHONPATH`.

This was a focused run using uvloop, not the full unit suite. The adaptive-crawler test checks construction and queue ownership without launching a browser.
