### PR TITLE
chore: Update Camoufox templates

### DIFF
--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/Dockerfile
@@ -8,7 +8,7 @@
 # % set playwright_version = '1.62.0'
 {# Camoufox ships its own Firefox build and caps the Playwright version it supports, so it keeps
    an explicit compatible version instead of following the automatically updated shared pin. #}
-# % set camoufox_playwright_version = '1.60.0'
+# % set camoufox_playwright_version = '1.62.0'
 
 # % if cookiecutter.crawler_type == 'playwright' or cookiecutter.crawler_type.startswith('adaptive-') or cookiecutter.crawler_type == 'stagehand'
 # % set base_image = 'apify/actor-python-playwright:3.13-' ~ playwright_version

--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/pyproject.toml
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.10,<4.0"
 dependencies = [
     "crawlee[{{ extras|join(',') }}]",
     # % if cookiecutter.crawler_type == 'playwright-camoufox'
-    "camoufox[geoip]~=0.4.5",
+    "camoufox[geoip]~=0.5.6",
     # % endif
     # % if cookiecutter.enable_apify_integration
     "apify",

--- a/src/crawlee/project_template/{{cookiecutter.project_name}}/requirements.txt
+++ b/src/crawlee/project_template/{{cookiecutter.project_name}}/requirements.txt
@@ -1,5 +1,5 @@
 # % if cookiecutter.crawler_type == 'playwright-camoufox'
-camoufox[geoip]~=0.4.5
+camoufox[geoip]~=0.5.6
 # % endif
 # % if cookiecutter.crawler_type.startswith('adaptive-')
 # % set extras = ['adaptive-crawler', 'beautifulsoup', 'parsel']


### PR DESCRIPTION
### Description

Bump Camoufox and Playwright versions in templates to use the latest compatible versions

[Latest version](https://pypi.org/project/camoufox/0.5.6/) is already compatible with Playwright < 1.63.0

Similar in templates repo: https://github.com/apify/actor-templates/pull/928

