### PR TITLE
test: Restore the crawlee.crawlers binding in import-error tests

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,6 +12,7 @@ from fakeredis import FakeAsyncRedis
 from proxy import Proxy
 from uvicorn.config import Config
 
+import crawlee.crawlers
 from crawlee import service_locator
 from crawlee.crawlers import BasicCrawler
 from crawlee.fingerprint_suite._browserforge_adapter import get_available_header_network
@@ -92,6 +93,20 @@ def _isolate_test_environment(prepare_test_env: Callable[[], None]) -> None:
         prepare_test_env: Fixture to prepare the environment before each test.
     """
     prepare_test_env()
+
+
+@pytest.fixture
+def _restore_crawlers_binding(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Restore the `crawlers` attribute of the `crawlee` package for tests that re-import `crawlee.crawlers`.
+
+    Dropping `crawlee.crawlers` from `sys.modules` and importing it again binds a fresh module object onto the
+    `crawlee` package. That object has no private submodule attributes, because the submodules themselves stay
+    cached and so are never re-bound. `mock.patch.dict('sys.modules', ...)` restores the module cache but not the
+    attribute, which leaves the fresh object reachable through `crawlee.crawlers`. Targets such as
+    `crawlee.crawlers._basic._basic_crawler.X` then fail to resolve under `mock.patch` on Python 3.10, which walks
+    module attributes; 3.11 and newer go through the module cache instead and are unaffected.
+    """
+    monkeypatch.setattr(crawlee, 'crawlers', crawlee.crawlers)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
+++ b/tests/unit/crawlers/_adaptive_playwright/test_adaptive_playwright_crawler.py
@@ -943,6 +943,7 @@ async def test_adaptive_playwright_crawler_with_sql_storage(test_urls: list[str]
         pytest.param('sklearn', id='sklearn'),
     ],
 )
+@pytest.mark.usefixtures('_restore_crawlers_binding')
 def test_import_error_handled(optional_module_name: str) -> None:
     # Block the package and all its cached submodules to prevent submodule cache entries
     # from bypassing the blocked top-level package.

--- a/tests/unit/crawlers/_beautifulsoup/test_beautifulsoup_crawler.py
+++ b/tests/unit/crawlers/_beautifulsoup/test_beautifulsoup_crawler.py
@@ -501,6 +501,7 @@ async def test_enqueue_links_with_limit(server_url: URL, http_client: HttpClient
     visit.assert_has_calls(expected_visit_calls, any_order=True)
 
 
+@pytest.mark.usefixtures('_restore_crawlers_binding')
 def test_import_error_handled() -> None:
     # Simulate ImportError for BeautifulSoup
     with mock.patch.dict('sys.modules', {'bs4': None}):

--- a/tests/unit/crawlers/_parsel/test_parsel_crawler.py
+++ b/tests/unit/crawlers/_parsel/test_parsel_crawler.py
@@ -218,6 +218,7 @@ async def test_handle_blocked_status_code(server_url: URL, http_client: HttpClie
     assert crawler._statistics.error_tracker.total == 1
 
 
+@pytest.mark.usefixtures('_restore_crawlers_binding')
 def test_import_error_handled() -> None:
     # Simulate ImportError for parsel
     with mock.patch.dict('sys.modules', {'parsel': None}):


### PR DESCRIPTION
Three `test_import_error_handled` tests drop `crawlee.crawlers` from `sys.modules` and import it again, to check that a missing optional extra raises a clear error. The private submodules stay cached across that re-import, so the fresh module object never gets `_basic` and its siblings re-bound, and completing the import rebinds `crawlee.crawlers` on the `crawlee` package to that incomplete object. `patch.dict('sys.modules', ...)` restores the module cache on exit but cannot undo the attribute assignment.

A later test on the same xdist worker then resolves a dotted `mock.patch` target under `crawlee.crawlers` against the incomplete module. That fails on Python 3.10, where `mock.patch` walks module attributes; 3.11 switched to `pkgutil.resolve_name`, which goes through the module cache instead. Hence `AttributeError: module 'crawlee.crawlers' has no attribute '_basic'` in `test_lock_with_get_robots_txt_file_for_url` on the windows-latest 3.10 job of [this run](https://github.com/apify/crawlee-python/actions/runs/34121244179/job/101739520092).

The new `_restore_crawlers_binding` fixture snapshots the attribute with `monkeypatch` and puts it back at teardown, so none of the three tests can leave a half-bound `crawlee.crawlers` behind.

Running any of the three immediately before `test_lock_with_get_robots_txt_file_for_url` on Python 3.10 failed 4 out of 4 times before this change and 0 out of 324 after. The full unit suite passes under `-n auto` on 3.10 and 3.13.

*✍️ Drafted by Claude Code*
